### PR TITLE
 Emerald: store transaction result 

### DIFF
--- a/analyzer/emerald/incoming.go
+++ b/analyzer/emerald/incoming.go
@@ -34,6 +34,7 @@ type BlockTransactionData struct {
 	Hash                    string
 	EthHash                 *string
 	Raw                     []byte
+	RawResult               []byte
 	SignerData              []*BlockTransactionSignerData
 	RelatedAccountAddresses map[string]bool
 }
@@ -186,6 +187,7 @@ func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logg
 			blockTransactionData.EthHash = &ethHash
 		}
 		blockTransactionData.Raw = cbor.Marshal(txr.Tx)
+		blockTransactionData.RawResult = cbor.Marshal(txr.Result)
 		blockTransactionData.RelatedAccountAddresses = map[string]bool{}
 		tx, err := common.OpenUtxNoVerify(&txr.Tx)
 		if err != nil {
@@ -372,7 +374,7 @@ func emitRoundBatch(batch *storage.QueryBatch, qf *analyzer.QueryFactory, round 
 		for addr := range transactionData.RelatedAccountAddresses {
 			batch.Queue(qf.RuntimeRelatedTransactionInsertQuery(), addr, round, transactionData.Index)
 		}
-		batch.Queue(qf.RuntimeTransactionInsertQuery(), round, transactionData.Index, transactionData.Hash, transactionData.EthHash, transactionData.Raw)
+		batch.Queue(qf.RuntimeTransactionInsertQuery(), round, transactionData.Index, transactionData.Hash, transactionData.EthHash, transactionData.Raw, transactionData.RawResult)
 	}
 	for addr, preimageData := range blockData.AddressPreimages {
 		batch.Queue(qf.AddressPreimageInsertQuery(), addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -370,8 +370,8 @@ func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transactions (round, tx_index, tx_hash, tx_eth_hash, raw)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transactions (round, tx_index, tx_hash, tx_eth_hash, raw, result_raw)
+			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -35,6 +35,8 @@ CREATE TABLE oasis_3.emerald_transactions
   -- later store sufficiently detailed data in other columns or if we turn out
   -- to be able to get a copy of the transaction elsewhere.
   raw         BYTEA NOT NULL,
+  -- result_raw is cbor(CallResult).
+  result_raw  BYTEA NOT NULL,
   PRIMARY KEY (round, tx_index)
 );
 

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -4,6 +4,7 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -93,7 +94,7 @@ func (c *Client) SendBatch(ctx context.Context, batch *storage.QueryBatch) error
 		defer common.CloseOrLog(batchResults, c.logger)
 		for i := 0; i < pgxBatch.Len(); i++ {
 			if _, err := batchResults.Exec(); err != nil {
-				return err
+				return fmt.Errorf("query %d %v: %w", i, batch.Queries()[i], err)
 			}
 		}
 


### PR DESCRIPTION
we're about to add the transactions api, where we'll want to look at the tx results. I'm proposing that we store a copy in the db so that we don't have to bother the grpc server when answering indexer clients. we do this for the transactions already, i.e. we have the inputs but not the outputs.