### PR TITLE
Fix Validator query

### DIFF
--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1464,22 +1464,6 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 		}
 	}
 
-	pagination, err := common.NewPagination(r)
-	if err != nil {
-		c.logger.Info("pagination failed",
-			"request_id", ctx.Value(RequestIDContextKey),
-			"err", err.Error(),
-		)
-		return nil, common.ErrBadRequest
-	}
-	if err = qb.AddPagination(ctx, pagination); err != nil {
-		c.logger.Info("pagination add failed",
-			"request_id", ctx.Value(RequestIDContextKey),
-			"err", err.Error(),
-		)
-		return nil, common.ErrBadRequest
-	}
-
 	rows, err := c.db.Query(ctx, qb.String())
 	if err != nil {
 		c.logger.Info("query failed",

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1449,6 +1449,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 			WHERE %s.entities.id = %s.nodes.entity_id
 				AND %s.nodes.roles like '%%validator%%'
 		)
+	ORDER BY voting_power DESC
 	`, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID), c.db)
 
 	params := r.URL.Query()

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1347,8 +1347,8 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 				%s.nodes.id AS node_address,
 				%s.accounts.escrow_balance_active AS escrow,
 				%s.commissions.schedule AS commissions_schedule,
-				case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND voting_power > 0) then true else false end as active,
-				case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') then true else false end as status,
+				CASE WHEN EXISTS(SELECT null FROM %s.nodes WHERE %s.entities.id = %s.nodes.entity_id AND voting_power > 0) THEN true ELSE false END AS active,
+				CASE WHEN EXISTS(SELECT null FROM %s.nodes WHERE %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') THEN true ELSE false END AS status,
 				%s.entities.meta AS meta
 			FROM %s.entities
 			JOIN %s.accounts ON %s.entities.address = %s.accounts.address
@@ -1437,8 +1437,8 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 		%s.nodes.id AS node_address,
 		%s.accounts.escrow_balance_active AS escrow,
 		%s.commissions.schedule AS commissions_schedule,
-		case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND voting_power > 0) then true else false end as active,
-		case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') then true else false end as status,
+		CASE WHEN EXISTS(SELECT NULL FROM %s.nodes WHERE %s.entities.id = %s.nodes.entity_id AND voting_power > 0) THEN true ELSE false END AS active,
+		CASE WHEN EXISTS(SELECT NULL FROM %s.nodes WHERE %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') THEN true ELSE false END AS status,
 		%s.entities.meta AS meta
 	FROM %s.entities
 	JOIN %s.accounts ON %s.entities.address = %s.accounts.address

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1348,7 +1348,7 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 				%s.accounts.escrow_balance_active AS escrow,
 				%s.commissions.schedule AS commissions_schedule,
 				case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND voting_power > 0) then true else false end as active,
-				case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like 'validator') then true else false end as status,
+				case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') then true else false end as status,
 				%s.entities.meta AS meta
 			FROM %s.entities
 			JOIN %s.accounts ON %s.entities.address = %s.accounts.address
@@ -1358,7 +1358,7 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 					SELECT max(voting_power)
 					FROM %s.nodes
 					WHERE %s.entities.id = %s.nodes.entity_id
-						AND %s.nodes.roles like 'validator'
+						AND %s.nodes.roles like '%%validator%%'
 				)
 			WHERE %s.entities.address = $1::text`,
 			chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID),
@@ -1437,7 +1437,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 		%s.accounts.escrow_balance_active AS escrow,
 		%s.commissions.schedule AS commissions_schedule,
 		case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND voting_power > 0) then true else false end as active,
-		case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like 'validator') then true else false end as status,
+		case when exists(select null from %s.nodes where %s.entities.id = %s.nodes.entity_id AND %s.nodes.roles like '%%validator%%') then true else false end as status,
 		%s.entities.meta AS meta
 	FROM %s.entities
 	JOIN %s.accounts ON %s.entities.address = %s.accounts.address
@@ -1447,7 +1447,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 			SELECT max(voting_power)
 			FROM %s.nodes
 			WHERE %s.entities.id = %s.nodes.entity_id
