### PR TITLE
storage/migrations: Initialize framework for aggregate statistics

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -101,6 +101,9 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 func (m *Main) Start() {
 	ctx := context.Background()
 
+	// Start aggregate worker.
+	go m.aggregateWorker(ctx)
+
 	// Get block to be indexed.
 	var height int64
 

--- a/analyzer/consensus/queries.go
+++ b/analyzer/consensus/queries.go
@@ -332,3 +332,15 @@ func (qf QueryFactory) VoteInsertQuery() string {
 		INSERT INTO %s.votes (proposal, voter, vote)
 			VALUES ($1, $2, $3)`, qf.chainID)
 }
+
+func (qf QueryFactory) RefreshDailyTxVolumeQuery() string {
+	return `
+		REFRESH MATERIALIZED VIEW daily_tx_volume
+	`
+}
+
+func (qf QueryFactory) RefreshMin5TxVolumeQuery() string {
+	return `
+		REFRESH MATERIALIZED VIEW min5_tx_volume
+	`
+}

--- a/analyzer/consensus/workers.go
+++ b/analyzer/consensus/workers.go
@@ -1,0 +1,48 @@
+package consensus
+
+import (
+	"context"
+	"time"
+
+	"github.com/oasisprotocol/oasis-indexer/storage"
+)
+
+const (
+	aggregateWorkerInterval = 10 * time.Second
+	aggregateWorkerTimeout  = 60 * time.Second
+)
+
+// The aggregate worker refreshes aggregate statistics for the consensus layer.
+func (m *Main) aggregateWorker(ctx context.Context) {
+	m.logger.Info("starting aggregate worker")
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(aggregateWorkerInterval):
+			func() {
+				cancelCtx, cancel := context.WithTimeout(ctx, aggregateWorkerTimeout)
+				defer cancel()
+
+				// Note: The order matters here! Daily tx volume is a materialized view
+				// that's instantiated from 5 minute tx volume.
+				batch := &storage.QueryBatch{}
+				batch.Queue(m.qf.RefreshMin5TxVolumeQuery())
+				batch.Queue(m.qf.RefreshDailyTxVolumeQuery())
+
+				opName := "aggregate_stats"
+				timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
+				defer timer.ObserveDuration()
+
+				if err := m.target.SendBatch(cancelCtx, batch); err != nil {
+					m.metrics.DatabaseCounter(m.target.Name(), opName, "failure").Inc()
+					m.logger.Error("Failed to refresh aggregate statistics",
+						"err", err,
+					)
+				}
+
+				m.logger.Debug("aggregate worker step completed")
+			}()
+		}
+	}
+}

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -676,6 +676,42 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /consensus/stats/tps:
+    get:
+      summary: Returns the consensus layer TPS for each 5 minute interval.
+      responses:
+        '200':
+          description: |
+            A JSON object containing a list of TPS values for each interval.
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/TpsCheckpoints'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /consensus/stats/daily_volume:
+    get:
+      summary: Returns the consensus layer daily transaction volume for each day.
+      responses:
+        '200':
+          description: |
+            A JSON object containing a list of daily transaction volumes for each day.
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/Volumes'
+        '400':
+          $ref: '#/components/responses/InvalidRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
 components:
   schemas:
     ApiError:
@@ -1195,6 +1231,60 @@ components:
           type: string
           description: The vote cast.
           example: 'yes'
+    
+    TpsCheckpoints:
+      type: object
+      properties:
+        interval_minutes:
+          type: integer
+          format: int
+          description: The length, in minutes, of each TPS measurement window.
+        tps_checkpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/TpsCheckpoint'
+          description: The list of TPS checkpoint windows.
+      description: |
+        A list of TPS checkpoint windows.
+
+    TpsCheckpoint:
+      type: object
+      properties: 
+        timestamp:
+          type: string
+          format: date-time
+          description: The timestamp anchoring this TPS measurement window.
+          example: *iso_timestamp_1
+        tx_volume:
+          type: integer
+          format: int64
+          description: The transaction volume in this measurement window.
+          example: 420
+
+  VolumeList:
+      type: object
+      properties:
+        volumes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Volume'
+          description: The list of daily transaction volumes.
+      description: |
+        A list of daily transaction volumes.
+
+    Volume:
+      type: object
+      properties: 
+        date:
+          type: string
+          format: date-time
+          description: The date for this daily transaction volume measurement.
+          example: *iso_timestamp_1
+        tx_volume:
+          type: integer
+          format: int64
+          description: The transaction volume on this day.
+          example: 420
 
   responses:
     InvalidRequest:

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -704,7 +704,7 @@ paths:
           content:
             application/json:
               schema: 
-                $ref: '#/components/schemas/Volumes'
+                $ref: '#/components/schemas/VolumeList'
         '400':
           $ref: '#/components/responses/InvalidRequest'
         '404':
@@ -1261,7 +1261,7 @@ components:
           description: The transaction volume in this measurement window.
           example: 420
 
-  VolumeList:
+    VolumeList:
       type: object
       properties:
         volumes:

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -679,6 +679,9 @@ paths:
   /consensus/stats/tps:
     get:
       summary: Returns the consensus layer TPS for each 5 minute interval.
+      parameters:
+        - *limit
+        - *offset
       responses:
         '200':
           description: |
@@ -697,6 +700,9 @@ paths:
   /consensus/stats/daily_volume:
     get:
       summary: Returns the consensus layer daily transaction volume for each day.
+      parameters:
+        - *limit
+        - *offset
       responses:
         '200':
           description: |

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -1219,9 +1219,13 @@ func (c *storageClient) Validator(ctx context.Context, r *http.Request) (*Valida
 func (c *storageClient) TransactionsPerSecond(ctx context.Context, r *http.Request) (*TpsCheckpointList, error) {
 	qf := NewQueryFactory(strcase.ToSnake(LatestChainID))
 
-	pagination := common.Pagination{
-		Limit:  100,
-		Offset: 0,
+	pagination, err := common.NewPagination(r)
+	if err != nil {
+		c.logger.Info("pagination failed",
+			"request_id", ctx.Value(RequestIDContextKey),
+			"err", err.Error(),
+		)
+		return nil, common.ErrBadRequest
 	}
 
 	rows, err := c.db.Query(
@@ -1274,9 +1278,13 @@ func (c *storageClient) TransactionsPerSecond(ctx context.Context, r *http.Reque
 func (c *storageClient) DailyVolumes(ctx context.Context, r *http.Request) (*VolumeList, error) {
 	qf := NewQueryFactory(strcase.ToSnake(LatestChainID))
 
-	pagination := common.Pagination{
-		Limit:  100,
-		Offset: 0,
+	pagination, err := common.NewPagination(r)
+	if err != nil {
+		c.logger.Info("pagination failed",
+			"request_id", ctx.Value(RequestIDContextKey),
+			"err", err.Error(),
+		)
+		return nil, common.ErrBadRequest
 	}
 
 	rows, err := c.db.Query(

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -611,6 +611,68 @@ func (h *Handler) ListValidators(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// ListTransactionsPerSecond gets a list of TPS values.
+func (h *Handler) ListTransactionsPerSecond(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	tps, err := h.client.TransactionsPerSecond(ctx, r)
+	if err != nil {
+		h.logAndReply(ctx, "failed to list tps", w, err)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
+		return
+	}
+
+	var resp []byte
+	resp, err = json.Marshal(tps)
+	if err != nil {
+		h.logAndReply(ctx, "failed to marshal tps", w, err)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	if _, err := w.Write(resp); err != nil {
+		h.logger.Error("failed to write response",
+			"request_id", ctx.Value(RequestIDContextKey),
+			"error", err,
+		)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "http_error").Inc()
+	} else {
+		h.metrics.RequestCounter(r.URL.Path, "success").Inc()
+	}
+}
+
+// ListDailyVolume gets a list of daily transaction volume.
+func (h *Handler) ListDailyVolume(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	volumes, err := h.client.DailyVolumes(ctx, r)
+	if err != nil {
+		h.logAndReply(ctx, "failed to list daily tx volume", w, err)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
+		return
+	}
+
+	var resp []byte
+	resp, err = json.Marshal(volumes)
+	if err != nil {
+		h.logAndReply(ctx, "failed to marshal volumes", w, err)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
+		return
+	}
+
+	w.Header().Set("content-type", "application/json")
+	if _, err := w.Write(resp); err != nil {
+		h.logger.Error("failed to write response",
+			"request_id", ctx.Value(RequestIDContextKey),
+			"error", err,
+		)
+		h.metrics.RequestCounter(r.URL.Path, "failure", "http_error").Inc()
+	} else {
+		h.metrics.RequestCounter(r.URL.Path, "success").Inc()
+	}
+}
+
 func (h *Handler) logAndReply(ctx context.Context, msg string, w http.ResponseWriter, err error) {
 	h.logger.Error(msg,
 		"request_id", ctx.Value(RequestIDContextKey),

--- a/api/v1/queries.go
+++ b/api/v1/queries.go
@@ -302,3 +302,26 @@ func (qf QueryFactory) ValidatorsDataQuery() string {
 		LIMIT $2::bigint
 		OFFSET $3::bigint`, qf.chainID)
 }
