### PR TITLE
Small readability, logging, debugging fixes

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -22,6 +22,7 @@ jobs:
   build-go:
     runs-on: ubuntu-20.04
     services:
+      # Generic postgres server; used only for testing our DB client lib. Not used by indexer.
       postgres:
         image: postgres:13
         env:
@@ -80,7 +81,18 @@ jobs:
         run: make start-docker-e2e
       - name: Confirm containers
         run: docker ps -a
-      - name: Log containers
-        run: docker logs oasis-indexer
       - name: Test
         run: docker exec oasis-indexer sh -c "cd /oasis-indexer && make test-e2e"
+      - name: Dump logs and DB contents
+        run: |
+          docker logs oasis-indexer | tee /tmp/oasis-indexer.log;
+          docker logs indexer-postgres | tee /tmp/indexer-postgres.log;
+          docker exec indexer-postgres pg_dump -U indexer --create | tee /tmp/indexer_db.sql;
+        if: success() || failure()  # but not if job is manually cancelled
+      - uses: actions/upload-artifact@v3
+        with:
+          name: indexer_db.sql
+          path: |
+            /tmp/indexer_db.sql
+            /tmp/*.log
+        if: success() || failure()  # but not if job is manually cancelled

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ start-docker:
 	@docker compose up --remove-orphans
 
 start-docker-e2e:
-	@docker compose -f tests/e2e/docker-compose.e2e.yml up -d
+	@env HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f tests/e2e/docker-compose.e2e.yml up -d
 
 start-e2e: start-docker-e2e
 	docker exec oasis-indexer sh -c "cd /oasis-indexer && make test-e2e"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 include common.mk
 
+# For running `docker compose` containers as current user
+export HOST_UID := $(shell id -u)
+export HOST_GID := $(shell id -g)
+
 all: build
 
 build:
@@ -76,7 +80,7 @@ start-docker:
 	@docker compose up --remove-orphans
 
 start-docker-e2e:
-	@env HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose -f tests/e2e/docker-compose.e2e.yml up -d
+	@docker compose -f tests/e2e/docker-compose.e2e.yml up -d
 
 start-e2e: start-docker-e2e
 	docker exec oasis-indexer sh -c "cd /oasis-indexer && make test-e2e"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: oasislabs/oasis-indexer:dev
     container_name: oasis-indexer
     depends_on:
-      postgres:
+      indexer-postgres:
         condition: service_healthy
       oasis-node:
         condition: service_healthy
@@ -21,9 +21,9 @@ services:
       - type: bind
         source: ./config
         target: /config
-  postgres:
+  indexer-postgres:
     image: postgres:13.7
-    container_name: oasis-postgres
+    container_name: indexer-postgres
     ports:
       - 5432:5432
     environment:

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -30,6 +30,7 @@ type pgxLogger struct {
 	logger *log.Logger
 }
 
+// logFuncForLevel maps a pgx log severity level to a corresponding indexer logger function.
 func (l *pgxLogger) logFuncForLevel(level pgx.LogLevel) func(string, ...interface{}) {
 	switch level {
 	case pgx.LogLevelTrace, pgx.LogLevelDebug:
@@ -46,7 +47,7 @@ func (l *pgxLogger) logFuncForLevel(level pgx.LogLevel) func(string, ...interfac
 	}
 }
 
-// Implements pgx.Logger interface.
+// Implements pgx.Logger interface. Logs to indexer logger.
 func (l *pgxLogger) Log(ctx context.Context, level pgx.LogLevel, msg string, data map[string]interface{}) {
 	args := []interface{}{}
 	for k, v := range data {

--- a/storage/postgres/client_test.go
+++ b/storage/postgres/client_test.go
@@ -18,7 +18,7 @@ import (
 
 func newClient(t *testing.T) (*Client, error) {
 	connString := os.Getenv("CI_TEST_CONN_STRING")
-	logger, err := log.NewLogger("cockroach-test", io.Discard, log.FmtJSON, log.LevelInfo)
+	logger, err := log.NewLogger("postgres-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.Nil(t, err)
 
 	return NewClient(connString, logger)
@@ -36,7 +36,7 @@ func TestInvalidConnect(t *testing.T) {
 	tests.SkipIfShort(t)
 
 	connString := "an invalid connstring"
-	logger, err := log.NewLogger("cockroach-test", io.Discard, log.FmtJSON, log.LevelInfo)
+	logger, err := log.NewLogger("postgres-test", io.Discard, log.FmtJSON, log.LevelInfo)
 	require.Nil(t, err)
 
 	_, err = NewClient(connString, logger)

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -7,7 +7,7 @@ analysis:
       from: 1
       to: 86400
   storage:
-    endpoint: postgresql://indexer:password@postgres:5432/indexer?sslmode=disable
+    endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable
     backend: postgres
   migrations: file:///storage/migrations
 
@@ -15,7 +15,7 @@ server:
   chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner
   endpoint: 0.0.0.0:8008
   storage:
-    endpoint: postgresql://indexer:password@postgres:5432/indexer?sslmode=disable
+    endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable
     backend: postgres
 
 log:

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -3,7 +3,7 @@ services:
     image: oasislabs/oasis-indexer:dev
     container_name: oasis-indexer
     depends_on:
-      postgres:
+      indexer-postgres:
         condition: service_healthy
       oasis-net-runner:
         condition: service_healthy
@@ -18,9 +18,9 @@ services:
       - type: bind
         source: ./testnet
         target: /testnet
-  postgres:
+  indexer-postgres:
     image: postgres:13.7
-    container_name: oasis-postgres
+    container_name: indexer-postgres
     ports:
       - 5432:5432
     command: ["postgres", "-c", "log_statement=all"]

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -30,9 +30,11 @@ import (
 
 const (
 	fundAccountAmount = 10000000000
-	// Net runner seems to generate a block per second.
-	// 2 seconds appears to be enough for now.
-	timeout = 2 * time.Second
+	// The amount of time to wait after a blockchain tx to make sure that the a block with the
+	// tx was produced and the indexer has indexed the block.
+	// The node seems to generate a block per second.
+	// 2 seconds is experimentally enough, 1 second was flaky.
+	indexerDelay = 2 * time.Second
 )
 
 func TestIndexer(t *testing.T) {
@@ -111,7 +113,7 @@ func TestIndexer(t *testing.T) {
 		t.Errorf("account funding failure: %v", err)
 	}
 
-	time.Sleep(timeout)
+	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
 	require.Equal(t, account.Available, uint64(100000000))
@@ -136,14 +138,14 @@ func TestIndexer(t *testing.T) {
 	}
 
 	// Bob account has correct delegation balance
-	time.Sleep(timeout)
+	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
 	require.Equal(t, account.DelegationsBalance, uint64(25000000))
 	require.Equal(t, account.Available, uint64(75000000))
 
 	// Alice account has correct escrow balance
-	time.Sleep(timeout)
+	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", aliceAddress), &account)
 	require.Nil(t, err)
 	require.Equal(t, account.Escrow, uint64(25000000))

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -116,7 +116,7 @@ func TestIndexer(t *testing.T) {
 	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
-	require.Equal(t, account.Available, uint64(100000000))
+	require.Equal(t, uint64(100000000), account.Available)
 
 	// Create escrow tx.
 	escrow := &staking.Escrow{
@@ -141,13 +141,13 @@ func TestIndexer(t *testing.T) {
 	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
-	require.Equal(t, account.DelegationsBalance, uint64(25000000))
-	require.Equal(t, account.Available, uint64(75000000))
+	require.Equal(t, uint64(25000000), account.DelegationsBalance)
+	require.Equal(t, uint64(75000000), account.Available)
 
 	// Alice account has correct escrow balance
 	time.Sleep(indexerDelay)
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", aliceAddress), &account)
 	require.Nil(t, err)
-	require.Equal(t, account.Escrow, uint64(25000000))
-	require.Equal(t, account.Available, uint64(9900000000))
+	require.Equal(t, uint64(25000000), account.Escrow)
+	require.Equal(t, uint64(9900000000), account.Available)
 }


### PR DESCRIPTION
Various small improvements I made while working on #221:
- CI: expose container logs and DB contents as github CI artifacts
- e2e in Makefile: fix permissions so that `make stop-e2e` can clean up all the files created by `make start-e2e`. Previously, some oasis-net-runner files were created by `root` (from within a container), but in a location mounted from the host. So those were always a little clumsy to clean up.
- docker-compose: rename container `oasis-postgres` to `indexer-postgres` for consistency with non-docker-compose way of running
- postgres unit tests: fixes a typo where we referred to postgres as cockroach
- adds comments in various places
- e2e test: fix the reverted order of expected and actual values (made for weird-looking error reports)

The splitting into commits is approximate.