### PR TITLE
API: Improve latest Indexer status documentation

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -767,17 +767,17 @@ components:
       properties:
         latest_chain_id:
           type: string
-          description: The latest chain ID at the head of indexing.
+          description: The most recently indexed chain ID.
           example: *chain_id_1
         latest_block:
           type: integer
           format: int64
-          description: The latest indexed block at the head of indexing.
+          description: The height of the most recent indexed block. Query a synced Oasis node for the latest block produced.
           example: *block_height_1
         latest_update:
           type: string
           format: date-time
-          description: The RFC 3339 formatted time of latest indexing update.
+          description: The RFC 3339 formatted time when the Indexer processed the latest block. Compare with current time for approximate indexing progress with the Oasis Network.
           example: *iso_timestamp_1
 
     BlockList:

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -82,6 +82,10 @@ func (c *StorageClient) Status(ctx context.Context) (*Status, error) {
 		)
 		return nil, common.ErrStorageError
 	}
+	// oasis-node control status returns time truncated to the second
+	// https://github.com/oasisprotocol/oasis-core/blob/5985dc5c2844de28241b7b16b19d91a86e5cbeda/docs/oasis-node/cli.md?plain=1#L41
+	s.LatestUpdate = s.LatestUpdate.Truncate(time.Second)
+
 	return &s, nil
 }
 


### PR DESCRIPTION
## Why
Close #102 and update documentation around status endpoint.

Move away from the fractional time displayed.

### Question
Status endpoint `https://index.oasislabs.com/v1/` returns:
```json
{"latest_chain_id":"oasis-3","latest_block":10639663,"latest_update":"2022-10-06T06:25:34.233355Z"}
```
while the block endpoint `https://index.oasislabs.com/v1/consensus/blocks/10639663` returns:
```json
{"height":10639663,"hash":"9a6b77dee42acace88583ea02ca6db2e15a38c5ce07c7a08b63ad179abaf1752","timestamp":"2022-10-06T06:25:24Z"}
```

I think we probably want to standardize the time format.