### PR TITLE
aggregate stats: Increase interval, timeout

### DIFF
--- a/analyzer/consensus/workers.go
+++ b/analyzer/consensus/workers.go
@@ -8,41 +8,54 @@ import (
 )
 
 const (
-	aggregateWorkerInterval = 10 * time.Second
-	aggregateWorkerTimeout  = 60 * time.Second
+	// We would ideally recompute stats (which include 5-min aggregates) every 5 min, but the
+	// current naive implementation is too inefficient for that. Conservatively wait a long time,
+	// also so as not to overburden the DB with computing aggregate stats.
+	aggregateWorkerInterval = 6 * time.Hour
+	aggregateWorkerTimeout  = 10 * time.Minute // as of height 10767524, this takes ~3m15s
 )
 
-// The aggregate worker refreshes aggregate statistics for the consensus layer.
+// The aggregate worker continually refreshes aggregate statistics for the consensus layer.
+//
+// NOTE: The worker generates stats by bucketing _all_ txs into 5-minute (and 1-day)
+// intervals. In other words, all historical stats are recomputed every time.
+// This is inefficient, but easy to implement.
 func (m *Main) aggregateWorker(ctx context.Context) {
 	m.logger.Info("starting aggregate worker")
+	m.aggregate(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-time.After(aggregateWorkerInterval):
-			func() {
-				cancelCtx, cancel := context.WithTimeout(ctx, aggregateWorkerTimeout)
-				defer cancel()
-
-				// Note: The order matters here! Daily tx volume is a materialized view
-				// that's instantiated from 5 minute tx volume.
-				batch := &storage.QueryBatch{}
-				batch.Queue(m.qf.RefreshMin5TxVolumeQuery())
-				batch.Queue(m.qf.RefreshDailyTxVolumeQuery())
-
-				opName := "aggregate_stats"
-				timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
-				defer timer.ObserveDuration()
-
-				if err := m.target.SendBatch(cancelCtx, batch); err != nil {
-					m.metrics.DatabaseCounter(m.target.Name(), opName, "failure").Inc()
-					m.logger.Error("Failed to refresh aggregate statistics",
-						"err", err,
-					)
-				}
-
-				m.logger.Debug("aggregate worker step completed")
-			}()
+			m.aggregate(ctx)
 		}
 	}
+}
+
+// Performs a single run of aggregation.
+func (m *Main) aggregate(ctx context.Context) {
+	cancelCtx, cancel := context.WithTimeout(ctx, aggregateWorkerTimeout)
+	defer cancel()
+	startTime := time.Now()
+	m.logger.Info("starting aggregate statistics refresh")
+
+	// Note: The order matters here! Daily tx volume is a materialized view
+	// that's instantiated from 5 minute tx volume.
+	batch := &storage.QueryBatch{}
+	batch.Queue(m.qf.RefreshMin5TxVolumeQuery())
+	batch.Queue(m.qf.RefreshDailyTxVolumeQuery())
+
+	opName := "aggregate_stats"
+	timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
+	defer timer.ObserveDuration()
+
+	if err := m.target.SendBatch(cancelCtx, batch); err != nil {
+		m.metrics.DatabaseCounter(m.target.Name(), opName, "failure").Inc()
+		m.logger.Error("Failed to refresh aggregate statistics",
+			"err", err,
+		)
+	}
+
+	m.logger.Info("refreshed aggregate statistics", "duration", time.Since(startTime))
 }

--- a/storage/migrations/0010_agg_stats_init.up.sql
+++ b/storage/migrations/0010_agg_stats_init.up.sql
@@ -4,6 +4,7 @@ BEGIN;
 
 -- min5_tx_volume stores the transaction volume in 5 minute buckets
 -- This can be used to estimate real time TPS.
+-- NOTE: This materialized view is NOT refreshed every 5 minutes due to computational cost.
 CREATE MATERIALIZED VIEW min5_tx_volume AS
   SELECT
     date_trunc( 'hour', b.time ) AS hour,


### PR DESCRIPTION
Closes #144 by increasing the allowed timeout for stats aggregation. To reduce DB load (and because we expect no immediate critically important uses of aggregate stats), also conservatively hugely increases the interval between consecutive runs.

Another tiny change: aggregation used to run `N*interval` seconds after analyzer start for `N>=1`. Now, it runs for `N>=0`, i.e. there's an additional run immediately when the analyzer starts. The motivation is to make debugging easier and to obtain stats faster after a new deploy.

**Testing:** Ran against a fully synced indexer db (prod :)) and confirmed the aggregation step no longer errors out.