### PR TITLE
Improve Docker dev and e2e test

### DIFF
--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -11,7 +11,7 @@ analysis:
       chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
       from: 2550000
   storage:
-    endpoint: postgresql://indexer:password@postgres:5432/indexer?sslmode=disable
+    endpoint: postgresql://rwuser:password@postgres:5432/indexer?sslmode=disable
     backend: postgres
   migrations: file:///storage/migrations
 
@@ -19,7 +19,7 @@ server:
   chain_id: oasis-3
   endpoint: 0.0.0.0:8008
   storage:
-    endpoint: postgresql://indexer:password@postgres:5432/indexer?sslmode=disable
+    endpoint: postgresql://rwuser:password@postgres:5432/indexer?sslmode=disable
     backend: postgres
 
 log:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   indexer:
     image: oasislabs/oasis-indexer:dev
+    container_name: oasis-indexer
     depends_on:
       postgres:
         condition: service_healthy
@@ -22,20 +23,22 @@ services:
         target: /config
   postgres:
     image: postgres:13.7
+    container_name: oasis-postgres
     ports:
       - 5432:5432
     environment:
-      POSTGRES_USER: indexer
+      POSTGRES_USER: rwuser
       POSTGRES_PASSWORD: password
       POSTGRES_DB: indexer
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U indexer"]
+      test: ["CMD-SHELL", "pg_isready -U rwuser -d indexer"]
       interval: 5s
       retries: 10
       timeout: 5s
       start_period: 15s
   oasis-node:
     image: oasislabs/oasis-node:dev
+    container_name: oasis-node
     user: oasis
     command:
       - /bin/sh

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -30,7 +30,9 @@ import (
 
 const (
 	fundAccountAmount = 10000000000
-	timeout           = 1 * time.Second
+	// Net runner seems to generate a block per second.
+	// 2 seconds appears to be enough for now.
+	timeout = 2 * time.Second
 )
 
 func TestIndexer(t *testing.T) {


### PR DESCRIPTION
**Why**

Make Docker setup and configuration more consistent with non-Docker local development.

Increase e2e test timeout to reduce flakes.