### PR TITLE
cmd: flag for wiping the db on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,9 @@ postgres:
 		-e POSTGRES_PASSWORD=password \
 		-e POSTGRES_DB=indexer \
 		-d postgres
+	@sleep 1  # Experimentally enough for postgres to start accepting connections
+	# Create a read-only user to mimic the production environment.
+	docker exec -it indexer-postgres psql -U rwuser indexer -c "CREATE ROLE indexer_readonly; CREATE USER api WITH PASSWORD 'password' IN ROLE indexer_readonly;"
 
 # Attach to the local DB from "make postgres"
 psql:

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -159,6 +159,7 @@ func (m *Main) Start() {
 	}
 	for m.cfg.Range.To == 0 || height <= m.cfg.Range.To {
 		backoff.Wait()
+		m.logger.Info("attempting block", "height", height)
 
 		if err := m.processBlock(ctx, height); err != nil {
 			if err == analyzer.ErrOutOfRange {
@@ -176,6 +177,7 @@ func (m *Main) Start() {
 			continue
 		}
 
+		m.logger.Info("processed block", "height", height)
 		backoff.Success()
 		height++
 	}
@@ -270,10 +272,6 @@ func (m *Main) processGenesis(ctx context.Context) error {
 // from source storage and committing an atomically-executed batch of queries
 // to target storage.
 func (m *Main) processBlock(ctx context.Context, height int64) error {
-	m.logger.Info("processing block",
-		"height", height,
-	)
-
 	group, groupCtx := errgroup.WithContext(ctx)
 
 	// Prepare and perform updates.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,10 +57,12 @@ func rootMain(cmd *cobra.Command, args []string) {
 	// Initialize services.
 	analysisService, err := analyzer.Init(cfg.Analysis)
 	if err != nil {
+		logger.Error("failed to initialize analysis service", "err", err)
 		os.Exit(1)
 	}
 	apiService, err := api.Init(cfg.Server)
 	if err != nil {
+		logger.Error("failed to initialize api service", "err", err)
 		os.Exit(1)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -202,6 +202,10 @@ type StorageConfig struct {
 
 	// Backend is the storage backend to select.
 	Backend string `koanf:"backend"`
+
+	// If true, we'll first delete all tables in the DB to
+	// force a full re-index of the blockchain.
+	WipeStorage bool `koanf:"DANGER__WIPE_STORAGE_ON_STARTUP"`
 }
 
 // Validate validates the storage configuration.

--- a/storage/api.go
+++ b/storage/api.go
@@ -250,4 +250,7 @@ type TargetStorage interface {
 
 	// Name returns the name of the target storage.
 	Name() string
+
+	// Wipe removes all contents of the target storage.
+	Wipe(ctx context.Context) error
 }


### PR DESCRIPTION
This PR allows one to wipe the DB with a config flag:
```
analysis:
  analyzers: [...]
  storage:
    backend: postgres
    DANGER__wipe_storage_on_startup: true
```

I found it handy in my testing. It's also useful for hypothetical scenarios in staging/prod where we know we have to reindex, and a flag is better than doing manual surgery.

The PR also includes some very minor unrelated logging improvements.