### PR TITLE
infra: update github actions

### DIFF
--- a/.github/workflows/docker-indexer.yaml
+++ b/.github/workflows/docker-indexer.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:  # manual; for debugging workflow before merging branch into `main`
 
 jobs:
   build-docker:
@@ -20,7 +21,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_ACCESS_TOKEN }}


### PR DESCRIPTION
Our docker build CI action is [suddenly failing](https://github.com/oasisprotocol/oasis-indexer/actions/runs/3237922106) with `buildx failed with: ERROR: failed to solve: server message: insufficient_scope: authorization failed`.

The error is accompanied with some deprecation warnings that this PR fixes by bumping versions. My bet is that the PR will not actually solve the error, but better safe than sorry, and we need to upgrade eventually anyway.