### PR TITLE
Emerald: Rename height->round, use BIGINT

### DIFF
--- a/analyzer/emerald/emerald.go
+++ b/analyzer/emerald/emerald.go
@@ -271,7 +271,7 @@ func (m *Main) queueBlockAndTransactionInserts(batch *storage.QueryBatch, data *
 		m.qf.RuntimeBlockInsertQuery(),
 		data.Round,
 		data.BlockHeader.Header.Version,
-		data.BlockHeader.Header.Timestamp,
+		time.Unix(int64(data.BlockHeader.Header.Timestamp), 0 /* nanos */),
 		data.BlockHeader.Header.EncodedHash().Hex(),
 		data.BlockHeader.Header.PreviousHash.Hex(),
 		data.BlockHeader.Header.IORoot.Hex(),

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -337,55 +337,55 @@ func (qf QueryFactory) ConsensusVoteInsertQuery() string {
 
 func (qf QueryFactory) RuntimeBlockInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_rounds (height, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
+		INSERT INTO %s.%s_rounds (round, version, produced_at, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (height, receiver, amount)
+		INSERT INTO %s.%s_transfers (round, receiver, amount)
 			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeBurnInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (height, sender, amount)
+		INSERT INTO %s.%s_transfers (round, sender, amount)
 			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransferInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (height, sender, receiver, amount)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
 			VALUES ($1, $2, $3, $4)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeDepositInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_deposits (height, sender, receiver, amount, nonce)
+		INSERT INTO %s.%s_deposits (round, sender, receiver, amount, nonce)
 			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeDepositErrorInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_deposits (height, sender, receiver, amount, nonce, module, code)
+		INSERT INTO %s.%s_deposits (round, sender, receiver, amount, nonce, module, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_withdraws (height, sender, receiver, amount, nonce)
+		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce)
 			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeWithdrawErrorInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_withdraws (height, sender, receiver, amount, nonce, module, code)
+		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce, module, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_gas_used (height, sender, amount)
+		INSERT INTO %s.%s_gas_used (round, sender, amount)
 			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
 }
 

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -337,7 +337,7 @@ func (qf QueryFactory) ConsensusVoteInsertQuery() string {
 
 func (qf QueryFactory) RuntimeBlockInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_rounds (round, version, produced_at, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
+		INSERT INTO %s.%s_rounds (round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID, qf.runtime)
 }
 

--- a/storage/migrations/0000_oasis_3_init.up.sql
+++ b/storage/migrations/0000_oasis_3_init.up.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS oasis_3.transactions
 
   txn_hash   TEXT NOT NULL,
   txn_index  INTEGER,
-  nonce      NUMERIC NOT NULL,
+  nonce      BIGINT NOT NULL,
   fee_amount NUMERIC,
   max_gas    NUMERIC,
   method     TEXT NOT NULL,

--- a/storage/migrations/0009_oasis_3_emerald_init.up.sql
+++ b/storage/migrations/0009_oasis_3_emerald_init.up.sql
@@ -4,9 +4,9 @@ BEGIN;
 
 CREATE TABLE IF NOT EXISTS oasis_3.emerald_rounds
 (
-  height    NUMERIC PRIMARY KEY,
-  version   BIGINT,
-  timestamp NUMERIC NOT NULL,
+  round       BIGINT PRIMARY KEY,
+  version     BIGINT NOT NULL,
+  produced_at TIMESTAMP WITH TIME ZONE NOT NULL,
 
   block_hash      TEXT NOT NULL,
   prev_block_hash TEXT NOT NULL,
@@ -91,7 +91,7 @@ CREATE TABLE IF NOT EXISTS oasis_3.address_preimages
 -- Core Module Data
 CREATE TABLE IF NOT EXISTS oasis_3.emerald_gas_used
 (
-  height NUMERIC NOT NULL,
+  round  BIGINT NOT NULL,
   sender TEXT NOT NULL,
   amount NUMERIC NOT NULL
 );
@@ -105,7 +105,7 @@ CREATE INDEX ix_emerald_gas_used_sender ON oasis_3.emerald_gas_used(sender);
 -- denoted by the 0-address as the sender.
 CREATE TABLE IF NOT EXISTS oasis_3.emerald_transfers
 (
-  height   NUMERIC NOT NULL,
+  round    BIGINT NOT NULL,
   sender   TEXT NOT NULL DEFAULT '0',
   receiver TEXT NOT NULL DEFAULT '0',
   amount   TEXT NOT NULL
@@ -117,15 +117,15 @@ CREATE INDEX ix_emerald_transfers_receiver ON oasis_3.emerald_transfers(receiver
 -- Consensus Accounts Module Data
 CREATE TABLE IF NOT EXISTS oasis_3.emerald_deposits
 (
-  height   NUMERIC NOT NULL,
+  round    BIGINT NOT NULL,
   sender   TEXT NOT NULL,
   receiver TEXT NOT NULL,
   amount   TEXT NOT NULL,
-  nonce    NUMERIC NOT NULL,
+  nonce    BIGINT NOT NULL,
 
   -- Optional error data
   module TEXT,
-  code   NUMERIC
+  code   BIGINT
 );
 
 CREATE INDEX ix_emerald_deposits_sender ON oasis_3.emerald_deposits(sender);
@@ -133,15 +133,15 @@ CREATE INDEX ix_emerald_deposits_receiver ON oasis_3.emerald_deposits(receiver);
 
 CREATE TABLE IF NOT EXISTS oasis_3.emerald_withdraws
 (
-  height   NUMERIC NOT NULL,
+  round    BIGINT NOT NULL,
   sender   TEXT NOT NULL,
   receiver TEXT NOT NULL,
   amount   TEXT NOT NULL,
-  nonce    NUMERIC NOT NULL,
+  nonce    BIGINT NOT NULL,
 
   -- Optional error data
   module TEXT,
-  code   NUMERIC
+  code   BIGINT
 );
 
 CREATE INDEX ix_emerald_withdraws_sender ON oasis_3.emerald_withdraws(sender);

--- a/storage/migrations/0009_oasis_3_emerald_init.up.sql
+++ b/storage/migrations/0009_oasis_3_emerald_init.up.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS oasis_3.emerald_rounds
 (
   round       BIGINT PRIMARY KEY,
   version     BIGINT NOT NULL,
-  produced_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
 
   block_hash      TEXT NOT NULL,
   prev_block_hash TEXT NOT NULL,

--- a/tests/e2e/migrations/0000_oasis_3_test_e2e.up.sql
+++ b/tests/e2e/migrations/0000_oasis_3_test_e2e.up.sql
@@ -30,7 +30,7 @@ CREATE TABLE IF NOT EXISTS oasis_test.transactions
 
   txn_hash   TEXT NOT NULL,
   txn_index  INTEGER,
-  nonce      NUMERIC NOT NULL,
+  nonce      BIGINT NOT NULL,
   fee_amount NUMERIC,
   max_gas    NUMERIC,
   method     TEXT NOT NULL,


### PR DESCRIPTION
This PR also:
- changes the type of a timestamp column to `TIMESTAMP` (from INT; used to contain unix-style timestamp)
- changes the type of `nonce` columns to BIGINT

Closes #152 

**Note: uint->int cast is left to the DB.** Details: The PR changes the type of `round` from NUMERIC (arbitrarily large integers) to BIGINT (int64). In go, rounds are `uint64`, so when we store a `round` variable into the DB, it's theoretically possible for the value to be too large. I initially coded up an explicit cast (uint->int) that panics if the uint value is too large. However I realized that the panic doesn't provide very good debugging context. OTOH if we let a value that's >=2^63 into the DB, postgres will error out, showing the query and the actual problematic value -- great for debugging. So I decided to just rely on the db to do the checks reliably. It's not as future-proof, but good enough given how low the risk is.