### PR TITLE
Strenghten sql constraints

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -31,8 +31,7 @@ import (
 
 const (
 	consensusDamaskAnalyzerName = "consensus_damask"
-	noKeyManager                = "none" // KM name to use when there is no KM
-	registryUpdateFrequency     = 100    // once per n block
+	registryUpdateFrequency     = 100 // once per n block
 )
 
 // Main is the main Analyzer for the consensus layer.
@@ -501,10 +500,11 @@ func (m *Main) queueRuntimeRegistrations(batch *storage.QueryBatch, data *storag
 	runtimeUpsertQuery := m.qf.ConsensusRuntimeUpsertQuery()
 
 	for _, runtimeEvent := range data.RuntimeEvents {
-		keyManager := noKeyManager
+		var keyManager *string
 
 		if runtimeEvent.Runtime.KeyManager != nil {
-			keyManager = runtimeEvent.Runtime.KeyManager.String()
+			km := runtimeEvent.Runtime.KeyManager.String()
+			keyManager = &km
 		}
 
 		batch.Queue(runtimeUpsertQuery,

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -431,7 +431,7 @@ func (m *Main) queueTransactionInserts(batch *storage.QueryBatch, data *storage.
 			}
 
 			batch.Queue(commissionsUpsertQuery,
-				staking.NewAddress(signedTx.Signature.PublicKey),
+				staking.NewAddress(signedTx.Signature.PublicKey).String(),
 				string(schedule),
 			)
 		}
@@ -543,7 +543,7 @@ func (m *Main) queueEntityEvents(batch *storage.QueryBatch, data *storage.Regist
 		for _, node := range entityEvent.Entity.Nodes {
 			batch.Queue(claimedNodeInsertQuery,
 				entityID,
-				node,
+				node.String(),
 			)
 		}
 		batch.Queue(entityUpsertQuery,
@@ -626,7 +626,7 @@ func (m *Main) queueMetadataRegistry(ctx context.Context, batch *storage.QueryBa
 	entityMetaUpsertQuery := m.qf.ConsensusEntityMetaUpsertQuery()
 	for id, meta := range entities {
 		batch.Queue(entityMetaUpsertQuery,
-			id,
+			id.String(),
 			meta,
 		)
 	}
@@ -822,7 +822,7 @@ func (m *Main) queueValidatorUpdates(batch *storage.QueryBatch, data *storage.Sc
 	validatorNodeUpdateQuery := m.qf.ConsensusValidatorNodeUpdateQuery()
 	for _, validator := range data.Validators {
 		batch.Queue(validatorNodeUpdateQuery,
-			validator.ID,
+			validator.ID.String(),
 			validator.VotingPower,
 		)
 	}

--- a/analyzer/consensus/genesis.go
+++ b/analyzer/consensus/genesis.go
@@ -117,12 +117,12 @@ VALUES
 VALUES
 `
 		for i, runtime := range document.Registry.Runtimes {
-			keyManager := noKeyManager
+			keyManager := "NULL"
 			if runtime.KeyManager != nil {
-				keyManager = runtime.KeyManager.String()
+				keyManager = fmt.Sprintf("'%s'", runtime.KeyManager.String())
 			}
 			query += fmt.Sprintf(
-				"\t('%s', %t, '%s', '%s', '%s')",
+				"\t('%s', %t, '%s', '%s', %s)",
 				runtime.ID.String(),
 				false,
 				runtime.Kind.String(),
@@ -144,12 +144,12 @@ VALUES
 `
 
 		for i, runtime := range document.Registry.SuspendedRuntimes {
-			keyManager := noKeyManager
+			keyManager := "NULL"
 			if runtime.KeyManager != nil {
-				keyManager = runtime.KeyManager.Hex()
+				keyManager = fmt.Sprintf("'%s'", runtime.KeyManager.String())
 			}
 			query += fmt.Sprintf(
-				"\t('%s', %t, '%s', '%s', '%s')",
+				"\t('%s', %t, '%s', '%s', %s)",
 				runtime.ID.String(),
 				true,
 				runtime.Kind.String(),

--- a/analyzer/emerald/emerald.go
+++ b/analyzer/emerald/emerald.go
@@ -9,6 +9,8 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgx/v4"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
@@ -103,6 +105,13 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 func (m *Main) Start() {
 	ctx := context.Background()
 
+	if err := m.prework(); err != nil {
+		m.logger.Error("error doing prework",
+			"err", err,
+		)
+		return
+	}
+
 	// Get round to be indexed.
 	var round uint64
 
@@ -176,6 +185,27 @@ func (m *Main) latestRound(ctx context.Context) (uint64, error) {
 		return 0, err
 	}
 	return latest, nil
+}
+
+// prework performs tasks that need to be done before the main loop starts.
+func (m *Main) prework() error {
+	batch := &storage.QueryBatch{}
+	ctx := context.Background()
+
+	// Register special addresses.
+	batch.Queue(
+		m.qf.AddressPreimageInsertQuery(),
+		rewards.RewardPoolAddress.String(),          // oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav for emerald on mainnet oasis-3
+		types.AddressV0ModuleContext.Identifier,     // context_identifier
+		int32(types.AddressV0ModuleContext.Version), // context_version,
+		"rewards.reward-pool",                       // address_data (reconstructed from NewAddressForModule())
+	)
+	if err := m.target.SendBatch(ctx, batch); err != nil {
+		return err
+	}
+	m.logger.Info("registered special addresses")
+
+	return nil
 }
 
 // processRound processes the provided round, retrieving all required information

--- a/analyzer/modules/accounts.go
+++ b/analyzer/modules/accounts.go
@@ -58,7 +58,7 @@ func (h *AccountsHandler) queueMints(batch *storage.QueryBatch, data *storage.Ac
 			h.qf.RuntimeMintInsertQuery(),
 			data.Round,
 			mint.Owner.String(),
-			mint.Amount.String(),
+			mint.Amount.Amount.String(),
 		)
 	}
 
@@ -71,7 +71,7 @@ func (h *AccountsHandler) queueBurns(batch *storage.QueryBatch, data *storage.Ac
 			h.qf.RuntimeBurnInsertQuery(),
 			data.Round,
 			burn.Owner.String(),
-			burn.Amount.String(),
+			burn.Amount.Amount.String(),
 		)
 	}
 
@@ -85,7 +85,7 @@ func (h *AccountsHandler) queueTransfers(batch *storage.QueryBatch, data *storag
 			data.Round,
 			transfer.From.String(),
 			transfer.To.String(),
-			transfer.Amount.String(),
+			transfer.Amount.Amount.String(),
 		)
 	}
 

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -53,13 +53,21 @@ func (h *ConsensusAccountsHandler) Name() string {
 
 func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data *storage.ConsensusAccountsData) error {
 	for _, deposit := range data.Deposits {
+		if !deposit.Amount.Denomination.IsNative() {
+			// Should never happen.
+			h.logger.Error("non-native denomination in deposit; pretending it is native",
+				"denomination", deposit.Amount.Denomination,
+				"round", data.Round,
+				"from", deposit.From.String(),
+				"to", deposit.To.String())
+		}
 		if deposit.Error != nil {
 			batch.Queue(
 				h.qf.RuntimeDepositErrorInsertQuery(),
 				data.Round,
 				deposit.From.String(),
 				deposit.To.String(),
-				deposit.Amount.String(),
+				deposit.Amount.Amount.String(),
 				deposit.Nonce,
 				deposit.Error.Module,
 				deposit.Error.Code,
@@ -70,7 +78,7 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 				data.Round,
 				deposit.From.String(),
 				deposit.To.String(),
-				deposit.Amount.String(),
+				deposit.Amount.Amount.String(),
 				deposit.Nonce,
 			)
 		}
@@ -81,13 +89,21 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 
 func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, data *storage.ConsensusAccountsData) error {
 	for _, withdraw := range data.Withdraws {
+		if !withdraw.Amount.Denomination.IsNative() {
+			// Should never happen.
+			h.logger.Error("non-native denomination in withdraw; pretending it is native",
+				"denomination", withdraw.Amount.Denomination,
+				"round", data.Round,
+				"from", withdraw.From.String(),
+				"to", withdraw.To.String())
+		}
 		if withdraw.Error != nil {
 			batch.Queue(
 				h.qf.RuntimeWithdrawErrorInsertQuery(),
 				data.Round,
 				withdraw.From.String(),
 				withdraw.To.String(),
-				withdraw.Amount.String(),
+				withdraw.Amount.Amount.String(),
 				withdraw.Nonce,
 				withdraw.Error.Module,
 				withdraw.Error.Code,
@@ -98,7 +114,7 @@ func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, dat
 				data.Round,
 				withdraw.From.String(),
 				withdraw.To.String(),
-				withdraw.Amount.String(),
+				withdraw.Amount.Amount.String(),
 				withdraw.Nonce,
 			)
 		}

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -55,7 +55,7 @@ func (h *CoreHandler) queueGasUsed(batch *storage.QueryBatch, data *storage.Core
 		batch.Queue(
 			h.qf.RuntimeGasUsedInsertQuery(),
 			data.Round,
-			"unknown", // TODO: Get sender from transaction data
+			nil, // TODO: Get sender address from transaction data
 			gasUsed.Amount,
 		)
 	}

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -376,14 +376,14 @@ func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, receiver, amount)
-			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
+			VALUES ($1, NULL, $2, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeBurnInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, amount)
-			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
+			VALUES ($1, $2, NULL, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransferInsertQuery() string {

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -99,6 +99,7 @@ CREATE TABLE oasis_3.nodes
   -- historically (as per @Yawning), we also allowed node registrations that are signed with the entity signing key,
   -- in which case, the node would be allowed to register without having been pre-claimed by the entity.
   -- For those cases, (id, entity_id) is not a foreign key into oasis_3.claimed_nodes.
+  -- Similarly, an entity can un-claim a node after the node registered, but the node can remain be registered for a while.
   entity_id  base64_ed25519_pubkey NOT NULL REFERENCES oasis_3.entities(id),
   expiration BIGINT NOT NULL,
 
@@ -168,7 +169,12 @@ CREATE TABLE oasis_3.accounts
 CREATE TABLE oasis_3.allowances
 (
   owner       oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
-  beneficiary oasis_addr,  -- No REFERENCES; the beneficiary can technically be a nonexistent/unused address.
+  -- When creating an allowance for the purpose of subsequently depositing funds to a
+  -- paratime account A in paratime P (i.e. the expected use case for allowances), `beneficiary` is
+  -- the "staking account" of P. The staking account is a special account derived from the paratime ID:
+  --  - derivation: https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/staking/api/address.go#L96-L96
+  --  - precomputed accounts: https://github.com/oasisprotocol/oasis-wallet-web/blob/34fdf495de5ca0d585addf0073f6a71bba556588/src/config.ts#L89-L139
+  beneficiary oasis_addr,
   allowance   UINT_NUMERIC,
 
   PRIMARY KEY (owner, beneficiary)

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -6,19 +6,27 @@ BEGIN;
 -- Create Damask Upgrade Schema with `chain-id`.
 CREATE SCHEMA IF NOT EXISTS oasis_3;
 
--- Block Data
+-- Custom types
+CREATE DOMAIN uint_numeric NUMERIC(1000,0) CHECK(VALUE >= 0);
+CREATE DOMAIN uint63 BIGINT CHECK(VALUE >= 0);
+CREATE DOMAIN uint31 INTEGER CHECK(VALUE >= 0);
+CREATE DOMAIN hex64 TEXT CHECK(VALUE ~ '^[0-9a-f]{64}$');
+-- base64(ed25519 public key); from https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/common/crypto/signature/signature.go#L90-L90
+CREATE DOMAIN base64_ed25519_pubkey TEXT CHECK(VALUE ~ '^[A-Za-z0-9+/]{43}=$');
+CREATE DOMAIN oasis_addr TEXT CHECK(length(VALUE) = 46 AND VALUE ~ '^oasis1');
 
+-- Block Data
 CREATE TABLE oasis_3.blocks
 (
-  height     BIGINT PRIMARY KEY,
-  block_hash TEXT NOT NULL,
+  height     UINT63 PRIMARY KEY,
+  block_hash HEX64 NOT NULL,
   time       TIMESTAMP WITH TIME ZONE NOT NULL,
 
   -- State Root Info
   namespace TEXT NOT NULL,
-  version   BIGINT NOT NULL,
-  type      TEXT NOT NULL,
-  root_hash TEXT NOT NULL,
+  version   UINT63 NOT NULL,
+  type      TEXT NOT NULL,  -- "invalid" | "state-root" | "io-root"; From https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/storage/mkvs/node/node.go#L68-L68
+  root_hash HEX64 NOT NULL,
 
   beacon     BYTEA,
   metadata   JSON
@@ -26,21 +34,21 @@ CREATE TABLE oasis_3.blocks
 
 CREATE TABLE oasis_3.transactions
 (
-  block BIGINT NOT NULL REFERENCES oasis_3.blocks(height),
+  block BIGINT NOT NULL REFERENCES oasis_3.blocks(height) DEFERRABLE INITIALLY DEFERRED,
 
-  txn_hash   TEXT NOT NULL,
-  txn_index  INTEGER,
-  nonce      BIGINT NOT NULL,
-  fee_amount NUMERIC,
-  max_gas    NUMERIC,
+  txn_hash   HEX64 NOT NULL,
+  txn_index  UINT31,
+  nonce      UINT63 NOT NULL,
+  fee_amount UINT_NUMERIC,
+  max_gas    UINT_NUMERIC,
   method     TEXT NOT NULL,
-  sender     TEXT NOT NULL,
+  sender     oasis_addr NOT NULL,
   body       BYTEA,
 
   -- Error Fields
   -- This includes an encoding of no error.
   module  TEXT,
-  code    BIGINT,
+  code    UINT31,  -- From https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/consensus/api/transaction/results/results.go#L20-L20
   message TEXT,
 
   -- We require a composite primary key since duplicate transactions can
@@ -52,42 +60,46 @@ CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);
 
 CREATE TABLE oasis_3.events
 (
-  backend TEXT NOT NULL,
-  type    TEXT NOT NULL,
+  backend TEXT NOT NULL,  -- E.g. registry, staking
+  type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/oasis-indexer/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
   body    JSON,
 
-  txn_block  BIGINT NOT NULL,
-  txn_hash   TEXT NOT NULL,
-  txn_index  INTEGER,
+  txn_block  UINT63 NOT NULL,
+  txn_hash   HEX64 NOT NULL,
+  txn_index  UINT31,
 
-  FOREIGN KEY (txn_block, txn_hash, txn_index) REFERENCES oasis_3.transactions(block, txn_hash, txn_index)
+  FOREIGN KEY (txn_block, txn_hash, txn_index) REFERENCES oasis_3.transactions(block, txn_hash, txn_index) DEFERRABLE INITIALLY DEFERRED
 );
 
 -- Beacon Backend Data
 
 CREATE TABLE oasis_3.epochs
 (
-  id           BIGINT PRIMARY KEY,
-  start_height BIGINT NOT NULL,
-  end_height   BIGINT,
+  id           UINT63 PRIMARY KEY,
+  start_height UINT63 NOT NULL,
+  end_height   UINT63 CHECK (end_height IS NULL OR end_height >= start_height),
   UNIQUE (start_height, end_height)
 );
 
 -- Registry Backend Data
 CREATE TABLE oasis_3.entities
 (
-  id      TEXT PRIMARY KEY,
-  address TEXT,
+  id      base64_ed25519_pubkey PRIMARY KEY,
+  address oasis_addr,
   -- Signed statements about the entity from https://github.com/oasisprotocol/metadata-registry
   meta    JSON
 );
 
 CREATE TABLE oasis_3.nodes
 (
-  id         TEXT PRIMARY KEY,
-  -- Entities are free to claim any node, and nodes are free to associate
-  -- themselves with any entity. So oasis_3.entities(id) is not a foreign key.
-  entity_id  TEXT NOT NULL,
+  -- `id` technically REFERENCES oasis_3.claimed_nodes(node_id) because node had to be pre-claimed; see oasis_3.claimed_nodes.
+  -- However, postgres does not allow foreign keys to a non-unique column.
+  id         base64_ed25519_pubkey PRIMARY KEY,
+  -- Owning entity. The entity has likely claimed this node (see oasis_3.claimed_nodes) previously. However
+  -- historically (as per @Yawning), we also allowed node registrations that are signed with the entity signing key,
+  -- in which case, the node would be allowed to register without having been pre-claimed by the entity.
+  -- For those cases, (id, entity_id) is not a foreign key into oasis_3.claimed_nodes.
+  entity_id  base64_ed25519_pubkey NOT NULL REFERENCES oasis_3.entities(id),
   expiration BIGINT NOT NULL,
 
   -- TLS Info
@@ -110,73 +122,69 @@ CREATE TABLE oasis_3.nodes
   software_version TEXT,
 
   -- Voting power should only be nonzero for consensus validator nodes.
-  voting_power     BIGINT DEFAULT 0,
+  voting_power     BIGINT DEFAULT 0
 
   -- TODO: Track node status.
-
-  -- Arbitrary additional data.
-  extra_data JSON
 );
 
+-- Claims of entities that they own nodes. Each entity claims 0 or more nodes when it registers.
+-- A node can only register if it declares itself to be owned by an entity that previously claimed it.
 CREATE TABLE oasis_3.claimed_nodes
 (
-  entity_id TEXT NOT NULL,
-  node_id   TEXT NOT NULL,
+  entity_id base64_ed25519_pubkey NOT NULL REFERENCES oasis_3.entities(id) DEFERRABLE INITIALLY DEFERRED,
+  node_id   base64_ed25519_pubkey NOT NULL,  -- No REFERENCES because the node likely does not exist (in the indexer) yet when the entity claims it.
 
   PRIMARY KEY (entity_id, node_id)  
 );
 
 CREATE TABLE oasis_3.runtimes
 (
-  id           TEXT PRIMARY KEY,
+  id           HEX64 PRIMARY KEY,
   suspended    BOOLEAN NOT NULL DEFAULT false,
-  kind         TEXT NOT NULL,
-  tee_hardware TEXT NOT NULL,
-  key_manager  TEXT
+  kind         TEXT NOT NULL,  -- "invalid" | "compute" | "manager"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/registry/api/runtime.go#L54-L54
+  tee_hardware TEXT NOT NULL,  -- "invalid" | "intel-sgx"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/common/node/node.go#L474-L474
+  key_manager  HEX64
 );
 
 -- Staking Backend Data
 
 CREATE TABLE oasis_3.accounts
 (
-  address TEXT PRIMARY KEY,
+  address oasis_addr PRIMARY KEY,
 
   -- General Account
   general_balance NUMERIC DEFAULT 0,
-  nonce           BIGINT DEFAULT 0,
+  nonce           UINT63 NOT NULL DEFAULT 0,
 
   -- Escrow Account
-  escrow_balance_active         NUMERIC(1000,0) DEFAULT 0,
-  escrow_total_shares_active    NUMERIC(1000,0) DEFAULT 0,
-  escrow_balance_debonding      NUMERIC(1000,0) DEFAULT 0,
-  escrow_total_shares_debonding NUMERIC(1000,0) DEFAULT 0,
+  escrow_balance_active         UINT_NUMERIC NOT NULL DEFAULT 0,
+  escrow_total_shares_active    UINT_NUMERIC NOT NULL DEFAULT 0,
+  escrow_balance_debonding      UINT_NUMERIC NOT NULL DEFAULT 0,
+  escrow_total_shares_debonding UINT_NUMERIC NOT NULL DEFAULT 0
 
   -- TODO: Track commission schedule and staking accumulator.
-
-  -- Arbitrary additional data.
-  extra_data JSON
 );
 
 CREATE TABLE oasis_3.allowances
 (
-  owner       TEXT NOT NULL,
-  beneficiary TEXT NOT NULL,
-  allowance   NUMERIC,
+  owner       oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  beneficiary oasis_addr,  -- No REFERENCES; the beneficiary can technically be a nonexistent/unused address.
+  allowance   UINT_NUMERIC,
 
   PRIMARY KEY (owner, beneficiary)
 );
 
 CREATE TABLE oasis_3.commissions
 (
-  address  TEXT PRIMARY KEY NOT NULL REFERENCES oasis_3.accounts(address),
+  address  oasis_addr PRIMARY KEY NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
   schedule JSON
 );
 
 CREATE TABLE oasis_3.delegations
 (
-  delegatee TEXT NOT NULL,
-  delegator TEXT NOT NULL,
-  shares    NUMERIC NOT NULL,
+  delegatee oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  delegator oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  shares    UINT_NUMERIC NOT NULL,
 
   PRIMARY KEY (delegatee, delegator)
 );
@@ -184,10 +192,10 @@ CREATE TABLE oasis_3.delegations
 CREATE TABLE oasis_3.debonding_delegations
 (
   id         BIGSERIAL PRIMARY KEY,  -- index-internal ID
-  delegatee  TEXT NOT NULL,
-  delegator  TEXT NOT NULL,
-  shares     NUMERIC NOT NULL,
-  debond_end BIGINT NOT NULL
+  delegatee  oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  delegator  oasis_addr NOT NULL REFERENCES oasis_3.accounts(address) DEFERRABLE INITIALLY DEFERRED,
+  shares     UINT_NUMERIC NOT NULL,
+  debond_end UINT63 NOT NULL  -- EpochTime, i.e. number of epochs since base epoch
 );
 
 -- Scheduler Backend Data
@@ -195,7 +203,7 @@ CREATE TABLE oasis_3.debonding_delegations
 CREATE TABLE oasis_3.committee_members
 (
   node      TEXT NOT NULL,
-  valid_for BIGINT NOT NULL,
+  valid_for UINT63 NOT NULL,
   runtime   TEXT NOT NULL,
   kind      TEXT NOT NULL,
   role      TEXT NOT NULL,
@@ -207,9 +215,9 @@ CREATE TABLE oasis_3.committee_members
 
 CREATE TABLE oasis_3.proposals
 (
-  id            BIGINT PRIMARY KEY,
-  submitter     TEXT NOT NULL,
-  state         TEXT NOT NULL DEFAULT 'active',
+  id            UINT63 PRIMARY KEY,
+  submitter     oasis_addr NOT NULL,
+  state         TEXT NOT NULL DEFAULT 'active',  -- "active" | "passed" | "rejected" | "failed"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/governance/api/proposal.go#L29-L29
   executed      BOOLEAN NOT NULL DEFAULT false,
   deposit       NUMERIC NOT NULL,
 
@@ -218,21 +226,21 @@ CREATE TABLE oasis_3.proposals
   cp_target_version  TEXT,
   rhp_target_version TEXT,
   rcp_target_version TEXT,
-  upgrade_epoch      BIGINT,
+  upgrade_epoch      UINT63,
 
   -- If this proposal cancels an existing proposal.
   cancels BIGINT REFERENCES oasis_3.proposals(id) DEFAULT NULL,
 
-  created_at    BIGINT NOT NULL,
-  closes_at     BIGINT NOT NULL,
-  invalid_votes NUMERIC NOT NULL DEFAULT 0
+  created_at    UINT63 NOT NULL,  -- EpochTime, i.e. number of epochs since base epoch
+  closes_at     UINT63 NOT NULL,  -- EpochTime, i.e. number of epochs since base epoch
+  invalid_votes UINT_NUMERIC NOT NULL DEFAULT 0
 );
 
 CREATE TABLE oasis_3.votes
 (
-  proposal BIGINT NOT NULL REFERENCES oasis_3.proposals(id),
-  voter    TEXT NOT NULL,
-  vote     TEXT,
+  proposal UINT63 NOT NULL REFERENCES oasis_3.proposals(id) DEFERRABLE INITIALLY DEFERRED,
+  voter    oasis_addr NOT NULL,
+  vote     TEXT,  -- "yes" | "no" | "abstain"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/registry/api/runtime.go#L54-L54
 
   PRIMARY KEY (proposal, voter)
 );
@@ -240,7 +248,7 @@ CREATE TABLE oasis_3.votes
 -- Indexing Progress Management
 CREATE TABLE oasis_3.processed_blocks
 (
-  height         BIGINT NOT NULL,
+  height         UINT63 NOT NULL,
   analyzer       TEXT NOT NULL,
   processed_time TIMESTAMP WITH TIME ZONE NOT NULL,
 

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -4,21 +4,21 @@ BEGIN;
 
 CREATE TABLE oasis_3.emerald_rounds
 (
-  round     BIGINT PRIMARY KEY,
-  version   BIGINT NOT NULL,
+  round     UINT63 PRIMARY KEY,
+  version   UINT63 NOT NULL,
   timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
 
-  block_hash      TEXT NOT NULL,
-  prev_block_hash TEXT NOT NULL,
+  block_hash      HEX64 NOT NULL, -- Hash of this round's block. Does not reference consensus.
+  prev_block_hash HEX64 NOT NULL,
 
-  io_root          TEXT NOT NULL,
-  state_root       TEXT NOT NULL,
-  messages_hash    TEXT NOT NULL,
-  in_messages_hash TEXT NOT NULL,
+  io_root          HEX64 NOT NULL,
+  state_root       HEX64 NOT NULL,
+  messages_hash    HEX64 NOT NULL,
+  in_messages_hash HEX64 NOT NULL,
 
-  num_transactions INTEGER NOT NULL,
-  gas_used         BIGINT NOT NULL,
-  size             INTEGER NOT NULL
+  num_transactions UINT31 NOT NULL,
+  gas_used         UINT63 NOT NULL,
+  size             UINT31 NOT NULL  -- Total byte size of all transactions in the block.
 );
 
 CREATE INDEX ix_emerald_rounds_block_hash ON oasis_3.emerald_rounds USING hash (block_hash);
@@ -26,10 +26,10 @@ CREATE INDEX ix_emerald_rounds_timestamp ON oasis_3.emerald_rounds (timestamp);
 
 CREATE TABLE oasis_3.emerald_transactions
 (
-  round       BIGINT NOT NULL,
-  tx_index    INTEGER NOT NULL,
-  tx_hash     TEXT NOT NULL,
-  tx_eth_hash TEXT,
+  round       UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  tx_index    UINT31 NOT NULL,
+  tx_hash     HEX64 NOT NULL,
+  tx_eth_hash HEX64,
   -- raw is cbor(UnverifiedTransaction). If you're unable to get a copy of the
   -- transaction from the node itself, parse from here. Remove this if we
   -- later store sufficiently detailed data in other columns or if we turn out
@@ -45,25 +45,27 @@ CREATE INDEX ix_emerald_transactions_tx_eth_hash ON oasis_3.emerald_transactions
 
 CREATE TABLE oasis_3.emerald_transaction_signers
 (
-  round          BIGINT NOT NULL,
-  tx_index       INTEGER NOT NULL,
+  round          UINT63 NOT NULL,
+  tx_index       UINT31 NOT NULL,
   -- Emerald processes mainly Ethereum-format transactions with only one
   -- signer, but Emerald is built on the Oasis runtime SDK, which supports
   -- multiple signers on a transaction (note that this is a distinct concept
   -- from multisig accounts).
-  signer_index   INTEGER NOT NULL,
-  signer_address TEXT NOT NULL,
-  nonce          BIGINT NOT NULL,
-  PRIMARY KEY (round, tx_index, signer_index)
+  signer_index   UINT31 NOT NULL,
+  signer_address oasis_addr NOT NULL,
+  nonce          UINT31 NOT NULL,
+  PRIMARY KEY (round, tx_index, signer_index),
+  FOREIGN KEY (round, tx_index) REFERENCES oasis_3.emerald_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX ix_emerald_transaction_signers_signer_address_signer_nonce ON oasis_3.emerald_transaction_signers (signer_address, nonce);
 
 CREATE TABLE oasis_3.emerald_related_transactions
 (
-  account_address TEXT NOT NULL,
-  tx_round        BIGINT NOT NULL,
-  tx_index        INTEGER NOT NULL
+  account_address oasis_addr NOT NULL,
+  tx_round        UINT63 NOT NULL,
+  tx_index        UINT31 NOT NULL,
+  FOREIGN KEY (tx_round, tx_index) REFERENCES oasis_3.emerald_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
 
 CREATE INDEX ix_emerald_related_transactions_address_height_index ON oasis_3.emerald_related_transactions (account_address, tx_round, tx_index);
@@ -81,21 +83,26 @@ CREATE INDEX ix_emerald_related_transactions_address_height_index ON oasis_3.eme
 --
 -- Retain this across hard forks as long as the address derivation scheme is
 -- compatible.
+--
+-- The data is accumulated from signed paratime txs; signer info contains all the
+-- fields in this table (so that the signature can be verified correctly).
 CREATE TABLE oasis_3.address_preimages
 (
-    -- address is the Bech32-encoded Oasis address (i.e. starting with
-    -- oasis1...).
-    address            TEXT NOT NULL PRIMARY KEY,
+    address            oasis_addr NOT NULL PRIMARY KEY,
+    -- "oasis-core/address: staking" | "oasis-runtime-sdk/address: secp256k1eth" | "oasis-runtime-sdk/address: sr25519" | "oasis-runtime-sdk/address: multisig" | "oasis-runtime-sdk/address: module"
+    -- From https://github.com/oasisprotocol/oasis-sdk/blob/386ba0b99fcd1425c68015e0033a462d9a577835/client-sdk/go/types/address.go#L22-L22
     context_identifier TEXT NOT NULL,
-    context_version    INTEGER NOT NULL,
+    context_version    UINT31 NOT NULL,
+    -- Data from which the address was derived. For example, for a "secp256k1eth" context, this is the
+    -- Ethereum address. For a "staking" context, this is the ed25519 pubkey.
     address_data       BYTEA NOT NULL
 );
 
 -- Core Module Data
 CREATE TABLE oasis_3.emerald_gas_used
 (
-  round  BIGINT NOT NULL,
-  sender TEXT NOT NULL,
+  round  UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  sender TEXT NOT NULL,  -- not oasis_addr because it uses a special value "unknown"
   amount NUMERIC NOT NULL
 );
 
@@ -108,7 +115,7 @@ CREATE INDEX ix_emerald_gas_used_sender ON oasis_3.emerald_gas_used(sender);
 -- denoted by the 0-address as the sender.
 CREATE TABLE oasis_3.emerald_transfers
 (
-  round    BIGINT NOT NULL,
+  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
   sender   TEXT NOT NULL DEFAULT '0',
   receiver TEXT NOT NULL DEFAULT '0',
   amount   TEXT NOT NULL
@@ -118,33 +125,52 @@ CREATE INDEX ix_emerald_transfers_sender ON oasis_3.emerald_transfers(sender);
 CREATE INDEX ix_emerald_transfers_receiver ON oasis_3.emerald_transfers(receiver);
 
 -- Consensus Accounts Module Data
+-- Deposits from the consensus layer into the paratime.
 CREATE TABLE oasis_3.emerald_deposits
 (
-  round    BIGINT NOT NULL,
-  sender   TEXT NOT NULL,
-  receiver TEXT NOT NULL,
+  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  -- The `sender` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
+  -- that consensus and paratimes can be indexed independently.
+  -- It also REFERENCES oasis_3.address_preimages because the sender signed at least the Deposit tx.
+  sender   oasis_addr NOT NULL REFERENCES oasis_3.address_preimages DEFERRABLE INITIALLY DEFERRED,
+  -- The `receiver` can be any oasis1-form paratime address.
+  -- With EVM paratimes, two types of deposits are common:
+  --  * Deposit intends to credit a hex-form (eth) account. The user first derives the oasis1-form address,
+  --    then uses it as `receiver`. Such a `receiver` address has a secp256k1eth key, an is not valid in
+  --    consensus (which only uses ed25519), meaning there is no FK in oasis_3.addresses.
+  --  * Deposit intends to credit an ed25519-backed account. These accounts do not exist in classic Ethereum.
+  --    The associated hex-form Ethereum address either does not exist or is not knowable.
+  -- Regardless, the `receiver` often REFERENCES oasis_3.address_preimages(address), a notable exception
+  -- being if the target account hasn't signed any txs yet.
+  receiver oasis_addr NOT NULL,
   amount   TEXT NOT NULL,
-  nonce    BIGINT NOT NULL,
+  nonce    UINT63 NOT NULL,
 
-  -- Optional error data
+  -- Optional error data; from https://github.com/oasisprotocol/oasis-sdk/blob/386ba0b99fcd1425c68015e0033a462d9a577835/client-sdk/go/modules/consensusaccounts/types.go#L44-L44
   module TEXT,
-  code   BIGINT
+  code   UINT63
 );
 
 CREATE INDEX ix_emerald_deposits_sender ON oasis_3.emerald_deposits(sender);
 CREATE INDEX ix_emerald_deposits_receiver ON oasis_3.emerald_deposits(receiver);
 
+-- Withdrawals from the paratime into consensus layer.
 CREATE TABLE oasis_3.emerald_withdraws
 (
-  round    BIGINT NOT NULL,
-  sender   TEXT NOT NULL,
-  receiver TEXT NOT NULL,
+  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  -- The `sender` can be any paratime address. (i.e. secp256k1eth-backed OR ed25519-backed;
+  -- other are options unlikely in an EVM paratime)
+  -- It REFERENCES oasis_3.address_preimages because the sender signed at least the Withdraw tx.
+  sender   oasis_addr NOT NULL REFERENCES oasis_3.address_preimages DEFERRABLE INITIALLY DEFERRED,
+  -- The `receiver` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
+  -- that consensus and paratimes can be indexed independently.
+  receiver oasis_addr NOT NULL,
   amount   TEXT NOT NULL,
-  nonce    BIGINT NOT NULL,
+  nonce    UINT63 NOT NULL,
 
   -- Optional error data
   module TEXT,
-  code   BIGINT
+  code   UINT63
 );
 
 CREATE INDEX ix_emerald_withdraws_sender ON oasis_3.emerald_withdraws(sender);

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -143,7 +143,7 @@ CREATE TABLE oasis_3.emerald_deposits
   -- Regardless, the `receiver` often REFERENCES oasis_3.address_preimages(address), a notable exception
   -- being if the target account hasn't signed any txs yet.
   receiver oasis_addr NOT NULL,
-  amount   TEXT NOT NULL,
+  amount   UINT_NUMERIC NOT NULL,
   nonce    UINT63 NOT NULL,
 
   -- Optional error data; from https://github.com/oasisprotocol/oasis-sdk/blob/386ba0b99fcd1425c68015e0033a462d9a577835/client-sdk/go/modules/consensusaccounts/types.go#L44-L44
@@ -165,7 +165,7 @@ CREATE TABLE oasis_3.emerald_withdraws
   -- The `receiver` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
   -- that consensus and paratimes can be indexed independently.
   receiver oasis_addr NOT NULL,
-  amount   TEXT NOT NULL,
+  amount   UINT_NUMERIC NOT NULL,
   nonce    UINT63 NOT NULL,
 
   -- Optional error data

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -102,7 +102,7 @@ CREATE TABLE oasis_3.address_preimages
 CREATE TABLE oasis_3.emerald_gas_used
 (
   round  UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
-  sender TEXT NOT NULL,  -- not oasis_addr because it uses a special value "unknown"
+  sender oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
   amount NUMERIC NOT NULL
 );
 


### PR DESCRIPTION
- Introduces custom types (oasis address, hash, uints, etc)
  - Postgres doesn't have `uint` types out of the box, so we emulate e.g. `uint64` with `int64 CHECK (VALUE >=0)`, which is in effect an `uint63`. Emulating a proper `uint64` with a `NUMERIC CHECK (...)` is much costlier and not needed at least for now.
- Adds numerous negative-value checks (by using the `uint` types)
- Adds foreign keys where possible
- Adds comments/explanations for various tables and columns
- *breaking:* Changes the semantics of several columns that used strings such as `"unknown"` and `"0"` to indicate a special value or lack of data. These columns now use `NULL` for the same purpose; it's more idiomatic, and it allows for stronger typing.
- *breaking, bugfix:* Changes some `TEXT` columns to `NUMERIC` where applicable. Change the go code to store the actual value in the db, not a string like `"2995000000000000000000 <native>"`.
- Adds a stub for registering special addresses (only one for now -- the rewards pool)

Closes #40. It would be nice to also carefully pre-check the validity of args in golang (so that we can e.g. clamp them, log an error, and let the indexer continue with slightly wrong info, rather than completely preventing the indexer from continuing, possibly in the middle of the night). But it's a good amount of busywork, and hard to do consistently ... so we can leave it for some other time.