### PR TITLE
bugfix: stringify big.Int and uint64 before sending to pgx

### DIFF
--- a/analyzer/emerald/emerald.go
+++ b/analyzer/emerald/emerald.go
@@ -197,7 +197,7 @@ func (m *Main) prework() error {
 		m.qf.AddressPreimageInsertQuery(),
 		rewards.RewardPoolAddress.String(),          // oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav for emerald on mainnet oasis-3
 		types.AddressV0ModuleContext.Identifier,     // context_identifier
-		int32(types.AddressV0ModuleContext.Version), // context_version,
+		int32(types.AddressV0ModuleContext.Version), // context_version
 		"rewards.reward-pool",                       // address_data (reconstructed from NewAddressForModule())
 	)
 	if err := m.target.SendBatch(ctx, batch); err != nil {
@@ -299,7 +299,7 @@ func (m *Main) queueBlockAndTransactionInserts(batch *storage.QueryBatch, data *
 		data.BlockHeader.Header.MessagesHash.Hex(),
 		data.BlockHeader.Header.InMessagesHash.Hex(),
 		blockData.NumTransactions,
-		blockData.GasUsed,
+		fmt.Sprintf("%d", blockData.GasUsed),
 		blockData.Size,
 	)
 

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -123,7 +123,7 @@ CREATE TABLE oasis_3.nodes
   software_version TEXT,
 
   -- Voting power should only be nonzero for consensus validator nodes.
-  voting_power     BIGINT DEFAULT 0
+  voting_power     UINT63 DEFAULT 0
 
   -- TODO: Track node status.
 );


### PR DESCRIPTION
This is a forward fix for the e2e tests broken in #217.

The underlying problem was a bad uint64 cast from go to sql. The e2e test uncovered one such cast, but then I found many more. Take the following as an example:
```
batch.Queue(transactionInsertQuery, [...],
			tx.Fee.Amount.ToBigInt().Uint64(),
			tx.Fee.Gas, [...]
)
```
This represents both types of errors fixed by the PR:
- Amount is an arbitrary-precision int, both in core and in the db. We simply ignore any values over uint64 here. That's pretty bad, though the e2e test didn't actually catch this. 
- Gas is `uint64` in core, and `uint_numeric` (custom type, defined as `numeric(1000,0) CHECK(VALUE>=0)` ) in the db. Postgres doesn't have uint64, it only has int64. Before #217, pgx somehow recognized that the go `uint64` was being used to fill a `numeric` db field, and presented it to postgres as a string (?). Now that the db field is a custom type, pgx doesn't want to force stringification, so it instead tries to represent the `uint64` to postgres as `Int8` (pgx's internal name for `int64`, as in "8 bytes"). For values above 1<<63, this fails.

The **fix in this PR** for both cases is to manually serialize the go value to string before sending it to pgx. This works, but it's brittle, because we have to remember to do it every time we write sql queries. Possible other fixes:
- Add explicit casts in sql statements (`... $1::numeric ...`); maybe that will help pgx. I only thought of this now, haven't tried it, also haven't tried to understand how pgx handles types internally.
- Introduce stronger typing to `queries.go`, so that every query-constructing fn would have a signature like `AddTransactionQuery(AddTransactionQueryParams params)`. We'd still have to get all the stringifying done manually and correctly, but it would be in a central spot, in `queries.go`.
- Use something other than pgx(?)