### PR TITLE
Fix negative delegation shares

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -732,7 +732,7 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 			`, chainID),
 				e.DebondingStart.Escrow.String(),
 				e.DebondingStart.Owner.String(),
-				e.DebondingStart.DebondingShares.ToBigInt().Uint64(),
+				e.DebondingStart.ActiveShares.ToBigInt().Uint64(),
 			)
 			batch.Queue(fmt.Sprintf(`
 				INSERT INTO %s.debonding_delegations (delegatee, delegator, shares, debond_end)

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -170,7 +170,7 @@ type ProposalVote struct {
 
 // Validators is the API response for GetValidators.
 type ValidatorList struct {
-	Validators []Validator `json:"validator"`
+	Validators []Validator `json:"validators"`
 }
 
 // Validator is the API response for GetValidator.


### PR DESCRIPTION
**Why**
Fix https://github.com/oasisprotocol/oasis-indexer/issues/86

**What**
I math-ed wrong and subtracted too many shares including the number of accrued shares in a `ReclaimEscrowEvent`.