### PR TITLE
Fix escrow_total_shares_debonding on Account

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -721,13 +721,15 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 				UPDATE %s.accounts
 					SET
 						escrow_balance_active = escrow_balance_active - $2,
-						escrow_balance_debonding = escrow_balance_debonding + $3,
-						escrow_total_shares_debonding = escrow_total_shares_debonding + $2
+						escrow_total_shares_active = escrow_total_shares_active - $3,
+						escrow_balance_debonding = escrow_balance_debonding + $2,
+						escrow_total_shares_debonding = escrow_total_shares_debonding + $4
 					WHERE address = $1;
 			`, chainID),
 				e.DebondingStart.Escrow.String(),
-				e.DebondingStart.ActiveShares.ToBigInt().Uint64(),
 				e.DebondingStart.Amount.ToBigInt().Uint64(),
+				e.DebondingStart.ActiveShares.ToBigInt().Uint64(),
+				e.DebondingStart.DebondingShares.ToBigInt().Uint64(),
 			)
 			batch.Queue(fmt.Sprintf(`
 				UPDATE %s.delegations

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -709,8 +709,8 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 			batch.Queue(fmt.Sprintf(`
 				UPDATE %s.accounts
 					SET
-						escrow_balance_active = escrow_balance_active - ROUND($2 * escrow_balance_active  / (escrow_balance_active + escrow_balance_debonding)),
-						escrow_balance_debonding = escrow_balance_debonding - ROUND($2 * escrow_balance_debonding  / (escrow_balance_active + escrow_balance_debonding))
+						escrow_balance_active = escrow_balance_active - ROUND($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
+						escrow_balance_debonding = escrow_balance_debonding - ROUND($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
 					WHERE address = $1;
 			`, chainID),
 				e.Take.Owner.String(),


### PR DESCRIPTION
**Why**
I didn't recognize the difference between the two share differences. The shares returned are based on two different pools and can be pretty different.
```
{
  "owner": "oasis1qru7xdwx2tkpqgv92v5gk2nmtw2z9sczq5s5w0gu",
  "escrow": "oasis1qz2rxs50p4kn537tcupjhg7ad3zcm9s7uuyrrd9e",
  "amount": "105001458701",
  "active_shares": "88692405242",
  "debonding_shares": "105001458701",
  "debond_end_time": 13836
}
```