### PR TITLE
Cache genesisHeight in source client

### DIFF
--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -49,10 +49,17 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 	// Configure chain context for all signatures using chain domain separation.
 	signature.SetChainContext(consensusChainContext)
 
-	return &ConsensusClient{
+	c := &ConsensusClient{
 		client:  client,
 		network: cf.network,
-	}, nil
+	}
+	doc, err := c.GenesisDocument(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.genesisHeight = doc.Height
+
+	return c, nil
 }
 
 // Runtime creates a new RuntimeClient.

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -20,8 +20,9 @@ import (
 
 // ConsensusClient is a client to the consensus backends.
 type ConsensusClient struct {
-	client  consensus.ClientBackend
-	network *config.Network
+	client        consensus.ClientBackend
+	network       *config.Network
+	genesisHeight int64
 }
 
 // GenesisDocument returns the original genesis document.
@@ -198,12 +199,7 @@ func (cc *ConsensusClient) runtimeUpdates(ctx context.Context, height int64) (ma
 		return nil, err
 	}
 
-	doc, err := cc.client.GetGenesisDocument(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if height != doc.Height {
+	if height != cc.genesisHeight {
 		rtsPrev, err := cc.runtimes(ctx, height-1)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The oasis-client in `storage/oasis/client.go` used to store the genesisHeight, but this was overwritten in #129. Unfortunately this caused the indexer to re-fetch the genesis document on each block, resulting in a considerable (20x) slowdown in the analyzer speed. This MR thus reintroduces the cached genesisHeight in the oasis client.