### PR TITLE
Update concurrency of process block goroutines

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -275,7 +275,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 
 	// Prepare and perform updates.
 	batch := &storage.QueryBatch{}
-	queries := make([]storage.QueryBatch, 6)
+	queries := make([]storage.QueryBatch, 5)
 
 	type prepareFunc = func(context.Context, int64, *storage.QueryBatch) error
 	for i, f := range []prepareFunc{
@@ -285,9 +285,9 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		m.prepareSchedulerData,
 		m.prepareGovernanceData,
 	} {
-		func(f prepareFunc, idx int) {
+		func(f prepareFunc, i int) {
 			group.Go(func() error {
-				return f(groupCtx, height, &queries[idx])
+				return f(groupCtx, height, &queries[i])
 			})
 		}(f, i)
 	}
@@ -311,7 +311,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 
 	for i, b := range queries {
 		if b.Len() == 0 {
-			m.logger.Info(fmt.Sprintf("Block %d missing %d data", height, i))
+			m.logger.Info(fmt.Sprintf("Block %d goroutine %d emitted zero queries", height, i))
 			continue
 		}
 		batch.Append(&b)

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -316,7 +316,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 			m.logger.Debug(fmt.Sprintf("Block %d goroutine %d emitted zero queries", height, i))
 			continue
 		}
-		batch.Extend(&b)
+		batch.Extend(b)
 	}
 
 	opName := "process_block_consensus"

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -278,20 +278,20 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 	queries := make([]storage.QueryBatch, 0)
 
 	type prepareFunc = func(context.Context, int64, *storage.QueryBatch) error
-	for i, f := range []prepareFunc{
+	for _, f := range []prepareFunc{
 		m.prepareBlockData,
 		m.prepareRegistryData,
 		m.prepareStakingData,
 		m.prepareSchedulerData,
 		m.prepareGovernanceData,
 	} {
-		func(f prepareFunc, i int) {
+		func(f prepareFunc) {
 			batch := storage.QueryBatch{}
 			queries = append(queries, batch)
 			group.Go(func() error {
 				return f(groupCtx, height, &batch)
 			})
-		}(f, i)
+		}(f)
 	}
 
 	// Update indexing progress.

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -311,7 +311,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 
 	for i, b := range queries {
 		if b.Len() == 0 {
-			m.logger.Info(fmt.Sprintf("Block %d goroutine %d emitted zero queries", height, i))
+			m.logger.Debug(fmt.Sprintf("Block %d goroutine %d emitted zero queries", height, i))
 			continue
 		}
 		batch.Append(&b)

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -285,9 +285,9 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		m.prepareSchedulerData,
 		m.prepareGovernanceData,
 	} {
-		func(f prepareFunc, i int) {
+		func(f prepareFunc, idx int) {
 			group.Go(func() error {
-				return f(groupCtx, height, &queries[i])
+				return f(groupCtx, height, &queries[idx])
 			})
 		}(f, i)
 	}

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -275,7 +275,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 
 	// Prepare and perform updates.
 	batch := &storage.QueryBatch{}
-	queries := make([]storage.QueryBatch, 0)
+	queries := make([]*storage.QueryBatch, 0)
 
 	type prepareFunc = func(context.Context, int64, *storage.QueryBatch) error
 	for _, f := range []prepareFunc{
@@ -287,7 +287,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 	} {
 		func(f prepareFunc) {
 			batch := storage.QueryBatch{}
-			queries = append(queries, batch)
+			queries = append(queries, &batch)
 			group.Go(func() error {
 				return f(groupCtx, height, &batch)
 			})

--- a/storage/api.go
+++ b/storage/api.go
@@ -47,8 +47,8 @@ func (b *QueryBatch) Queue(cmd string, args ...interface{}) {
 	})
 }
 
-// Append merges another batch into the current batch.
-func (b *QueryBatch) Append(qb *QueryBatch) {
+// Extend merges another batch into the current batch.
+func (b *QueryBatch) Extend(qb *QueryBatch) {
 	b.items = append(b.items, qb.items...)
 }
 

--- a/storage/api.go
+++ b/storage/api.go
@@ -51,6 +51,11 @@ func (b *QueryBatch) Append(qb *QueryBatch) {
 	b.items = append(b.items, qb.items...)
 }
 
+// Len returns the number of queries in the batch.
+func (b *QueryBatch) Len() int {
+	return len(b.items)
+}
+
 // AsPgxBatch converts a QueryBatch to a pgx.Batch.
 func (b *QueryBatch) AsPgxBatch() pgx.Batch {
 	pgxBatch := pgx.Batch{}

--- a/storage/api.go
+++ b/storage/api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v4"
+
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"

--- a/storage/api.go
+++ b/storage/api.go
@@ -46,6 +46,11 @@ func (b *QueryBatch) Queue(cmd string, args ...interface{}) {
 	})
 }
 
+// Append merges another batch into the current batch.
+func (b *QueryBatch) Append(qb *QueryBatch) {
+	b.items = append(b.items, qb.items...)
+}
+
 // AsPgxBatch converts a QueryBatch to a pgx.Batch.
 func (b *QueryBatch) AsPgxBatch() pgx.Batch {
 	pgxBatch := pgx.Batch{}


### PR DESCRIPTION
Warren pointed out that our `QueryBatch.Queue` was not thread-safe. This MR aims to remedy that. Part of a broader goal of tracking down inconsistent balances/db state in #211  and #159 

I've been running a version of this locally to hunt for negative balances. No issues as of yet