### PR TITLE
[analyzer] Reduce logspam when caught up with the blockchain

### DIFF
--- a/analyzer/modules/accounts.go
+++ b/analyzer/modules/accounts.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -30,10 +31,7 @@ func NewAccountsHandler(source storage.RuntimeSourceStorage, qf *analyzer.QueryF
 func (h *AccountsHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
 	data, err := h.source.AccountsData(ctx, round)
 	if err != nil {
-		h.logger.Error("error retrieving accounts data",
-			"error", err,
-		)
-		return err
+		return fmt.Errorf("error retrieving accounts data: %w", err)
 	}
 
 	for _, f := range []func(*storage.QueryBatch, *storage.AccountsData) error{

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -30,10 +31,7 @@ func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, qf *analyz
 func (h *ConsensusAccountsHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
 	data, err := h.source.ConsensusAccountsData(ctx, round)
 	if err != nil {
-		h.logger.Error("error retrieving consensus_accounts data",
-			"error", err,
-		)
-		return err
+		return fmt.Errorf("error retrieving consensus_accounts data: %w", err)
 	}
 
 	for _, f := range []func(*storage.QueryBatch, *storage.ConsensusAccountsData) error{

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -30,10 +31,7 @@ func NewCoreHandler(source storage.RuntimeSourceStorage, qf *analyzer.QueryFacto
 func (h *CoreHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
 	data, err := h.source.CoreData(ctx, round)
 	if err != nil {
-		h.logger.Error("error retrieving core data",
-			"error", err,
-		)
-		return err
+		return fmt.Errorf("error retrieving core data: %w", err)
 	}
 
 	for _, f := range []func(*storage.QueryBatch, *storage.CoreData) error{

--- a/analyzer/util/util.go
+++ b/analyzer/util/util.go
@@ -43,6 +43,19 @@ func NewBackoff(initialTimeout time.Duration, maximumTimeout time.Duration) (*Ba
 // Wait waits for the appropriate backoff interval.
 func (b *Backoff) Wait() {
 	time.Sleep(b.currentTimeout)
+}
+
+// Success slightly decreases the backoff interval.
+func (b *Backoff) Success() {
+	b.currentTimeout *= 9
+	b.currentTimeout /= 10
+	if b.currentTimeout < b.initialTimeout {
+		b.currentTimeout = b.initialTimeout
+	}
+}
+
+// Failure increases the backoff interval.
+func (b *Backoff) Failure() {
 	b.currentTimeout *= 2
 	if b.currentTimeout > b.maximumTimeout {
 		b.currentTimeout = b.maximumTimeout

--- a/analyzer/util/util_test.go
+++ b/analyzer/util/util_test.go
@@ -17,7 +17,7 @@ func TestBackoffWait(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 10; i++ {
-		backoff.Wait()
+		backoff.Failure()
 	}
 	require.Equal(t, backoff.Timeout(), 1024*time.Millisecond)
 }
@@ -28,7 +28,7 @@ func TestBackoffReset(t *testing.T) {
 	backoff, err := NewBackoff(time.Millisecond, 10*time.Second)
 	require.Nil(t, err)
 
-	backoff.Wait()
+	backoff.Failure()
 	backoff.Reset()
 	require.Equal(t, backoff.Timeout(), time.Millisecond)
 }
@@ -40,9 +40,22 @@ func TestBackoffMaximum(t *testing.T) {
 	require.Nil(t, err)
 
 	for i := 0; i < 10; i++ {
-		backoff.Wait()
+		backoff.Failure()
 	}
 	require.Equal(t, backoff.Timeout(), 10*time.Millisecond)
+}
+
+// TestBackoffMinimum tests if the backoff time is
+// appropriately lower bounded.
+func TestBackoffMinimum(t *testing.T) {
+	backoff, err := NewBackoff(time.Millisecond, 10*time.Millisecond)
+	require.Nil(t, err)
+
+	backoff.Failure()
+	for i := 0; i < 100; i++ {
+		backoff.Success()
+	}
+	require.Equal(t, backoff.Timeout(), time.Millisecond)
 }
 
 // TestMaximumTimeoutUpperBound tests that the maximum timeout upper


### PR DESCRIPTION
Closes #143.

Before this PR, both analyzers (consensus and emerald) over-eagerly fetched blocks. The biggest offenders:
- When the analyzers catch up with the latest block (or equivalently, round), block `latest_block+1` cannot be fetched. This was logged at the `ERROR` level, making logs full of these errors, and making it harder to find real errors. This PR demotes this kind of errors to `INFO`. It detects these errors by string matching (yikes!) the error messages generated deep inside the oasis-node and sent to the indexer via RPC any many library layers. I feel OK about the tradeoff: It would be lots of work to expose those errors in a structured way, and the only impact of potentially misparsing the error is to log it at the wrong severity level.
- Block fetching was retried with a back-off delay that was expected to settle at 6 seconds. However, the backoff timer got reset to 0.1s every time we did successfully fetch a block, which means that after every block, we retried (and logged failure) at 0.1, 0.2, 0.4, etc seconds. The PR changes this so that upon every fetched block, we decrease the sleep timer by only a little bit.
- The analyzer for each SDK module logged failures independently in addition to bubbling them up. In the prevailing case where the "error" was simply that we had caught up with the newest block, this resulted in lots of log spam. This PR removes logging at the SDK-module-analyzer level.