### PR TITLE
openAPI: simplify stats stack, publish html version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,8 @@ docker/node/etc/genesis.json
 
 # Oasis net-runner data.
 tests/e2e/testnet/net-runner
+
+# Local workdirs
+cache
+.*
+*.log

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -57,10 +57,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Normalize YAML
+        run: |
+          VERSION=v4.30.5 BINARY=yq_linux_amd64
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O ./yq
+          chmod +x ./yq
+          # OpenAPI parser fails to parse YAML templates (*, <<:). Expand them out here.
+          <api/spec/v1.yaml ./yq --output-format json | ./yq --output-format yaml --input-format json >api/spec/v1-normalized.yaml
       - name: Validate OpenAPI definition
         uses: char0n/swagger-editor-validate@v1
         with:
-          definition-file: api/spec/v1.yaml
+          definition-file: api/spec/v1-normalized.yaml
 
   validate-migrations:
     runs-on: ubuntu-20.04

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ lint: $(lint-targets)
 docs-targets := docs-api
 
 docs-api:
-	@npx redoc-cli build api/spec/v1.yaml -o index.html
+	@npx redoc-cli build api/spec/v1.yaml -o api/spec/v1.html
 
 docs: $(docs-targets)
 

--- a/api/common/pagination.go
+++ b/api/common/pagination.go
@@ -17,6 +17,8 @@ const (
 	DefaultOffset = uint64(0)
 
 	MaximumLimit = uint64(1000)
+
+	DefaultBucketSizeSeconds = uint64(3600)
 )
 
 // Pagination is used to define parameters for pagination.
@@ -24,6 +26,12 @@ type Pagination struct {
 	Limit  uint64
 	Offset uint64
 	Order  *string
+}
+
+// BucketedStatsParams are used to parametrize stats queries that return
+// time-bucketed results.
+type BucketedStatsParams struct {
+	BucketSizeSeconds uint32
 }
 
 // NewPagination extracts pagination parameters from an http request.
@@ -49,6 +57,21 @@ func NewPagination(r *http.Request) (p Pagination, err error) {
 		Limit:  limit,
 		Offset: offset,
 		Order:  &order,
+	}
+	return
+}
+
+// BucketedStatsParams extracts bucket size parameters from an http request.
+func NewBucketedStatsParams(r *http.Request) (b BucketedStatsParams, err error) {
+	values := r.URL.Query()
+
+	bucketSizeSeconds := DefaultBucketSizeSeconds
+	if v := values.Get("bucket_size_seconds"); v != "" {
+		bucketSizeSeconds, err = strconv.ParseUint(v, 10, 32)
+	}
+
+	b = BucketedStatsParams{
+		BucketSizeSeconds: uint32(bucketSizeSeconds), // safe cast because of how the "32" param to ParseUint
 	}
 	return
 }

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -34,6 +34,17 @@ x-query-params:
     description: |
       The block height from which to query state. The Oasis Indexer does not
       make any guarantees about availability of historical state data.
+  - &bucket_size_seconds
+    in: query
+    name: bucket_size_seconds
+    schema:
+      type: integer
+      format: int32
+      default: 3600
+    description: |
+      The size of buckets into which the statistic is grouped, in seconds.
+      The backend supports a limited number of bucket sizes: 300 (5 minutes) and
+      3600 (1 hour). Requests with other values may be rejected.
 
 x-examples:
   chain-id:
@@ -714,32 +725,17 @@ paths:
                 $ref: '#/components/schemas/RuntimeTokenList'
         <<: *common_error_responses
 
-  /consensus/stats/tps:
+  /consensus/stats/tx_volume:
     get:
-      summary: Returns the consensus layer TPS for each 5 minute interval.
+      summary: Returns the consensus layer transaction volume at daily granularity
       parameters:
         - *limit
         - *offset
+        - *bucket_size_seconds
       responses:
         '200':
           description: |
             A JSON object containing a list of TPS values for each interval.
