### PR TITLE
Change delegations rounding->floor

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -221,8 +221,8 @@ func (qf QueryFactory) ConsensusTakeEscrowUpdateQuery() string {
 	return fmt.Sprintf(`
 		UPDATE %s.accounts
 			SET
-				escrow_balance_active = escrow_balance_active - ROUND($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
-				escrow_balance_debonding = escrow_balance_debonding - ROUND($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
+				escrow_balance_active = escrow_balance_active - ($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
+				escrow_balance_debonding = escrow_balance_debonding - ($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
 			WHERE address = $1`, qf.chainID)
 }
 

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -221,8 +221,8 @@ func (qf QueryFactory) ConsensusTakeEscrowUpdateQuery() string {
 	return fmt.Sprintf(`
 		UPDATE %s.accounts
 			SET
-				escrow_balance_active = escrow_balance_active - ($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
-				escrow_balance_debonding = escrow_balance_debonding - ($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
+				escrow_balance_active = escrow_balance_active - FLOOR($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
+				escrow_balance_debonding = escrow_balance_debonding - FLOOR($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
 			WHERE address = $1`, qf.chainID)
 }
 

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -146,10 +146,10 @@ CREATE TABLE oasis_3.accounts
   nonce           BIGINT DEFAULT 0,
 
   -- Escrow Account
-  escrow_balance_active         NUMERIC DEFAULT 0,
-  escrow_total_shares_active    NUMERIC DEFAULT 0,
-  escrow_balance_debonding      NUMERIC DEFAULT 0,
-  escrow_total_shares_debonding NUMERIC DEFAULT 0,
+  escrow_balance_active         NUMERIC(1000,0) DEFAULT 0,
+  escrow_total_shares_active    NUMERIC(1000,0) DEFAULT 0,
+  escrow_balance_debonding      NUMERIC(1000,0) DEFAULT 0,
+  escrow_total_shares_debonding NUMERIC(1000,0) DEFAULT 0,
 
   -- TODO: Track commission schedule and staking accumulator.
 


### PR DESCRIPTION
#192 

The validator delegations balances are slightly too low. Current hypothesis is that the rounding in `ConsensusTakeEscrowUpdateQuery` is the root cause. Since postgres `numeric` types support arbitrary precision, we should instead do the rounding at the API layer. Testing still in progress. 