### PR TITLE
Allow partial configs, optionally run just API or just analyzers

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,28 +55,31 @@ func rootMain(cmd *cobra.Command, args []string) {
 	logger := common.Logger()
 
 	// Initialize services.
-	analysisService, err := analyzer.Init(cfg.Analysis)
-	if err != nil {
-		logger.Error("failed to initialize analysis service", "err", err)
-		os.Exit(1)
-	}
-	apiService, err := api.Init(cfg.Server)
-	if err != nil {
-		logger.Error("failed to initialize api service", "err", err)
-		os.Exit(1)
-	}
-
 	var wg sync.WaitGroup
-	for _, service := range []Service{
-		analysisService,
-		apiService,
-	} {
+	runInWG := func(s Service) {
 		wg.Add(1)
 		go func(s Service) {
 			defer wg.Done()
 			defer s.Shutdown()
 			s.Start()
-		}(service)
+		}(s)
+	}
+
+	if cfg.Analysis != nil {
+		analysisService, err := analyzer.Init(cfg.Analysis)
+		if err != nil {
+			logger.Error("failed to initialize analysis service", "err", err)
+			os.Exit(1)
+		}
+		runInWG(analysisService)
+	}
+	if cfg.Server != nil {
+		apiService, err := api.Init(cfg.Server)
+		if err != nil {
+			logger.Error("failed to initialize api service", "err", err)
+			os.Exit(1)
+		}
+		runInWG(apiService)
 	}
 
 	logger.Info("started all services")


### PR DESCRIPTION
This PR allows one to provide a "partial" config.yaml, e.g. without an `server:` or `analysis:` section (which configure the API server and the analyzers, respectively), and the binary will simply not run the components without a config. Before this PR, the binary would crash.

I later discovered that it is already possible to run the binary as `./analyzer analyze` or `analyzer serve`, which will make it read only one specific part of the config and thus also work with partial config files. Even so, it doesn't hurt to have the additional robustness provided in this PR.