### PR TITLE
Emerald: add index for token holders count

### DIFF
--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -106,6 +106,8 @@ CREATE TABLE oasis_3.emerald_token_balances
   PRIMARY KEY (token_address, account_address)
 );
 
+CREATE INDEX ix_emerald_token_address ON oasis_3.emerald_token_balances (token_address) WHERE balance != 0;
+
 -- Core Module Data
 CREATE TABLE oasis_3.emerald_gas_used
 (


### PR DESCRIPTION
here's the index, but I haven't made a huge table to see if the EXPLAIN is good

```
indexer=# analyze oasis_3.emerald_token_balances;
ANALYZE
indexer=# explain select token_address, count(*) as num_holders from oasis_3.emerald_token_balances where balance != 0 group by token_address;
                                  QUERY PLAN                                   
-------------------------------------------------------------------------------
 HashAggregate  (cost=6.95..7.22 rows=27 width=55)
   Group Key: token_address
   ->  Seq Scan on emerald_token_balances  (cost=0.00..6.25 rows=140 width=47)
         Filter: (balance <> '0'::numeric)
(4 rows)
```

reviewers: will this work?