### PR TITLE
storage: Add index on tx sender

### DIFF
--- a/storage/migrations/0006_oasis_3_tx_sender_ix.sql
+++ b/storage/migrations/0006_oasis_3_tx_sender_ix.sql
@@ -1,0 +1,3 @@
+-- Creates an index on transaction sender. This is a very common
+-- query, and is unusably slow otherwise.
+CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);


### PR DESCRIPTION
Hitting the `/consensus/transactions?sender=<address>` endpoint is unusably slow without this.