+
+func (qf QueryFactory) TpsCheckpointQuery() string {
+	return `
+		SELECT hour, min_slot, tx_volume
+			FROM min5_tx_volume
+		ORDER BY
+			hour DESC, min_slot DESC
+		LIMIT $1::bigint
+		OFFSET $2::bigint
+	`
+}
+
+func (qf QueryFactory) TxVolumesQuery() string {
+	return `
+		SELECT day, daily_tx_volume
+			FROM daily_tx_volume
+		ORDER BY
+			$1::text
+		DESC
+		LIMIT $2::bigint
+		OFFSET $3::bigint
+	`
+}

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -169,7 +169,7 @@ type ProposalVote struct {
 	Vote    string `json:"vote"`
 }
 
-// Validators is the API response for GetValidators.
+// ValidatorList is the API response for GetValidators.
 type ValidatorList struct {
 	Validators []Validator `json:"validators"`
 }
@@ -206,4 +206,27 @@ type ValidatorCommissionBound struct {
 	Upper      uint64 `json:"upper"`
 	EpochStart uint64 `json:"epoch_start"`
 	EpochEnd   uint64 `json:"epoch_end"`
+}
+
+// TpsCheckpointList is the API response for ListTransactionsPerSecond.
+type TpsCheckpointList struct {
+	IntervalMinutes int             `json:"interval_minutes"`
+	TpsCheckpoints  []TpsCheckpoint `json:"tps_checkpoints"`
+}
+
+// TpsCheckpoint is the live TPS value at the provided marker timestamp.
+type TpsCheckpoint struct {
+	Timestamp time.Time `json:"timestamp"`
+	TxVolume  uint64    `json:"tx_volume"`
+}
+
+// VolumeList is the API response for GetVolumes.
+type VolumeList struct {
+	Volumes []Volume `json:"volumes"`
+}
+
+// Volume is the daily transaction volume on the specified day.
+type Volume struct {
+	Date     time.Time `json:"date"`
+	TxVolume uint64    `json:"tx_volume"`
 }

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -87,6 +87,12 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 				r.Get("/", h.ListValidators)
 				r.Get("/{entity_id}", h.GetValidator)
 			})