-				AND %s.nodes.roles like 'validator'
+				AND %s.nodes.roles like '%%validator%%'
 		)
 	`, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID), c.db)
 

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1354,6 +1354,7 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 			JOIN %s.accounts ON %s.entities.address = %s.accounts.address
 			LEFT JOIN %s.commissions ON %s.entities.address = %s.commissions.address
 			JOIN %s.nodes ON %s.entities.id = %s.nodes.entity_id
+				AND %s.nodes.roles like '%%validator%%'
 				AND %s.nodes.voting_power = (
 					SELECT max(voting_power)
 					FROM %s.nodes
@@ -1361,7 +1362,7 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 						AND %s.nodes.roles like '%%validator%%'
 				)
 			WHERE %s.entities.address = $1::text`,
-			chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID),
+			chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID),
 		chi.URLParam(r, "entity_id"),
 	)
 
@@ -1443,6 +1444,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 	JOIN %s.accounts ON %s.entities.address = %s.accounts.address
 	LEFT JOIN %s.commissions ON %s.entities.address = %s.commissions.address
 	JOIN %s.nodes ON %s.entities.id = %s.nodes.entity_id
+		AND %s.nodes.roles like '%%validator%%'
 		AND %s.nodes.voting_power = (
 			SELECT max(voting_power)
 			FROM %s.nodes
@@ -1450,7 +1452,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 				AND %s.nodes.roles like '%%validator%%'
 		)
 	ORDER BY voting_power DESC
-	`, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID), c.db)
+	`, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID), c.db)
 
 	params := r.URL.Query()
 	if v := params.Get("height"); v != "" {

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1352,7 +1352,7 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 				%s.entities.meta AS meta
 			FROM %s.entities
 			JOIN %s.accounts ON %s.entities.address = %s.accounts.address
-			JOIN %s.commissions ON %s.entities.address = %s.commissions.address
+			LEFT JOIN %s.commissions ON %s.entities.address = %s.commissions.address
 			JOIN %s.nodes ON %s.entities.id = %s.nodes.entity_id
 				AND %s.nodes.voting_power = (
 					SELECT max(voting_power)
@@ -1441,7 +1441,7 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 		%s.entities.meta AS meta
 	FROM %s.entities
 	JOIN %s.accounts ON %s.entities.address = %s.accounts.address
-	JOIN %s.commissions ON %s.entities.address = %s.commissions.address
+	LEFT JOIN %s.commissions ON %s.entities.address = %s.commissions.address
 	JOIN %s.nodes ON %s.entities.id = %s.nodes.entity_id
 		AND %s.nodes.voting_power = (
 			SELECT max(voting_power)

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1451,7 +1451,6 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 			WHERE %s.entities.id = %s.nodes.entity_id
 				AND %s.nodes.roles like '%%validator%%'
 		)
-	ORDER BY voting_power DESC
 	`, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID, chainID), c.db)
 
 	params := r.URL.Query()
@@ -1465,6 +1464,18 @@ func (c *storageClient) Validators(ctx context.Context, r *http.Request) (*Valid
 				return nil, common.ErrBadRequest
 			}
 		}
+	}
+
+	if err := qb.AddPagination(ctx, common.Pagination{
+		Limit:  1000,
+		Offset: 0,
+		Order:  "voting_power",
+	}); err != nil {
+		c.logger.Info("pagination add failed",
+			"request_id", ctx.Value(RequestIDContextKey),
+			"err", err.Error(),
+		)
+		return nil, common.ErrBadRequest
 	}
 
 	rows, err := c.db.Query(ctx, qb.String())


### PR DESCRIPTION
**Why**
Relates to #92. See original issue https://github.com/oasisprotocol/oasis-indexer/issues/46 and reference https://github.com/oasisprotocol/oasis-indexer/issues/46#issuecomment-1129251832

**Expanded**
My assumption is that we want to make a single query that returns `active` and `inactive` validators aka `entities` based on their node voting power.

**TODO**
- [x] Remove pagination
- [x] Order by voting power