### PR TITLE
db: fix permissions, search paths

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -25,7 +25,7 @@ func (qf QueryFactory) LatestBlockQuery() string {
 func (qf QueryFactory) IsGenesisProcessedQuery() string {
 	return `
 		SELECT EXISTS (
-			SELECT 1 FROM processed_geneses
+			SELECT 1 FROM multichain.processed_geneses
 			WHERE chain_id = $1 AND analyzer = $2
 		)`
 }
@@ -39,7 +39,7 @@ func (qf QueryFactory) IndexingProgressQuery() string {
 
 func (qf QueryFactory) GenesisIndexingProgressQuery() string {
 	return `
-		INSERT INTO processed_geneses (chain_id, analyzer, processed_time)
+		INSERT INTO multichain.processed_geneses (chain_id, analyzer, processed_time)
 			VALUES
 				($1, $2, CURRENT_TIMESTAMP)`
 }
@@ -439,12 +439,12 @@ func (qf QueryFactory) RuntimeTokenChangeUpdateQuery() string {
 
 func (qf QueryFactory) RefreshDailyTxVolumeQuery() string {
 	return `
-		REFRESH MATERIALIZED VIEW daily_tx_volume
+		REFRESH MATERIALIZED VIEW stats.daily_tx_volume
 	`
 }
 
 func (qf QueryFactory) RefreshMin5TxVolumeQuery() string {
 	return `
-		REFRESH MATERIALIZED VIEW min5_tx_volume
+		REFRESH MATERIALIZED VIEW stats.min5_tx_volume
 	`
 }

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -314,7 +314,7 @@ func (qf QueryFactory) RuntimeTokensQuery() string {
 func (qf QueryFactory) FineTxVolumesQuery() string {
 	return `
 		SELECT window_start, tx_volume
-			FROM min5_tx_volume
+			FROM stats.min5_tx_volume
 		ORDER BY
 			window_start DESC
 		LIMIT $1::bigint
@@ -325,7 +325,7 @@ func (qf QueryFactory) FineTxVolumesQuery() string {
 func (qf QueryFactory) TxVolumesQuery() string {
 	return `
 		SELECT window_start, tx_volume
-			FROM daily_tx_volume
+			FROM stats.daily_tx_volume
 		ORDER BY
 			window_start DESC
 		LIMIT $1::bigint

--- a/storage/migrations/00_genesis_processing.up.sql
+++ b/storage/migrations/00_genesis_processing.up.sql
@@ -1,8 +1,11 @@
 BEGIN;
 
+-- Schema for data that is not tied to a specific chain.
+CREATE SCHEMA IF NOT EXISTS multichain;
+
 -- Keeps track of chains for which we've already processed the genesis data.
-CREATE TABLE processed_geneses (
-    chain_id TEXT NOT NULL,
+CREATE TABLE multichain.processed_geneses (
+    chain_id TEXT NOT NULL,  -- e.g. 'oasis_3'; corresponds to the name of the schema that contains the chain's data.
     analyzer TEXT NOT NULL,
     processed_time TIMESTAMP WITH TIME ZONE NOT NULL,
 

--- a/storage/migrations/00_genesis_processing.up.sql
+++ b/storage/migrations/00_genesis_processing.up.sql
@@ -2,6 +2,7 @@ BEGIN;
 
 -- Schema for data that is not tied to a specific chain.
 CREATE SCHEMA IF NOT EXISTS multichain;
+GRANT USAGE ON SCHEMA multichain TO PUBLIC;
 
 -- Keeps track of chains for which we've already processed the genesis data.
 CREATE TABLE multichain.processed_geneses (
@@ -11,5 +12,9 @@ CREATE TABLE multichain.processed_geneses (
 
     PRIMARY KEY (chain_id, analyzer)
 );
+
+-- Grant others read-only use. This does NOT apply to future tables in the schema.
+-- Likely not needed for this schema, but just in case.
+GRANT SELECT ON ALL TABLES IN SCHEMA multichain TO PUBLIC;
 
 COMMIT;

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -5,6 +5,7 @@ BEGIN;
 
 -- Create Damask Upgrade Schema with `chain-id`.
 CREATE SCHEMA IF NOT EXISTS oasis_3;
+GRANT USAGE ON SCHEMA oasis_3 TO PUBLIC;
 
 -- Custom types
 CREATE DOMAIN uint_numeric NUMERIC(1000,0) CHECK(VALUE >= 0);
@@ -260,5 +261,9 @@ CREATE TABLE oasis_3.processed_blocks
 
   PRIMARY KEY (height, analyzer)
 );
+
+-- Grant others read-only use. This does NOT apply to future tables in the schema.
+GRANT SELECT ON ALL TABLES IN SCHEMA oasis_3 TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA oasis_3 TO PUBLIC;
 
 COMMIT;

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -195,4 +195,9 @@ CREATE TABLE oasis_3.emerald_withdraws
 CREATE INDEX ix_emerald_withdraws_sender ON oasis_3.emerald_withdraws(sender);
 CREATE INDEX ix_emerald_withdraws_receiver ON oasis_3.emerald_withdraws(receiver);
 
+-- Grant others read-only use.
+-- (We granted already in 01_oasis_3_consensus.up.sql, but the grant does not apply to new tables.)
+GRANT SELECT ON ALL TABLES IN SCHEMA oasis_3 TO PUBLIC;
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA oasis_3 TO PUBLIC;
+
 COMMIT;

--- a/storage/migrations/03_agg_stats.up.sql
+++ b/storage/migrations/03_agg_stats.up.sql
@@ -4,11 +4,13 @@ BEGIN;
 
 -- Schema for aggregate statistics that are not tied to a specific chain "generation" (oasis_3, oasis_4, etc.). 
 CREATE SCHEMA IF NOT EXISTS stats;
+GRANT USAGE ON SCHEMA stats TO PUBLIC;
 
 -- Rounds a given timestamp down to the nearest 5-minute "bucket" (e.g. 12:34:56 -> 12:30:00).
 CREATE FUNCTION floor_5min (ts timestamptz) RETURNS timestamptz AS $$
     SELECT date_trunc('hour', $1) + date_part('minute', $1)::int / 5 * '5 minutes'::interval;
 $$ LANGUAGE SQL IMMUTABLE;
+GRANT EXECUTE ON FUNCTION floor_5min TO PUBLIC;
 
 
 -- min5_tx_volume stores the consensus transaction volume in 5 minute buckets
@@ -30,5 +32,9 @@ CREATE MATERIALIZED VIEW stats.daily_tx_volume AS
     SUM(sub.tx_volume) AS tx_volume
   FROM stats.min5_tx_volume AS sub
   GROUP BY 1;
+
+
+-- Grant others read-only use. This does NOT apply to future tables in the schema.
+GRANT SELECT ON ALL TABLES IN SCHEMA stats TO PUBLIC;
 
 COMMIT;


### PR DESCRIPTION
After this PR, the API server should be able to access tables more robustly across deployments and schema migrations. 

PR fixes two problems:
- After a migration (or a wipe+regeneration of all tables), access was not granted to the new tables.
- API server was using the wrong schema.table path to some tables

Underlying issues:
- Some of our queries don't use explicit `<schema>.<table>` references to tables, using just `<table>` instead. 
 The API server and the analyzer use different users (read-only vs read-write), so the API server was unable to find those tables. The default `search_path` in postgres (= schemas in order of attempted use) is `"$user", public`, so those tables ended up in different schemas for the two users.
- `GRANT SELECT ON ALL TABLES IN SCHEMA` doesn't affect the tables creaetd after this command.

Changes in the PR:
 - Move all tables (except schema_migrations, used by an opaque library, and only used by the readwrite user anyway) out of the `public` schema, into explicit schemas.
 - Add `GRANT` statements to the end of each of our migrations files.

Tested locally with a separate read-only user.

**TODO**: When deploying to prod and staging, we should delete the now-outdated `indexer` and `api` schemas.

