### PR TITLE
Do not fetch ChainContext when known

### DIFF
--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -3,7 +3,6 @@ package analyzer
 import (
 	"errors"
 	"strings"
-	"time"
 
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 
@@ -47,10 +46,6 @@ type ConsensusConfig struct {
 	// If this is set, the analyzer analyzes blocks in the provided range.
 	Range BlockRange
 
-	// Interval is the interval at which to process.
-	// If this is set, the analyzer runs once per interval.
-	Interval time.Duration
-
 	// Source is the storage source from which to fetch block data
 	// when processing blocks in this range.
 	Source storage.ConsensusSourceStorage
@@ -71,10 +66,6 @@ type RuntimeConfig struct {
 	// Range is the range of rounds to process.
 	// If this is set, the analyzer analyzes rounds in the provided range.
 	Range RoundRange
-
-	// Interval is the interval at which to process.
-	// If this is set, the analyzer runs once per interval.
-	Interval time.Duration
 
 	// Source is the storage source from which to fetch block data
 	// when processing blocks in this range.

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -52,7 +52,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		ChainContext: cfg.ChainContext,
 		RPC:          cfg.RPC,
 	}
-	factory, err := source.NewClientFactory(ctx, &networkCfg)
+	factory, err := source.NewClientFactory(ctx, &networkCfg, cfg.FastStartup)
 	if err != nil {
 		logger.Error("error creating client factory",
 			"err", err.Error(),

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -47,52 +47,35 @@ var _ analyzer.Analyzer = (*Main)(nil)
 func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
 	ctx := context.Background()
 
-	var ac analyzer.ConsensusConfig
-	if cfg.Interval == "" {
-		// Initialize source storage.
-		networkCfg := oasisConfig.Network{
-			ChainContext: cfg.ChainContext,
-			RPC:          cfg.RPC,
-		}
-		factory, err := source.NewClientFactory(ctx, &networkCfg)
-		if err != nil {
-			logger.Error("error creating client factory",
-				"err", err.Error(),
-			)
-			return nil, err
-		}
-		client, err := factory.Consensus()
-		if err != nil {
-			logger.Error("error creating consensus client",
-				"err", err.Error(),
-			)
-			return nil, err
-		}
+	// Initialize source storage.
+	networkCfg := oasisConfig.Network{
+		ChainContext: cfg.ChainContext,
+		RPC:          cfg.RPC,
+	}
+	factory, err := source.NewClientFactory(ctx, &networkCfg)
+	if err != nil {
+		logger.Error("error creating client factory",
+			"err", err.Error(),
+		)
+		return nil, err
+	}
+	client, err := factory.Consensus()
+	if err != nil {
+		logger.Error("error creating consensus client",
+			"err", err.Error(),
+		)
+		return nil, err
+	}
 
-		// Configure analyzer.
-		blockRange := analyzer.BlockRange{
-			From: cfg.From,
-			To:   cfg.To,
-		}
-		ac = analyzer.ConsensusConfig{
-			ChainID: cfg.ChainID,
-			Range:   blockRange,
-			Source:  client,
-		}
-	} else {
-		interval, err := time.ParseDuration(cfg.Interval)
-		if err != nil {
-			logger.Error("error parsing analysis interval",
-				"err", err.Error(),
-			)
-			return nil, err
-		}
-
-		// Configure analyzer.
-		ac = analyzer.ConsensusConfig{
-			ChainID:  cfg.ChainID,
-			Interval: interval,
-		}
+	// Configure analyzer.
+	blockRange := analyzer.BlockRange{
+		From: cfg.From,
+		To:   cfg.To,
+	}
+	ac := analyzer.ConsensusConfig{
+		ChainID: cfg.ChainID,
+		Range:   blockRange,
+		Source:  client,
 	}
 
 	logger.Info("Starting consensus analyzer", "config", ac)

--- a/analyzer/emerald/emerald.go
+++ b/analyzer/emerald/emerald.go
@@ -51,7 +51,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		ChainContext: cfg.ChainContext,
 		RPC:          cfg.RPC,
 	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg)
+	factory, err := oasis.NewClientFactory(ctx, &networkCfg, cfg.FastStartup)
 	if err != nil {
 		logger.Error("error creating client factory",
 			"err", err,

--- a/config/config.go
+++ b/config/config.go
@@ -83,12 +83,15 @@ type AnalyzerConfig struct {
 	Name string `koanf:"name"`
 
 	// ChainID is the chain ID of the chain this analyzer will process.
+	// Used to identify the chain in the database.
 	ChainID string `koanf:"chain_id"`
 
 	// RPC is the node endpoint.
 	RPC string `koanf:"rpc"`
 
-	// ChainContext is the domain separation context. It uniquely identifies the chain; it is derived as a hash of the genesis data.
+	// ChainContext is the domain separation context.
+	// It uniquely identifies the chain; it is derived as a hash of the genesis data.
+	// Used as safety check to prevent accidental use of the wrong RPC endpoint.
 	ChainContext string `koanf:"chaincontext"`
 
 	// From is the (inclusive) starting block for this analyzer.
@@ -104,6 +107,11 @@ type AnalyzerConfig struct {
 	// It should be specified as a string compliant with
 	// time.ParseDuration (https://pkg.go.dev/time#ParseDuration).
 	Interval string `koanf:"interval"`
+
+	// If set, the analyzer will skip some initial checks, e.g. that
+	// `rpc` really serves the chain with `chain_context`.
+	// NOT RECOMMENDED in production; intended for faster testing.
+	FastStartup bool `koanf:"fast_startup"`
 }
 
 // Validate validates the analysis configuration.

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -23,7 +23,7 @@ type ClientFactory struct {
 
 // NewClientFactory creates a new oasis-node client factory.
 func NewClientFactory(ctx context.Context, network *config.Network) (*ClientFactory, error) {
-	connection, err := connection.Connect(ctx, network)
+	connection, err := connection.ConnectNoVerify(ctx, network)
 	if err != nil {
 		return nil, err
 	}
@@ -41,13 +41,8 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 	connection := *cf.connection
 	client := connection.Consensus()
 
-	consensusChainContext, err := client.GetChainContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Configure chain context for all signatures using chain domain separation.
-	signature.SetChainContext(consensusChainContext)
+	signature.SetChainContext(cf.network.ChainContext)
 
 	c := &ConsensusClient{
 		client:  client,
@@ -71,20 +66,15 @@ func (cf *ClientFactory) Runtime(runtimeID string) (*RuntimeClient, error) {
 		ID: runtimeID,
 	})
 
-	consensusChainContext, err := connection.Consensus().GetChainContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	// Configure chain context for all signatures using chain domain separation.
-	signature.SetChainContext(consensusChainContext)
+	signature.SetChainContext(cf.network.ChainContext)
 
 	info, err := client.GetInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	rtCtx := runtimeSignature.DeriveChainContext(info.ID, consensusChainContext)
+	rtCtx := runtimeSignature.DeriveChainContext(info.ID, cf.network.ChainContext)
 	return &RuntimeClient{
 		client:  client,
 		network: cf.network,

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -22,14 +22,23 @@ type ClientFactory struct {
 }
 
 // NewClientFactory creates a new oasis-node client factory.
-func NewClientFactory(ctx context.Context, network *config.Network) (*ClientFactory, error) {
-	connection, err := connection.ConnectNoVerify(ctx, network)
+// Unless `skipChainContextCheck` is false, it also checks that
+// the RPC endpoint in `network` serves the chain context specified
+// in `network`.
+func NewClientFactory(ctx context.Context, network *config.Network, skipChainContextCheck bool) (*ClientFactory, error) {
+	var conn connection.Connection
+	var err error
+	if skipChainContextCheck {
+		conn, err = connection.ConnectNoVerify(ctx, network)
+	} else {
+		conn, err = connection.Connect(ctx, network)
+	}
 	if err != nil {
 		return nil, err
 	}
 
 	return &ClientFactory{
-		connection: &connection,
+		connection: &conn,
 		network:    network,
 	}, nil
 }

--- a/storage/oasis/client_test.go
+++ b/storage/oasis/client_test.go
@@ -21,7 +21,7 @@ func newClientFactory() (*ClientFactory, error) {
 		ChainContext: os.Getenv("CI_TEST_CHAIN_CONTEXT"),
 		RPC:          os.Getenv("CI_TEST_NODE_RPC"),
 	}
-	return NewClientFactory(context.Background(), network)
+	return NewClientFactory(context.Background(), network, true)
 }
 
 func TestConnect(t *testing.T) {
@@ -40,14 +40,14 @@ func TestInvalidConnect(t *testing.T) {
 		ChainContext: os.Getenv("CI_TEST_CHAIN_CONTEXT"),
 		RPC:          "an invalid rpc endpoint",
 	}
-	_, err := NewClientFactory(context.Background(), network)
+	_, err := NewClientFactory(context.Background(), network, false)
 	require.NotNil(t, err)
 
 	network = &config.Network{
 		ChainContext: "an invalid chaincontext",
 		RPC:          os.Getenv("CI_TEST_NODE_RPC"),
 	}
-	_, err = NewClientFactory(context.Background(), network)
+	_, err = NewClientFactory(context.Background(), network, false)
 	require.NotNil(t, err)
 }
 

--- a/tests/genesis/genesis_test.go
+++ b/tests/genesis/genesis_test.go
@@ -99,7 +99,7 @@ func newSourceClientFactory() (*oasis.ClientFactory, error) {
 		ChainContext: os.Getenv("HEALTHCHECK_TEST_CHAIN_CONTEXT"),
 		RPC:          os.Getenv("HEALTHCHECK_TEST_NODE_RPC"),
 	}
-	return oasis.NewClientFactory(context.Background(), network)
+	return oasis.NewClientFactory(context.Background(), network, true)
 }
 
 var chainID = "" // Memoization for getChainId(). Assumes all tests access the same chain.


### PR DESCRIPTION
This PR speeds up startup by avoiding 1-2 queries per analyzer (= consensus/emerald/...).
Affects startup only; these are not recurring queries. They are, however, on the heftier side.

Also includes a not-really-related commit (but in the config area, where I was mucking around): There's an `Interval` param that we were not using, except in one place, when constructing the consensus analyzer. And in that one place, I'm pretty sure it was forgotten about, and actually specifying an `Interval` would crash the program.