### PR TITLE
docker: per-user dev tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,15 @@ oasis-indexer:
 
 docker:
 	@docker build \
-		--tag oasislabs/oasis-node:dev \
+		--tag oasislabs/oasis-node:$(USER)-dev \
 		--file docker/oasis-node/Dockerfile \
 		docker/oasis-node
 	@docker build \
-		--tag oasislabs/oasis-indexer:dev \
+		--tag oasislabs/oasis-indexer:$(USER)-dev \
 		--file docker/indexer/Dockerfile \
 		.
 	@docker build \
-		--tag oasislabs/oasis-net-runner:dev \
+		--tag oasislabs/oasis-net-runner:$(USER)-dev \
 		--file docker/oasis-net-runner/Dockerfile \
 		docker/oasis-net-runner
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   indexer:
-    image: oasislabs/oasis-indexer:dev
+    image: oasislabs/oasis-indexer:${USER}-dev
     container_name: oasis-indexer
     depends_on:
       indexer-postgres:
@@ -37,7 +37,7 @@ services:
       timeout: 5s
       start_period: 15s
   oasis-node:
-    image: oasislabs/oasis-node:dev
+    image: oasislabs/oasis-node:${USER}-dev
     container_name: oasis-node
     user: oasis
     command:

--- a/tests/e2e/docker-compose.e2e.yml
+++ b/tests/e2e/docker-compose.e2e.yml
@@ -1,6 +1,6 @@
 services:
   indexer:
-    image: oasislabs/oasis-indexer:dev
+    image: oasislabs/oasis-indexer:${USER}-dev
     container_name: oasis-indexer
     depends_on:
       indexer-postgres:
@@ -35,7 +35,7 @@ services:
       timeout: 5s
       start_period: 15s
   oasis-net-runner:
-    image: oasislabs/oasis-net-runner:dev
+    image: oasislabs/oasis-net-runner:${USER}-dev
     # Allow running as a custom user with `env HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose ...`
     # This way, the temporary files created by the net-runner will be owned by the current user.
     # Useful for local testing.


### PR DESCRIPTION
Makes it harder for devs to inadvertently step on each other's toes when pushing locally-built images. (Which is naughty in the first place and shouldn't be encouraged, but ...)