### PR TITLE
Fix debonding delegation deletion

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -671,11 +671,11 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 				e.Reclaim.Amount.ToBigInt().Uint64(),
 				e.Reclaim.Shares.ToBigInt().Uint64(),
 			)
-
 			batch.Queue(deleteDebondingDelegationsQuery,
 				e.Reclaim.Owner.String(),
 				e.Reclaim.Escrow.String(),
 				e.Reclaim.Shares.ToBigInt().Uint64(),
+				data.Epoch,
 			)
 		}
 	}

--- a/analyzer/consensus/queries.go
+++ b/analyzer/consensus/queries.go
@@ -254,16 +254,12 @@ func (qf QueryFactory) DeleteDebondingDelegationsQuery() string {
 	// Network upgrades delays debonding by 1 epoch
 	return fmt.Sprintf(`
 		DELETE FROM %[1]s.debonding_delegations
-			WHERE (ctid) IN (
-				SELECT ctid
+			WHERE id = (
+				SELECT id
 				FROM %[1]s.debonding_delegations
 				WHERE
-					delegator = $1 AND delegatee = $2 AND shares = $3 AND debond_end IN (
-					SELECT id
-					FROM %[1]s.epochs
-					ORDER BY id DESC
-					LIMIT 2
-				) LIMIT 1
+					delegator = $1 AND delegatee = $2 AND shares = $3 AND debond_end IN ($4::bigint, $4::bigint - 1)
+				LIMIT 1
 			)`, qf.chainID)
 }
 

--- a/storage/api.go
+++ b/storage/api.go
@@ -119,6 +119,7 @@ type RegistryData struct {
 // retrieving events as updates to apply when getting data at specific height.
 type StakingData struct {
 	Height int64
+	Epoch  beacon.EpochTime
 
 	Transfers        []*staking.TransferEvent
 	Burns            []*staking.BurnEvent

--- a/storage/migrations/0008_oasis_3_debonding_delegation_primary_key.up.sql
+++ b/storage/migrations/0008_oasis_3_debonding_delegation_primary_key.up.sql
@@ -1,0 +1,3 @@
+-- Add a primary key on debonding delegations. This is needed for single
+-- deletions.
+ALTER TABLE oasis_3.debonding_delegations ADD COLUMN id bigserial PRIMARY KEY;

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -297,6 +297,11 @@ func (c *Client) StakingData(ctx context.Context, height int64) (*storage.Stakin
 		return nil, err
 	}
 
+	epoch, err := connection.Consensus().Beacon().GetEpoch(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+
 	var transfers []*stakingAPI.TransferEvent
 	var burns []*stakingAPI.BurnEvent
 	var escrows []*stakingAPI.EscrowEvent
@@ -317,6 +322,7 @@ func (c *Client) StakingData(ctx context.Context, height int64) (*storage.Stakin
 
 	return &storage.StakingData{
 		Height:           height,
+		Epoch:            epoch,
 		Transfers:        transfers,
 		Burns:            burns,
 		Escrows:          escrows,


### PR DESCRIPTION
**Why**
Sometimes the deletion query for debonding delegation on reclaim does not work. 😡 The deployed production Indexer has this symptom.

Close again #120. See CU-3r85g3p

I was able to sometimes repro this locally by querying the `oasis_3.epochs` table while the analyzer is running, causing the deletion to return a rows affected result of `0`. Perhaps separately, we are checking the expectations of these queries. Maybe it is important or good in some future correctness checking thing.

So there are two fixes/mitigations here:

1. Add a primary key of `id` column, so that deletion is better limited to 1.
2. Move away from a `WITH QUERY` on deleting a debonding delegation row. We can have the epoch number by querying the Consensus backend, so I added that to the `StakingData`.

**Deploy**
This will need a deploy and reindex.