### PR TITLE
Emerald: track tokens

### DIFF
--- a/analyzer/emerald/incoming.go
+++ b/analyzer/emerald/incoming.go
@@ -170,7 +170,6 @@ func registerRelatedAddressSpec(addressPreimages map[string]*AddressPreimageData
 	return addr, nil
 }
 
-//nolint:unparam
 func registerRelatedEthAddress(addressPreimages map[string]*AddressPreimageData, relatedAddresses map[string]bool, ethAddr []byte) (string, error) {
 	addr, err := registerEthAddress(addressPreimages, ethAddr)
 	if err != nil {
@@ -342,16 +341,16 @@ func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logg
 						amount := &big.Int{}
 						amount.SetBytes(amountU256)
 						if !bytes.Equal(fromEthAddr, common.ZeroEthAddr) {
-							fromAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, fromEthAddr)
-							if err1 != nil {
-								return fmt.Errorf("from: %w", err1)
+							fromAddr, err2 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, fromEthAddr)
+							if err2 != nil {
+								return fmt.Errorf("from: %w", err2)
 							}
 							registerTokenDecrease(blockData.TokenChanges, eventAddr, fromAddr, amount)
 						}
 						if !bytes.Equal(toEthAddr, common.ZeroEthAddr) {
-							toAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, toEthAddr)
-							if err1 != nil {
-								return fmt.Errorf("to: %w", err1)
+							toAddr, err2 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, toEthAddr)
+							if err2 != nil {
+								return fmt.Errorf("to: %w", err2)
 							}
 							registerTokenIncrease(blockData.TokenChanges, eventAddr, toAddr, amount)
 						}
@@ -359,15 +358,15 @@ func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logg
 					},
 					Erc20Approval: func(ownerEthAddr []byte, spenderEthAddr []byte, amountU256 []byte) error {
 						if !bytes.Equal(ownerEthAddr, common.ZeroEthAddr) {
-							_, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, ownerEthAddr)
-							if err1 != nil {
-								return fmt.Errorf("owner: %w", err1)
+							_, err2 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, ownerEthAddr)
+							if err2 != nil {
+								return fmt.Errorf("owner: %w", err2)
 							}
 						}
 						if !bytes.Equal(spenderEthAddr, common.ZeroEthAddr) {
-							_, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, spenderEthAddr)
-							if err1 != nil {
-								return fmt.Errorf("spender: %w", err1)
+							_, err2 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, spenderEthAddr)
+							if err2 != nil {
+								return fmt.Errorf("spender: %w", err2)
 							}
 						}
 						return nil

--- a/analyzer/emerald/incoming.go
+++ b/analyzer/emerald/incoming.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"math/big"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
@@ -45,6 +46,15 @@ type AddressPreimageData struct {
 	Data              []byte
 }
 