+
+			// Aggregate Statistics.
+			r.Route("/stats", func(r chi.Router) {
+				r.Get("/tps", h.ListTransactionsPerSecond)
+				r.Get("/daily_volume", h.ListDailyVolume)
+			})
 		})
 	})
 

--- a/storage/migrations/0009_agg_stats_init.up.sql
+++ b/storage/migrations/0009_agg_stats_init.up.sql
@@ -1,0 +1,25 @@
+-- Initialization of materialized views for aggregate statistics on the consensus layer.
+
+BEGIN;
+
+-- min5_tx_volume stores the transaction volume in 5 minute buckets
+-- This can be used to estimate real time TPS.
+CREATE MATERIALIZED VIEW min5_tx_volume AS
+  SELECT
+    date_trunc( 'hour', b.time ) AS hour,
+    ( extract( minute FROM b.time )::int / 5 ) AS min_slot,
+    COUNT(*) AS tx_volume
+  FROM oasis_3.blocks AS b
+    INNER JOIN oasis_3.transactions AS t ON b.height = t.block
+  GROUP BY 1, 2;
+
+-- daily_tx_volume stores the number of transactions per day
+-- at the consensus layer.
+CREATE MATERIALIZED VIEW daily_tx_volume AS
+  SELECT
+    date_trunc ( 'day', hour ) AS day,
+    SUM(tx_volume) AS daily_tx_volume
+  FROM min5_tx_volume
+  GROUP BY 1;
+
+COMMIT;


### PR DESCRIPTION
Resolves #131 

Adds a couple of basic aggregate statistics:

- Daily transaction volume
- TPS for every 5 minute interval

This can be easily extended to add any additional aggregate stats we'd want.

Note: This shouldn't be merged in until #129 goes in, since it'll introduce a number of structural changes anyway.