-          content:
-            application/json:
-              schema: 
-                $ref: '#/components/schemas/TpsCheckpoints'
-        <<: *common_error_responses
-
-  /consensus/stats/daily_volume:
-    get:
-      summary: Returns the consensus layer daily transaction volume for each day.
-      parameters:
-        - *limit
-        - *offset
-      responses:
-        '200':
-          description: |
-            A JSON object containing a list of daily transaction volumes for each day.
           content:
             application/json:
               schema: 
@@ -1412,35 +1408,6 @@ components:
             The number of addresses that have a nonzero balance of this token,
             as calculated from Transfer events.
           example: 123
-
-    TpsCheckpoints:
-      type: object
-      properties:
-        interval_minutes:
-          type: integer
-          format: int
-          description: The length, in minutes, of each TPS measurement window.
-        tps_checkpoints:
-          type: array
-          items:
-            $ref: '#/components/schemas/TpsCheckpoint'
-          description: The list of TPS checkpoint windows.
-      description: |
-        A list of TPS checkpoint windows.
-
-    TpsCheckpoint:
-      type: object
-      properties: 
-        timestamp:
-          type: string
-          format: date-time
-          description: The timestamp anchoring this TPS measurement window.
-          example: *iso_timestamp_1
-        tx_volume:
-          type: integer
-          format: int64
-          description: The transaction volume in this measurement window.
-          example: 420
 
     VolumeList:
       type: object

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -5,9 +5,9 @@ info:
   version: 0.1.0
 
 servers:
-  - url: http://index.oasis.dev/v1
+  - url: http://index.oasislabs.com/v1
     description: Mainnet index endpoint.
-  - url: http://index.testnet.oasis.dev/v1
+  - url: http://index.testnet.oasislabs.com/v1
     description: Testnet index endpoint.
 
 x-query-params:

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -123,7 +123,7 @@ paths:
 
   /consensus/blocks:
     get:
-      summary: Returns a list of consensus blocks.
+      summary: Returns a list of consensus blocks, sorted from most to least recent.
       parameters:
         - *limit
         - *offset

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -91,6 +91,23 @@ x-common-types:
     - beacon.PVSSReveal
     - beacon.VRFProve
 
+x-err-responses:
+  base-error: &base_error_response
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ApiError'
+  common-errors: &common_error_responses
+    '400':
+      <<: *base_error_response
+      description: Invalid request.
+    '404':
+      <<: *base_error_response
+      description: The requested resource was not found.
+    '500':
+      <<: *base_error_response
+      description: A server error occurred.
+
 paths:
   /:
     get:
@@ -102,12 +119,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Status'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/blocks:
     get:
@@ -150,12 +162,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/BlockList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/blocks/{height}:
     get:
@@ -176,12 +183,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Block'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/transactions:
     get:
@@ -236,12 +238,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/TransactionList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/transactions/{tx_hash}:
     get:
@@ -261,12 +258,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Transaction'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/entities:
     get:
@@ -283,12 +275,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EntityList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/entities/{entity_id}:
     get:
@@ -310,12 +297,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Entity'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/entities/{entity_id}/nodes:
     get:
@@ -339,12 +321,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/NodeList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/entities/{entity_id}/nodes/{node_id}:
     get:
@@ -373,12 +350,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Node'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/validators:
     get:
@@ -395,12 +367,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ValidatorList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/validators/{entity_id}:
     get:
@@ -422,12 +389,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Validator'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
           
   /consensus/accounts:
     get:
@@ -499,12 +461,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/AccountList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/accounts/{address}:
     get:
@@ -524,12 +481,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Account'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/accounts/{address}/delegations:
     get:
@@ -549,12 +501,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/DelegationList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/accounts/{address}/debonding_delegations:
     get:
@@ -574,12 +521,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DebondingDelegationList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/epochs:
     get:
@@ -594,12 +536,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EpochList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/epochs/{epoch}:
     get:
@@ -620,12 +557,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Epoch'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/proposals:
     get:
@@ -652,12 +584,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/ProposalList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/proposals/{proposal_id}:
     get:
@@ -678,12 +605,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/Proposal'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/proposals/{proposal_id}/votes:
     get:
@@ -708,12 +630,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/ProposalVotes'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /emerald/blocks:
     get:
@@ -756,12 +673,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeBlockList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /emerald/transactions:
     get:
@@ -784,12 +696,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeTransactionList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /emerald/tokens:
     get:
