### PR TITLE
bugfix: genesis_test: Ignore expired nodes in registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ postgres:
 		-e POSTGRES_USER=rwuser \
 		-e POSTGRES_PASSWORD=password \
 		-e POSTGRES_DB=indexer \
-		-d postgres
+		-d postgres -c log_statement=all
 	@sleep 1  # Experimentally enough for postgres to start accepting connections
 	# Create a read-only user to mimic the production environment.
 	docker exec -it indexer-postgres psql -U rwuser indexer -c "CREATE ROLE indexer_readonly; CREATE USER api WITH PASSWORD 'password' IN ROLE indexer_readonly;"

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
@@ -60,6 +61,11 @@ func (cc *ConsensusClient) Name() string {
 	return fmt.Sprintf("%s_consensus", moduleName)
 }
 
+// GetEpoch returns the epoch number at the specified block height.
+func (cc *ConsensusClient) GetEpoch(ctx context.Context, height int64) (api.EpochTime, error) {
+	return cc.client.Beacon().GetEpoch(ctx, height)
+}
+
 // BlockData retrieves data about a consensus block at the provided block height.
 func (cc *ConsensusClient) BlockData(ctx context.Context, height int64) (*storage.ConsensusBlockData, error) {
 	block, err := cc.client.GetBlock(ctx, height)
@@ -67,7 +73,7 @@ func (cc *ConsensusClient) BlockData(ctx context.Context, height int64) (*storag
 		return nil, err
 	}
 
-	epoch, err := cc.client.Beacon().GetEpoch(ctx, height)
+	epoch, err := cc.GetEpoch(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +108,7 @@ func (cc *ConsensusClient) BeaconData(ctx context.Context, height int64) (*stora
 		return nil, err
 	}
 
-	epoch, err := cc.client.Beacon().GetEpoch(ctx, height)
+	epoch, err := cc.GetEpoch(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +225,7 @@ func (cc *ConsensusClient) StakingData(ctx context.Context, height int64) (*stor
 		return nil, err
 	}
 
-	epoch, err := cc.client.Beacon().GetEpoch(ctx, height)
+	epoch, err := cc.GetEpoch(ctx, height)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
oasis-node keeps reporting some nodes (in the `registry` part of its StateToGenesis output) even after they've already expired. Their expiration epoch is included in the output, so the output is not technically wrong; it's just not useful to insist in genesis_test that the indexer's internal state and the node's StateToGenesis agree on which _expired_ nodes should be listed.
This PR ignores expired nodes on both sides before doing a comparison.

With this fix, genesis_test passes at height 8050156 (which used to be problematic) and also at height 8055536.

The PR is motivated by #211 (so genesis_test is more reliable for finding bugs) and #179 (so genesis_test is usable for finding would-be regressions introduced by that refactor).


### Remaining flakiness

Vaguely related: At 8055536, genesis_test passes the registry part but shows two new errors: Wrong nonce for oasis1qrn99n0hz4ka6vdj8vkmm8y04de5mwhtrckrgsrj, and wrong balance for oasis1qzv7a0gkxwpfelv985fvkl24k7jh3arfwy84zw7q.
Re-running the indexer to that height from scratch made the two problems go away. Just another confirmation that #211 is not resolved yet.