+type TokenChangeKey struct {
+	// TokenAddress is the Oasis address of the smart contract of the
+	// compatible (e.g. ERC-20) token.
+	TokenAddress string
+	// AccountAddress is the Oasis address of the owner of some amount of the
+	// compatible (e.g. ERC-20) token.
+	AccountAddress string
+}
+
 type BlockData struct {
 	Hash             string
 	NumTransactions  int
@@ -52,6 +62,7 @@ type BlockData struct {
 	Size             int
 	TransactionData  []*BlockTransactionData
 	AddressPreimages map[string]*AddressPreimageData
+	TokenChanges     map[TokenChangeKey]*big.Int
 }
 
 // Function naming conventions in this file:
@@ -171,6 +182,26 @@ func registerRelatedEthAddress(addressPreimages map[string]*AddressPreimageData,
 	return addr, nil
 }
 
+func findTokenChange(tokenChanges map[TokenChangeKey]*big.Int, contractAddr string, accountAddr string) *big.Int {
+	key := TokenChangeKey{contractAddr, accountAddr}
+	change, ok := tokenChanges[key]
+	if !ok {
+		change = &big.Int{}
+		tokenChanges[key] = change
+	}
+	return change
+}
+
+func registerTokenIncrease(tokenChanges map[TokenChangeKey]*big.Int, contractAddr string, accountAddr string, amount *big.Int) {
+	change := findTokenChange(tokenChanges, contractAddr, accountAddr)
+	change.Add(change, amount)
+}
+
+func registerTokenDecrease(tokenChanges map[TokenChangeKey]*big.Int, contractAddr string, accountAddr string, amount *big.Int) {
+	change := findTokenChange(tokenChanges, contractAddr, accountAddr)
+	change.Sub(change, amount)
+}
+
 //nolint:gocyclo
 func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logger *log.Logger) (*BlockData, error) {
 	var blockData BlockData
@@ -178,6 +209,7 @@ func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logg
 	blockData.NumTransactions = len(txrs)
 	blockData.TransactionData = make([]*BlockTransactionData, 0, len(txrs))
 	blockData.AddressPreimages = map[string]*AddressPreimageData{}
+	blockData.TokenChanges = map[TokenChangeKey]*big.Int{}
 	for txIndex, txr := range txrs {
 		var blockTransactionData BlockTransactionData
 		blockTransactionData.Index = txIndex
@@ -301,19 +333,27 @@ func extractRound(b *block.Block, txrs []*sdkClient.TransactionWithResults, logg
 				return nil
 			},
 			Evm: func(event *evm.Event) error {
-				if err1 := common.VisitEvmEvent(event, &common.EvmEventHandler{
+				eventAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, event.Address)
+				if err1 != nil {
+					return fmt.Errorf("event address: %w", err1)
+				}
+				if err1 = common.VisitEvmEvent(event, &common.EvmEventHandler{
 					Erc20Transfer: func(fromEthAddr []byte, toEthAddr []byte, amountU256 []byte) error {
+						amount := &big.Int{}
+						amount.SetBytes(amountU256)
 						if !bytes.Equal(fromEthAddr, common.ZeroEthAddr) {
-							_, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, fromEthAddr)
+							fromAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, fromEthAddr)
 							if err1 != nil {
 								return fmt.Errorf("from: %w", err1)
 							}
+							registerTokenDecrease(blockData.TokenChanges, eventAddr, fromAddr, amount)
 						}
 						if !bytes.Equal(toEthAddr, common.ZeroEthAddr) {
-							_, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, toEthAddr)
+							toAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, toEthAddr)
 							if err1 != nil {
 								return fmt.Errorf("to: %w", err1)
 							}
+							registerTokenIncrease(blockData.TokenChanges, eventAddr, toAddr, amount)
 						}
 						return nil
 					},
@@ -380,5 +420,8 @@ func emitRoundBatch(batch *storage.QueryBatch, qf *analyzer.QueryFactory, round 
 	}
 	for addr, preimageData := range blockData.AddressPreimages {
 		batch.Queue(qf.AddressPreimageInsertQuery(), addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
+	}
+	for key, change := range blockData.TokenChanges {
+		batch.Queue(qf.RuntimeTokenChangeUpdateQuery(), key.TokenAddress, key.AccountAddress, change.String())
 	}
 }

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -429,6 +429,14 @@ func (qf QueryFactory) AddressPreimageInsertQuery() string {
 		ON CONFLICT DO NOTHING`, qf.chainID)
 }
 
+func (qf QueryFactory) RuntimeTokenChangeUpdateQuery() string {
+	return fmt.Sprintf(`
+		INSERT INTO %[1]s.%[2]s_token_balances (token_address, account_address, balance)
+			VALUES ($1, $2, $3)
+		ON CONFLICT (token_address, account_address) DO
+			UPDATE SET balance = %[1]s.%[2]s_token_balances.balance + $3`, qf.chainID, qf.runtime)
+}
+
 func (qf QueryFactory) RefreshDailyTxVolumeQuery() string {
 	return `
 		REFRESH MATERIALIZED VIEW daily_tx_volume

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -179,7 +179,7 @@ func (qf QueryFactory) ConsensusReceiverUpdateQuery() string {
 		INSERT INTO %[1]s.accounts (address, general_balance)
 			VALUES ($1, $2)
 		ON CONFLICT (address) DO
-			UPDATE SET general_balance = %[1]s.accounts.general_balance + $2;`, qf.chainID)
+			UPDATE SET general_balance = %[1]s.accounts.general_balance + $2`, qf.chainID)
 }
 
 func (qf QueryFactory) ConsensusBurnUpdateQuery() string {

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -98,6 +98,14 @@ CREATE TABLE oasis_3.address_preimages
     address_data       BYTEA NOT NULL
 );
 
+CREATE TABLE oasis_3.emerald_token_balances
+(
+  token_address TEXT NOT NULL,
+  account_address TEXT NOT NULL,
+  balance NUMERIC(1000,0) NOT NULL,
+  PRIMARY KEY (token_address, account_address)
+);
+
 -- Core Module Data
 CREATE TABLE oasis_3.emerald_gas_used
 (


### PR DESCRIPTION
we already have the plumbing to run something on each erc20 Transfer event. this gathers them into a token_balances table.

details:
- transfers from the zero ethereum address count as mints
- transfers to the zero ethereum address count as burns
- addresses in the table are oasis addresses. look up ethereum addresses as needed in the address preimages table

other notes:
- this doesn't count holders. I'll ask about how to implement this
- there's no enforcement about starting from genesis-----you can start whenever, and you may have negative "balance" where it only shows the total of all in-minus-out during the time scanned
- no nothin done about contracts using erc20-compatible Transfer events in any wrong way

see design https://app.clickup.com/t/3u9y034?comment=1272147909