### PR TITLE
consensus: Do not track runtime (un)suspensions

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -257,7 +257,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		return err
 	}
 
-	data, err := source.AtHeightData(ctx, height)
+	data, err := source.AllData(ctx, height)
 	if err != nil {
 		return err
 	}

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -280,7 +280,6 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 
 	for _, f := range []func(*storage.QueryBatch, *storage.RegistryData) error{
 		m.queueRuntimeRegistrations,
-		m.queueRuntimeStatusUpdates,
 		m.queueEntityEvents,
 		m.queueNodeEvents,
 	} {
@@ -476,20 +475,6 @@ func (m *Main) queueRuntimeRegistrations(batch *storage.QueryBatch, data *storag
 			runtimeEvent.Runtime.TEEHardware.String(),
 			keyManager,
 		)
-	}
-
-	return nil
-}
-
-func (m *Main) queueRuntimeStatusUpdates(batch *storage.QueryBatch, data *storage.RegistryData) error {
-	runtimeSuspensionQuery := m.qf.ConsensusRuntimeSuspensionQuery()
-	runtimeUnsuspensionQuery := m.qf.ConsensusRuntimeUnsuspensionQuery()
-
-	for _, runtime := range data.RuntimeSuspensions {
-		batch.Queue(runtimeSuspensionQuery, runtime)
-	}
-	for _, runtime := range data.RuntimeUnsuspensions {
-		batch.Queue(runtimeUnsuspensionQuery, runtime)
 	}
 
 	return nil

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -105,20 +105,6 @@ func (qf QueryFactory) ConsensusRuntimeUpsertQuery() string {
 				key_manager = excluded.key_manager`, qf.chainID)
 }
 
-func (qf QueryFactory) ConsensusRuntimeSuspensionQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.runtimes
-			SET suspended = true
-			WHERE id = $1`, qf.chainID)
-}
-
-func (qf QueryFactory) ConsensusRuntimeUnsuspensionQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.runtimes
-			SET suspended = false
-			WHERE id = $1`, qf.chainID)
-}
-
 func (qf QueryFactory) ConsensusClaimedNodeInsertQuery() string {
 	return fmt.Sprintf(`
 		INSERT INTO %s.claimed_nodes (entity_id, node_id) VALUES ($1, $2)

--- a/storage/api.go
+++ b/storage/api.go
@@ -83,8 +83,8 @@ type ConsensusSourceStorage interface {
 	// GenesisDocument returns the genesis document for the chain.
 	GenesisDocument(ctx context.Context) (*genesisAPI.Document, error)
 
-	// AtHeightData returns all data tied to a specific height.
-	AtHeightData(ctx context.Context, height int64) (*ConsensusAtHeightData, error)
+	// AllData returns all data tied to a specific height.
+	AllData(ctx context.Context, height int64) (*ConsensusAllData, error)
 
 	// BlockData gets block data at the specified height. This includes all
 	// block header information, as well as transactions and events included
@@ -115,7 +115,7 @@ type ConsensusSourceStorage interface {
 	Name() string
 }
 
-type ConsensusAtHeightData struct {
+type ConsensusAllData struct {
 	BlockData      *ConsensusBlockData
 	BeaconData     *BeaconData
 	RegistryData   *RegistryData

--- a/storage/api.go
+++ b/storage/api.go
@@ -153,9 +153,6 @@ type RegistryData struct {
 	EntityEvents       []*registry.EntityEvent
 	NodeEvents         []*registry.NodeEvent
 	NodeUnfrozenEvents []*registry.NodeUnfrozenEvent
-
-	RuntimeSuspensions   []string
-	RuntimeUnsuspensions []string
 }
 
 // StakingData represents data for accounts at a given height.

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -142,7 +142,7 @@ CREATE TABLE oasis_3.claimed_nodes
 CREATE TABLE oasis_3.runtimes
 (
   id           HEX64 PRIMARY KEY,
-  suspended    BOOLEAN NOT NULL DEFAULT false,
+  suspended    BOOLEAN NOT NULL DEFAULT false,  -- not tracked as of Dec 2022
   kind         TEXT NOT NULL,  -- "invalid" | "compute" | "manager"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/registry/api/runtime.go#L54-L54
   tee_hardware TEXT NOT NULL,  -- "invalid" | "intel-sgx"; see https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/common/node/node.go#L474-L474
   key_manager  HEX64

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -45,8 +45,6 @@ func NewClientFactory(ctx context.Context, network *config.Network, skipChainCon
 
 // Consensus creates a new ConsensusClient.
 func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
-	ctx := context.Background()
-
 	connection := *cf.connection
 	client := connection.Consensus()
 
@@ -57,11 +55,6 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 		client:  client,
 		network: cf.network,
 	}
-	doc, err := c.GenesisDocument(ctx)
-	if err != nil {
-		return nil, err
-	}
-	c.genesisHeight = doc.Height
 
 	return c, nil
 }

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -65,8 +65,8 @@ func (cc *ConsensusClient) GetEpoch(ctx context.Context, height int64) (api.Epoc
 	return cc.client.Beacon().GetEpoch(ctx, height)
 }
 
-// AtHeightData returns all relevant data related to the given height.
-func (cc *ConsensusClient) AtHeightData(ctx context.Context, height int64) (*storage.ConsensusAtHeightData, error) {
+// AllData returns all relevant data related to the given height.
+func (cc *ConsensusClient) AllData(ctx context.Context, height int64) (*storage.ConsensusAllData, error) {
 	blockData, err := cc.BlockData(ctx, height)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (cc *ConsensusClient) AtHeightData(ctx context.Context, height int64) (*sto
 		return nil, err
 	}
 
-	data := storage.ConsensusAtHeightData{
+	data := storage.ConsensusAllData{
 		BlockData:      blockData,
 		BeaconData:     beaconData,
 		RegistryData:   registryData,


### PR DESCRIPTION
This PR removes functionality: For a given runtime, we are now no longer able to say if it is suspended.

**Motivation:** Suspension tracking was implemented with lots of RPCs -- roughly one third of all RPCs was dedicated to this functionality. At the same time, in the short/med term, it is not really important if a runtime is suspended; we expect to hand-pick the supported runtimes, and we expect them to never be suspended. Even if we later decide that this is important real-time information to have, we could implement tracking more efficiently, but it would take refactoring (and, for the most efficient solution, an additional field in the relevant oasis-node RPC response)

**Result:** On my machine (with lots of lag), the time to process a consensus block goes from 2.93s to 2.10s. Haven't tested in k8s but I expect a similar ratio since RPCs dominate processing time.
