### PR TITLE
Update fkey constraint

### DIFF
--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -35,9 +35,9 @@ CREATE TABLE oasis_3.blocks
 CREATE TABLE oasis_3.transactions
 (
   block BIGINT NOT NULL REFERENCES oasis_3.blocks(height) DEFERRABLE INITIALLY DEFERRED,
-
-  txn_hash   HEX64,
   txn_index  UINT31 NOT NULL,
+  
+  txn_hash   HEX64 NOT NULL,
   nonce      UINT63 NOT NULL,
   fee_amount UINT_NUMERIC,
   max_gas    UINT_NUMERIC,
@@ -51,7 +51,7 @@ CREATE TABLE oasis_3.transactions
   code    UINT31,  -- From https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/consensus/api/transaction/results/results.go#L20-L20
   message TEXT,
 
-  -- We require a composite primary key since duplicate transactions can
+  -- We require a composite primary key since duplicate transactions (with identical hashes) can
   -- be included within blocks for this chain.
   PRIMARY KEY (block, txn_index)
 );
@@ -60,13 +60,13 @@ CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);
 
 CREATE TABLE oasis_3.events
 (
+  txn_block  UINT63 NOT NULL,
+  txn_index  UINT31,
+  
   backend TEXT NOT NULL,  -- E.g. registry, staking
   type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/oasis-indexer/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
   body    JSON,
-
-  txn_block  UINT63 NOT NULL,
-  txn_hash   HEX64,
-  txn_index  UINT31,
+  txn_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency
 
   FOREIGN KEY (txn_block, txn_index) REFERENCES oasis_3.transactions(block, txn_index) DEFERRABLE INITIALLY DEFERRED
 );

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -36,8 +36,8 @@ CREATE TABLE oasis_3.transactions
 (
   block BIGINT NOT NULL REFERENCES oasis_3.blocks(height) DEFERRABLE INITIALLY DEFERRED,
 
-  txn_hash   HEX64 NOT NULL,
-  txn_index  UINT31,
+  txn_hash   HEX64,
+  txn_index  UINT31 NOT NULL,
   nonce      UINT63 NOT NULL,
   fee_amount UINT_NUMERIC,
   max_gas    UINT_NUMERIC,
@@ -53,7 +53,7 @@ CREATE TABLE oasis_3.transactions
 
   -- We require a composite primary key since duplicate transactions can
   -- be included within blocks for this chain.
-  PRIMARY KEY (block, txn_hash, txn_index)
+  PRIMARY KEY (block, txn_index)
 );
 -- Queries by sender are common, and unusably slow without an index.
 CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);
@@ -65,10 +65,10 @@ CREATE TABLE oasis_3.events
   body    JSON,
 
   txn_block  UINT63 NOT NULL,
-  txn_hash   HEX64 NOT NULL,
+  txn_hash   HEX64,
   txn_index  UINT31,
 
-  FOREIGN KEY (txn_block, txn_hash, txn_index) REFERENCES oasis_3.transactions(block, txn_hash, txn_index) DEFERRABLE INITIALLY DEFERRED
+  FOREIGN KEY (txn_block, txn_index) REFERENCES oasis_3.transactions(block, txn_index) DEFERRABLE INITIALLY DEFERRED
 );
 
 -- Beacon Backend Data


### PR DESCRIPTION
Per discussion in Slack, the `transactions` table will never have a null txn_index so we tighten it. Also, the `events` table can have  a null `txn_hash`, so we adjust the fkey constraint there