@@ -805,12 +712,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RuntimeTokenList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/stats/tps:
     get:
@@ -826,12 +728,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/TpsCheckpoints'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
   /consensus/stats/daily_volume:
     get:
@@ -847,12 +744,7 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/VolumeList'
-        '400':
-          $ref: '#/components/responses/InvalidRequest'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
+        <<: *common_error_responses
 
 components:
   schemas:

--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -685,8 +685,8 @@ func (c *storageClient) RuntimeTokens(ctx context.Context, r *http.Request) (*st
 	return c.storage.RuntimeTokens(ctx, &q, &p)
 }
 
-// TransactionsPerSecond returns a list of tps checkpoint values.
-func (c *storageClient) TransactionsPerSecond(ctx context.Context, r *http.Request) (*storage.TpsCheckpointList, error) {
+// TxVolumes returns a list of transaction volumes grouped into fine-grained buckets.
+func (c *storageClient) TxVolumes(ctx context.Context, r *http.Request) (*storage.TxVolumeList, error) {
 	p, err := common.NewPagination(r)
 	if err != nil {
 		c.logger.Info("pagination failed",
@@ -696,19 +696,14 @@ func (c *storageClient) TransactionsPerSecond(ctx context.Context, r *http.Reque
 		return nil, common.ErrBadRequest
 	}
 
-	return c.storage.TransactionsPerSecond(ctx, &p)
-}
-
-// DailyVolumes returns a list of daily transaction volumes.
-func (c *storageClient) DailyVolumes(ctx context.Context, r *http.Request) (*storage.VolumeList, error) {
-	p, err := common.NewPagination(r)
+	q, err := common.NewBucketedStatsParams(r)
 	if err != nil {
-		c.logger.Info("pagination failed",
+		c.logger.Info("bucket param extraction failed",
 			"request_id", ctx.Value(storage.RequestIDContextKey),
 			"err", err.Error(),
 		)
 		return nil, common.ErrBadRequest
 	}
 
-	return c.storage.DailyVolumes(ctx, &p)
+	return c.storage.TxVolumes(ctx, &p, &q)
 }

--- a/api/v1/handlers.go
+++ b/api/v1/handlers.go
@@ -701,44 +701,13 @@ func (h *Handler) RuntimeListTokens(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// ListTransactionsPerSecond gets a list of TPS values.
-func (h *Handler) ListTransactionsPerSecond(w http.ResponseWriter, r *http.Request) {
+// ListTxVolumes gets a list of transaction volume per time bucket.
+func (h *Handler) ListTxVolumes(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
-	tps, err := h.client.TransactionsPerSecond(ctx, r)
+	volumes, err := h.client.TxVolumes(ctx, r)
 	if err != nil {
-		h.logAndReply(ctx, "failed to list tps", w, err)
-		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
-		return
-	}
-
-	var resp []byte
-	resp, err = json.Marshal(tps)
-	if err != nil {
-		h.logAndReply(ctx, "failed to marshal tps", w, err)
-		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
-		return
-	}
-
-	w.Header().Set("content-type", "application/json")
-	if _, err := w.Write(resp); err != nil {
-		h.logger.Error("failed to write response",
-			"request_id", ctx.Value(storage.RequestIDContextKey),
-			"error", err,
-		)
-		h.metrics.RequestCounter(r.URL.Path, "failure", "http_error").Inc()
-	} else {
-		h.metrics.RequestCounter(r.URL.Path, "success").Inc()
-	}
-}
-
-// ListDailyVolume gets a list of daily transaction volume.
-func (h *Handler) ListDailyVolume(w http.ResponseWriter, r *http.Request) {
-	ctx := r.Context()
-
-	volumes, err := h.client.DailyVolumes(ctx, r)
-	if err != nil {
-		h.logAndReply(ctx, "failed to list daily tx volume", w, err)
+		h.logAndReply(ctx, "failed to list tx volume", w, err)
 		h.metrics.RequestCounter(r.URL.Path, "failure", "database_error").Inc()
 		return
 	}

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"net/http"
+
 	"github.com/go-chi/chi/v5"
 
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -40,6 +42,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 		// Status endpoints.
 		r.Get("/", h.GetStatus)
 
+		// Consensus Endpoints.
 		r.Route("/consensus", func(r chi.Router) {
 			// Block Endpoints.
 			r.Route("/blocks", func(r chi.Router) {
@@ -93,8 +96,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 			})
 		})
 
-		// ... ParaTime Endpoint Registration.
-
+		// ParaTime Endpoints.
 		r.Route("/emerald", func(r chi.Router) {
 			r.Use(h.runtimeMiddleware("emerald"))
 			// Block Endpoints.
@@ -107,6 +109,12 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 			r.Route("/tokens", func(r chi.Router) {
 				r.Get("/", h.RuntimeListTokens)
 			})
+		})
+
+		// API specs.
+		r.Route("/spec", func(r chi.Router) {
+			specServer := http.FileServer(http.Dir("api/spec"))
+			r.Handle("/*", http.StripPrefix("/v1/spec", specServer))
 		})
 	})
 }

--- a/api/v1/v1.go
+++ b/api/v1/v1.go
@@ -91,8 +91,7 @@ func (h *Handler) RegisterRoutes(r chi.Router) {
 
 			// Aggregate Statistics.
 			r.Route("/stats", func(r chi.Router) {
-				r.Get("/tps", h.ListTransactionsPerSecond)
-				r.Get("/daily_volume", h.ListDailyVolume)
+				r.Get("/tx_volume", h.ListTxVolumes)
 			})
 		})
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -109,7 +109,7 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 
 // Start starts the API service.
 func (s *Service) Start() {
-	s.logger.Info("starting api service")
+	s.logger.Info("starting api service at " + s.server)
 
 	server := &http.Server{
 		Addr:           s.server,

--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -7,6 +7,16 @@ COPY . ./
 RUN go mod download && \
     go build
 
+############
+
+FROM node:18-slim AS openapi-builder
+
+COPY api/spec /api/spec
+WORKDIR /
+RUN npx redoc-cli build api/spec/v1.yaml -o api/spec/v1.html
+
+############
+
 FROM golang:1.18-buster AS oasis-indexer
 
 WORKDIR /oasis-indexer
@@ -17,5 +27,6 @@ RUN apt-get update -q -q && \
 COPY --from=oasis-indexer-builder /code/go/oasis-indexer /usr/local/bin/oasis-indexer
 COPY --from=oasis-indexer-builder /code/go/storage/migrations /storage/migrations/
 COPY . /oasis-indexer
+COPY --from=openapi-builder /api/spec/v1.html api/spec/v1.html
 
 ENTRYPOINT ["oasis-indexer"]

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -18,9 +18,8 @@ import (
 )
 
 const (
-	tpsWindowSizeMinutes = 5
-	blockCost            = 1
-	txCost               = 1
+	blockCost = 1
+	txCost    = 1
 )
 
 // StorageClient is a wrapper around a storage.TargetStorage
@@ -1198,13 +1197,19 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, r *RuntimeTokensReque
 	return &ts, nil
 }
 
-// TransactionsPerSecond returns a list of tps checkpoint values.
-func (c *StorageClient) TransactionsPerSecond(ctx context.Context, p *common.Pagination) (*TpsCheckpointList, error) {
+// TxVolumes returns a list of transaction volumes per time bucket.
+func (c *StorageClient) TxVolumes(ctx context.Context, p *common.Pagination, q *common.BucketedStatsParams) (*TxVolumeList, error) {
 	qf := NewQueryFactory(strcase.ToSnake(c.chainID), "")
+	var query string
+	if q.BucketSizeSeconds == 300 {
+		query = qf.FineTxVolumesQuery()
+	} else {
+		query = qf.TxVolumesQuery()
+	}
 
 	rows, err := c.db.Query(
 		ctx,
-		qf.TpsCheckpointQuery(),
+		query,
 		p.Limit,
 		p.Offset,
 	)
@@ -1217,19 +1222,17 @@ func (c *StorageClient) TransactionsPerSecond(ctx context.Context, p *common.Pag
 	}
 	defer rows.Close()
 
-	ts := TpsCheckpointList{
-		IntervalMinutes: tpsWindowSizeMinutes,
-		TpsCheckpoints:  []TpsCheckpoint{},
+	ts := TxVolumeList{
+		BucketSizeSeconds: q.BucketSizeSeconds,
+		Buckets:           []TxVolume{},
 	}
 	for rows.Next() {
 		var d struct {
-			Hour     time.Time
-			MinSlot  int
-			TxVolume uint64
+			BucketStart time.Time
+			TxVolume    uint64
 		}
 		if err := rows.Scan(
-			&d.Hour,
-			&d.MinSlot,
+			&d.BucketStart,
 			&d.TxVolume,
 		); err != nil {
 			c.logger.Info("query failed",
@@ -1238,53 +1241,12 @@ func (c *StorageClient) TransactionsPerSecond(ctx context.Context, p *common.Pag
 			return nil, common.ErrStorageError
 		}
 
-		t := TpsCheckpoint{
-			Timestamp: d.Hour.Add(time.Duration(tpsWindowSizeMinutes*d.MinSlot) * time.Minute).UTC(),
-			TxVolume:  d.TxVolume,
+		t := TxVolume{
+			BucketStart: d.BucketStart.UTC(),
+			Volume:      d.TxVolume,
 		}
-		ts.TpsCheckpoints = append(ts.TpsCheckpoints, t)
+		ts.Buckets = append(ts.Buckets, t)
 	}
 
 	return &ts, nil
-}
-
-// DailyVolumes returns a list of daily transaction volumes.
-func (c *StorageClient) DailyVolumes(ctx context.Context, p *common.Pagination) (*VolumeList, error) {
-	qf := NewQueryFactory(strcase.ToSnake(c.chainID), "")
-
-	rows, err := c.db.Query(
-		ctx,
-		qf.TxVolumesQuery(),
-		p.Limit,
-		p.Offset,
-	)
-	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(RequestIDContextKey),
-			"err", err.Error(),
-		)
-		return nil, common.ErrStorageError
-	}
-	defer rows.Close()
-
-	vs := VolumeList{
-		Volumes: []Volume{},
-	}
-	for rows.Next() {
-		var v Volume
-		if err := rows.Scan(
-			&v.Date,
-			&v.TxVolume,
-		); err != nil {
-			c.logger.Info("query failed",
-				"err", err.Error(),
-			)
-			return nil, common.ErrStorageError
-		}
-		v.Date = v.Date.UTC()
-
-		vs.Volumes = append(vs.Volumes, v)
-	}
-
-	return &vs, nil
 }

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1076,7 +1076,9 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, r *RuntimeBlocksReque
 	}
 	defer rows.Close()
 
-	var bs RuntimeBlockList
+	bs := RuntimeBlockList{
+		Blocks: []RuntimeBlock{},
+	}
 	for rows.Next() {
 		var b RuntimeBlock
 		if err := rows.Scan(&b.Round, &b.Hash, &b.Timestamp, &b.NumTransactions, &b.Size, &b.GasUsed); err != nil {

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -311,12 +311,12 @@ func (qf QueryFactory) RuntimeTokensQuery() string {
 		OFFSET $2::bigint`, qf.chainID, qf.runtime)
 }
 
-func (qf QueryFactory) TpsCheckpointQuery() string {
+func (qf QueryFactory) FineTxVolumesQuery() string {
 	return `
-		SELECT hour, min_slot, tx_volume
+		SELECT window_start, tx_volume
 			FROM min5_tx_volume
 		ORDER BY
-			hour DESC, min_slot DESC
+			window_start DESC
 		LIMIT $1::bigint
 		OFFSET $2::bigint
 	`
@@ -324,9 +324,10 @@ func (qf QueryFactory) TpsCheckpointQuery() string {
 
 func (qf QueryFactory) TxVolumesQuery() string {
 	return `
-		SELECT day, daily_tx_volume
+		SELECT window_start, tx_volume
 			FROM daily_tx_volume
-		ORDER BY day DESC
+		ORDER BY
+			window_start DESC
 		LIMIT $1::bigint
 		OFFSET $2::bigint
 	`

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -247,25 +247,14 @@ type RuntimeToken struct {
 	NumHolders int64  `json:"num_holders"`
 }
 
-// TpsCheckpointList is the storage response for ListTransactionsPerSecond.
-type TpsCheckpointList struct {
-	IntervalMinutes int             `json:"interval_minutes"`
-	TpsCheckpoints  []TpsCheckpoint `json:"tps_checkpoints"`
+// TxVolumeList is the storage response for GetVolumes.
+type TxVolumeList struct {
+	Buckets           []TxVolume `json:"buckets"`
+	BucketSizeSeconds uint32     `json:"bucket_size_seconds"`
 }
 
-// TpsCheckpoint is the live TPS value at the provided marker timestamp.
-type TpsCheckpoint struct {
-	Timestamp time.Time `json:"timestamp"`
-	TxVolume  uint64    `json:"tx_volume"`
-}
-
-// VolumeList is the storage response for GetVolumes.
-type VolumeList struct {
-	Volumes []Volume `json:"volumes"`
-}
-
-// Volume is the daily transaction volume on the specified day.
-type Volume struct {
-	Date     time.Time `json:"date"`
-	TxVolume uint64    `json:"tx_volume"`
+// TxVolume is the daily transaction volume on the specified day.
+type TxVolume struct {
+	BucketStart time.Time `json:"start"`
+	Volume      uint64    `json:"volume"`
 }

--- a/storage/migrations/03_agg_stats.up.sql
+++ b/storage/migrations/03_agg_stats.up.sql
@@ -2,25 +2,30 @@
 
 BEGIN;
 
--- min5_tx_volume stores the transaction volume in 5 minute buckets
+-- Rounds a given timestamp down to the nearest 5-minute "bucket" (e.g. 12:34:56 -> 12:30:00).
+CREATE FUNCTION floor_5min (ts timestamptz) RETURNS timestamptz AS $$
+    SELECT date_trunc('hour', $1) + date_part('minute', $1)::int / 5 * '5 minutes'::interval;
+$$ LANGUAGE SQL IMMUTABLE;
+
+
+-- min5_tx_volume stores the consensus transaction volume in 5 minute buckets
 -- This can be used to estimate real time TPS.
 -- NOTE: This materialized view is NOT refreshed every 5 minutes due to computational cost.
 CREATE MATERIALIZED VIEW min5_tx_volume AS
   SELECT
-    date_trunc( 'hour', b.time ) AS hour,
-    ( extract( minute FROM b.time )::int / 5 ) AS min_slot,
+    floor_5min(b.time) AS window_start,
     COUNT(*) AS tx_volume
   FROM oasis_3.blocks AS b
     INNER JOIN oasis_3.transactions AS t ON b.height = t.block
-  GROUP BY 1, 2;
+  GROUP BY 1;
 
 -- daily_tx_volume stores the number of transactions per day
 -- at the consensus layer.
 CREATE MATERIALIZED VIEW daily_tx_volume AS
   SELECT
-    date_trunc ( 'day', hour ) AS day,
-    SUM(tx_volume) AS daily_tx_volume
-  FROM min5_tx_volume
+    date_trunc ( 'day', sub.window_start ) AS window_start,
+    SUM(sub.tx_volume) AS tx_volume
+  FROM min5_tx_volume AS sub
   GROUP BY 1;
 
 COMMIT;


### PR DESCRIPTION
This is a collection of loosely connected commits (so reviewing commit by commit is helpful) that I did as prework for writing more HTTP APIs (#242).

The three big changes are:
- Use a template in the openapi .yaml to represent possible HTTP error codes. Functionally a no-op, and a quick change, but a large red diff.
- Render the openAPI into a .html and make it accessible through the regular HTTP API, making it self-documenting. The URL is pretty much impossible to guess though: https://index.oasislabs.com/v1/spec/v1.html
- Simplify the existing tx_volume statistic. The two granularities (stats once per 5 minutes, or stats once per hour) had wildly different names and separate implementations throughout the stack. This PR reduces duplication a lot, makes the API consistent, and introduces a new `bucket_size_seconds` param in anticipation of future stats queries. (**Note:** The tx_volume query and tables also still need to be expanded to include paratimes. I did not want to cram that into this PR.)