### PR TITLE
api: specify inclusive min/max filters

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -120,28 +120,28 @@ paths:
           schema:
             type: integer
             format: int64
-          description: A filter on minimum block height.
+          description: A filter on minimum block height, inclusive.
           example: *block_height_1
         - in: query
           name: to
           schema:
             type: integer
             format: int64
-          description: A filter on maximum block height.
+          description: A filter on maximum block height, inclusive.
           example: *block_height_2
         - in: query
           name: after
           schema:
             type: string
             format: date-time
-          description: A filter on minimum block time.
+          description: A filter on minimum block time, inclusive.
           example: *iso_timestamp_1
         - in: query
           name: before
           schema:
             type: string
             format: date-time
-          description: A filter on maximum block time.
+          description: A filter on maximum block time, inclusive.
           example: *iso_timestamp_2
       responses:
         '200':
@@ -214,14 +214,14 @@ paths:
           schema:
             type: integer
             format: int64
-          description: A filter on minimum transaction fee.
+          description: A filter on minimum transaction fee, inclusive.
           example: 1000
         - in: query
           name: maxFee
           schema:
             type: integer
             format: int64
-          description: A filter on maximum transaction fee.
+          description: A filter on maximum transaction fee, inclusive.
           example: 10000
         - in: query
           name: code
@@ -726,28 +726,28 @@ paths:
           schema:
             type: integer
             format: int64
-          description: A filter on minimum block height.
+          description: A filter on minimum block height, inclusive.
           example: *block_height_1
         - in: query
           name: to
           schema:
             type: integer
             format: int64
-          description: A filter on maximum block height.
+          description: A filter on maximum block height, inclusive.
           example: *block_height_2
         - in: query
           name: after
           schema:
             type: string
             format: date-time
-          description: A filter on minimum block time.
+          description: A filter on minimum block time, inclusive.
           example: *iso_timestamp_1
         - in: query
           name: before
           schema:
             type: string
             format: date-time
-          description: A filter on maximum block time.
+          description: A filter on maximum block time, inclusive.
           example: *iso_timestamp_2
       responses:
         '200':


### PR DESCRIPTION
we had a lot of these min/max filters. the queries use `>=` `<=`, so I'm entering these as inclusive

actually the time ones are kinda not right to be called simply "inclusive." if I say the max time is 2022 oct 20, that doesn't mean a block etc from 2022 oct 20 at 9 PM is "included," right? it's only if the timestamp is exactly 2022 oct 20 00:00:00 and zero microseconds, then that's equal to the provided max time and that's included. but up to 999 nanoseconds is fine because that'll be lost when it gets converted from Go to postgresql. hm.

or am I wrong about the above? 