### PR TITLE
openapi: Add assorted fields required by MVP

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -876,6 +876,22 @@ components:
           format: date-time
           description: The second-granular consensus time.
           example: *iso_timestamp_1
+        num_transactions:
+          type: integer
+          format: int32
+          description: Number of transactions in the block.
+          example: 17
+        # TODO: Not available on backend
+        # size:
+        #   type: integer
+        #   format: int64
+        #   description: Size of the block, in bytes. TODO: Be more exact. Should this include results? By far the easiest is to give the total bytesize of txs here.
+        #   example: 123456
+        # gas_used:
+        #   type: integer
+        #   format: int64
+        #   description: Total gas used by the transactions in the block.
+        #   example: 123456
       description: |
         A consensus block.
 
@@ -954,15 +970,30 @@ components:
     Transaction:
       type: object
       properties: 
-        height:
+        block:
           type: integer
           format: int64
           description: The block height at which this transaction was executed.
           example: *block_height_1
+        index_in_block:
+          type: integer
+          format: int32
+          description: 0-based index of this transaction in its block
+          example: *block_height_1
+        timestamp:
+          type: string
+          format: date-time
+          # TODO REVIEW: Is this the time the block was _proposed_, or agreed on, or some other time?
+          description: The second-granular consensus time when this tx's block was proposed.
+          example: *iso_timestamp_3
         hash:
           type: string
           description: The cryptographic hash of this transaction's encoding.
           example: *tx_hash_1
+        sender:
+          type: string
+          description: The address of who sent this transaction.
+          example: *staking_address_1
         nonce:
           type: integer
           format: int64
@@ -982,6 +1013,9 @@ components:
           example: *tx_method_1
         body:
           type: string
+          # TODO: This is a serialzied CBOR blob. Expose as a JSON subtree instead.
+          # Front-end can pull the "recipient" field from here for transactions of a suitable type.
+          format: binary
           description: The method call body.
           example: *tx_body_1
         success:

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -120,6 +120,10 @@ x-common-types:
     - TakeEscrow
     - Transfer
     - Vote
+  emv-token-types: &evm_token_types
+    - ERC20
+    - ERC721
+    - ERC1155
 
 x-err-responses:
   base-error: &base_error_response
@@ -778,6 +782,18 @@ paths:
             format: int64
           description: A filter on block round.
           example: *runtime_block_round_1
+        - in: query
+          name: rel
+          schema:
+            type: string
+          # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
+          description: |
+            A filter on related accounts. Every returned transaction will refer to
+            this account in a way. For example, for an `accounts.Transfer` tx, this will be the
+            the sender or the recipient of tokens.
+            We detect related accounts inside EVM transactions and events on a best-effort basis.
+            However, you must provide the oasis-style derived address here, not the Eth address.
+          example: *staking_address_1
       responses:
         '200':
           description: |
@@ -1229,6 +1245,72 @@ components:
       description: |
         A list of consensus layer accounts.
     
+    AddressPreimage:
+      description: |
+        The data from which a consensus-style address (`oasis1...`, aka ed25519-backed,
+        aka staking address) was derived. Notably, for EVM runtimes like Sapphire,
+        this links the oasis address and the Ethereum address.
+
+        Oasis addresses are derived from a piece of data, such as an ed25519
+        public key or an Ethereum address. The type of underlying data usually also
+        determines how the signatuers for this address are verified.
+        
+        Consensus supports only staking addresses (`context="oasis-core/address: staking"` below).
+        Runtimes support all types. This means that every consensus address is also
+        valid in every runtime. For example, in EVM runtimes, you can use staking
+        addresses, but only with oasis tools (e.g. a wallet); EVM contracts such as
+        ERC20 tokens or tools such as Metamask cannot interact with staking addresses.
+      type: object
+      properties:
+        context:
+          type: string
+          enum:
+            - "oasis-core/address: staking"
+            - "oasis-runtime-sdk/address: secp256k1eth"
+            - "oasis-runtime-sdk/address: sr25519"
+            - "oasis-runtime-sdk/address: multisig"
+            - "oasis-runtime-sdk/address: module"
+          description: |
+            The method by which the oasis address was derived from `address_data`.
+          example: "oasis-runtime-sdk/address: secp256k1eth"
+        context_version:
+          type: integer
+          nullable: true
+          default: 0
+          description: Version of the `context`.
+        address_data:
+          type: string
+          format: hex
+          description: |
+            The hex-encoded data from which the oasis address was derived. 
+            When `context = "oasis-runtime-sdk/address: secp256k1eth"`, this
+            is the Ethereum address (without the leading `0x`).
+          example: '9907A0cF64Ec9Fbf6Ed8FD4971090DE88222a9aC'
+
+    RuntimeBalance:
+      description: Balance of an account in a runtime.
+      type: object
+      properties:
+        amount:
+          type: string
+          description: Number of base units held; as a string.
+          example: "1000000000000000000000"
+        runtime:
+          type: string
+          enum: ["emerald"]
+          description: Name of the runtime.
+        # TODO:
+        # - How do we handle NFTs? Add another field?
+        # - We do not handle non-native tokens from the `accounts` SDK module. The plan is to use
+        #   their denomination name for both `token_id` and `token_symbol`, or update the SDK to have tickers.
+        token_id:
+          type: string
+          format: binary
+          description: Unique dentifier for the token. For EVM tokens, this is their eth address.
+        token_symbol:
+          type: string
+          description: The token ticker symbol. Not guaranteed to be unique across distinct tokens.
+
     Account:
       type: object
       properties: 
@@ -1236,11 +1318,19 @@ components:
           type: string
           description: The staking address for this account.
           example: *staking_address_1
+        address_preimage:
+          $ref: '#/components/schemas/AddressPreimage'
         nonce:
           type: integer
           format: int64
           description: A nonce used to prevent replay.
           example: 0
+        # TODO: limit this to 1000 entries. If folks have more,
+        # we can eventually open up a separate, paginable endpoint just for balances. 
+        runtime_balances:
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeBalance'
         available:
           type: integer
           format: int64
@@ -1481,6 +1571,12 @@ components:
           format: int64
           description: The block round at which this transaction was executed.
           example: 3379702
+        timestamp:
+          type: string
+          format: date-time
+          # TODO REVIEW: Is this the time the block was _proposed_, or agreed on, or some other time?
+          description: The second-granular consensus time when this tx's block was proposed.
+          example: *iso_timestamp_3          
         hash:
           type: string
           description: The Oasis cryptographic hash of this transaction's encoding.
@@ -1493,20 +1589,24 @@ components:
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
         sender_0:
           type: string
-          description: The Oasis address of this transaction's 0th signer.
+          description: |
+            The Oasis address of this transaction's 0th signer.
+            Unlike Ethereum, Oasis natively supports multiple-signature transactions.
+            However, the great majority of transactions only have a single signer in practice.
+          # TODO: To access the other signers, ...
           example: oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd
         nonce_0:
           type: integer
           format: int64
           description: The nonce used with this transaction's 0th signer, to prevent replay.
           example: 114194
-        fee_amount:
+        fee:
           type: string
           description: |
             The fee that this transaction's sender committed to pay to execute
             it (total, native denomination, ParaTime base units, as a string).
           example: "3000000000000000"
-        fee_gas:
+        gas_limit:
           type: integer
           format: int64
           description: |
@@ -1553,10 +1653,37 @@ components:
     RuntimeToken:
       type: object
       properties:
-        token_addr:
+        contract_addr:
           type: string
           description: The Oasis address of this token's contract.
           example: 'oasis1qp2hssandc7dekjdr6ygmtzt783k3gn38uupdeys'
+        name:
+          type: string
+          description: Name of the token, as provided by token contract's `name()` method.
+          example: Uniswap
+        symbol:
+          type: string
+          description: Symbol of the token, as provided by token contract's `symbol()` method.
+          example: UNI
+        decimals:
+          type: integer
+          description: |
+            The number of least significant digits in base units that should be displayed as
+            decimals when displaying tokens. `tokens = base_units / (10**decimals)`.
+            Affects display only. Often equals 18, to match ETH.
+          example: 18
+        type:
+          type: string
+          enum: *evm_token_types
+          nullable: true
+          description: |
+            The heuristically determined interface that the token contract implements.
+            A less specialized variant of the token might be detected; for example, an
+            ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
+            detected or is not supported, this field will be null/absent.
+        total_supply:
+          type: string
+          description: The total number of base units available.
         num_holders:
           type: integer
           format: int64

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -917,7 +917,7 @@ components:
     DelegationList:
       type: object
       properties:
-        transactions:
+        delegations:
           type: array
           items:
             $ref: '#/components/schemas/Delegation'
@@ -950,7 +950,7 @@ components:
     DebondingDelegationList:
       type: object
       properties:
-        transactions:
+        delegations:
           type: array
           items:
             $ref: '#/components/schemas/DebondingDelegation'

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -25,6 +25,9 @@ x-query-params:
     name: limit
     schema:
       type: integer
+      default: 100
+      minimum: 1
+      maximum: 1000
     description: |
       The maximum numbers of items to return.
   - &height
@@ -122,7 +125,7 @@ x-common-types:
     - TakeEscrow
     - Transfer
     - Vote
-  emv-token-types: &evm_token_types
+  evm-token-types: &evm_token_types
     - ERC20
     - ERC721
     - ERC1155
@@ -153,7 +156,7 @@ paths:
           description: A JSON object containing status metadata.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Status'
         <<: *common_error_responses
 
@@ -196,7 +199,7 @@ paths:
           description: A JSON object containing a list of consensus blocks.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/BlockList'
         <<: *common_error_responses
 
@@ -217,7 +220,7 @@ paths:
           description: A JSON object containing a consensus block.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Block'
         <<: *common_error_responses
 
@@ -272,7 +275,7 @@ paths:
             A JSON object containing a list of consensus transactions.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/TransactionList'
         <<: *common_error_responses
 
@@ -287,22 +290,12 @@ paths:
             type: string
           description: The transaction hash of the transaction to return.
           example: *tx_hash_1
-        - in: query
-          name: rel
-          schema:
-            type: string
-          # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
-          description: |
-            A filter on related accounts. Every returned transaction will refer to
-            this account in a way. For example, for an `accounts.Transfer` tx, this will be the
-            the sender or the recipient of tokens.
-          example: *staking_address_1
       responses:
         '200':
           description: A JSON object containing a consensus transaction.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Transaction'
         <<: *common_error_responses
 
@@ -362,7 +355,7 @@ paths:
             Consensus events matching the filters, sorted by most recent first.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/ConsensusEventList'
         <<: *common_error_responses
 
@@ -401,7 +394,7 @@ paths:
             at the consensus layer.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Entity'
         <<: *common_error_responses
 
@@ -425,7 +418,7 @@ paths:
             A JSON object containing a list of nodes registered at the consensus layer.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/NodeList'
         <<: *common_error_responses
 
@@ -454,7 +447,7 @@ paths:
             A JSON object containing a node registered at the consensus layer.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Node'
         <<: *common_error_responses
 
@@ -489,14 +482,14 @@ paths:
       responses:
         '200':
           description: |
-            A JSON object containing a validator registered at the 
+            A JSON object containing a validator registered at the
             consensus layer.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Validator'
         <<: *common_error_responses
-          
+
   /consensus/accounts:
     get:
       summary: Returns a list of consensus layer accounts.
@@ -565,7 +558,7 @@ paths:
             A JSON object containing a list of consensus layer accounts.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/AccountList'
         <<: *common_error_responses
 
@@ -585,7 +578,7 @@ paths:
           description: A JSON object containing a consensus layer account.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Account'
         <<: *common_error_responses
 
@@ -605,7 +598,7 @@ paths:
           description: A JSON object containing a list of delegations.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/DelegationList'
         <<: *common_error_responses
 
@@ -661,7 +654,7 @@ paths:
           description: A JSON object containing a consensus epoch.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Epoch'
         <<: *common_error_responses
 
@@ -688,7 +681,7 @@ paths:
           description: A JSON object containing a list of governance proposals.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/ProposalList'
         <<: *common_error_responses
 
@@ -709,7 +702,7 @@ paths:
           description: A JSON object containing a governance proposal.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/Proposal'
         <<: *common_error_responses
 
@@ -734,7 +727,7 @@ paths:
             A JSON object containing a list of votes for a governance proposal.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/ProposalVotes'
         <<: *common_error_responses
 
@@ -801,11 +794,12 @@ paths:
           # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
           description: |
             A filter on related accounts. Every returned transaction will refer to
-            this account in a way. For example, for an `accounts.Transfer` tx, this will be the
+            this account in a way. For example, for an `accounts.Transfer` tx, this will be
             the sender or the recipient of tokens.
             The indexer detects related accounts inside EVM transactions and events on a
             best-effort basis. For example, it inspects ERC20 methods inside `evm.Call` txs.
             However, you must provide the oasis-style derived address here, not the Eth address.
+            See `AddressPreimage` for more info on oasis-style vs Eth addresses.
           example: *staking_address_1
       responses:
         '200':
@@ -846,7 +840,7 @@ paths:
             A JSON object containing a list of TPS values for each interval.
           content:
             application/json:
-              schema: 
+              schema:
                 $ref: '#/components/schemas/VolumeList'
         <<: *common_error_responses
 
@@ -890,7 +884,7 @@ components:
 
     Block:
       type: object
-      properties: 
+      properties:
         height:
           type: integer
           format: int64
@@ -926,7 +920,7 @@ components:
 
     Delegation:
       type: object
-      properties: 
+      properties:
         amount:
           type: integer
           format: int64
@@ -995,25 +989,26 @@ components:
             $ref: '#/components/schemas/Transaction'
       description: |
         A list of consensus transactions.
-    
+
     Transaction:
       type: object
-      properties: 
+      properties:
         block:
           type: integer
           format: int64
           description: The block height at which this transaction was executed.
           example: *block_height_1
-        index_in_block:
+        index:
           type: integer
           format: int32
           description: 0-based index of this transaction in its block
-          example: *block_height_1
+          example: 17
         timestamp:
           type: string
           format: date-time
-          # TODO REVIEW: Is this the time the block was _proposed_, or agreed on, or some other time?
-          description: The second-granular consensus time when this tx's block was proposed.
+          description: |
+            The second-granular consensus time this tx's block, i.e. roughly when the
+            [block was proposed](https://github.com/tendermint/tendermint/blob/v0.34.x/spec/core/data_structures.md#header).
           example: *iso_timestamp_3
         hash:
           type: string
@@ -1078,7 +1073,7 @@ components:
           description: |
             0-based index of this event's originating transaction within its block.
             Absent if the event did not originate from a transaction.
-          example: 5 
+          example: 5
         tx_hash:
           type: string
           nullable: true
@@ -1105,10 +1100,10 @@ components:
             $ref: '#/components/schemas/Entity'
       description: |
         A list of entities registered at the consensus layer.
-    
+
     Entity:
       type: object
-      properties: 
+      properties:
         id:
           type: string
           description: The public key identifying this entity.
@@ -1211,10 +1206,10 @@ components:
             $ref: '#/components/schemas/Node'
       description: |
         A list of nodes registered at the consensus layer.
-    
+
     Node:
       type: object
-      properties: 
+      properties:
         id:
           type: string
           description: The public key identifying this node.
@@ -1257,18 +1252,30 @@ components:
             $ref: '#/components/schemas/Account'
       description: |
         A list of consensus layer accounts.
-    
+
+    AddressDerivationContext:
+      type: string
+      enum:
+        - "oasis-core/address: staking"
+        - "oasis-runtime-sdk/address: secp256k1eth"
+        - "oasis-runtime-sdk/address: sr25519"
+        - "oasis-runtime-sdk/address: multisig"
+        - "oasis-runtime-sdk/address: module"
+        - "oasis-runtime-sdk/address: runtime"
+
     AddressPreimage:
       description: |
-        The data from which a consensus-style address (`oasis1...`, aka ed25519-backed,
-        aka staking address) was derived. Notably, for EVM runtimes like Sapphire,
+        The data from which a consensus-style address (`oasis1...`)
+        was derived. Notably, for EVM runtimes like Sapphire,
         this links the oasis address and the Ethereum address.
 
         Oasis addresses are derived from a piece of data, such as an ed25519
-        public key or an Ethereum address. The type of underlying data usually also
+        public key or an Ethereum address. For example, [this](https://github.com/oasisprotocol/oasis-sdk/blob/b37e6da699df331f5a2ac62793f8be099c68469c/client-sdk/go/helpers/address.go#L90-L91)
+        is how an Ethereum is converted to an oasis address. The type of underlying data usually also
         determines how the signatuers for this address are verified.
-        
-        Consensus supports only staking addresses (`context="oasis-core/address: staking"` below).
+
+        Consensus supports only "staking addresses" (`context="oasis-core/address: staking"`
+        below; always ed25519-backed).
         Runtimes support all types. This means that every consensus address is also
         valid in every runtime. For example, in EVM runtimes, you can use staking
         addresses, but only with oasis tools (e.g. a wallet); EVM contracts such as
@@ -1276,13 +1283,7 @@ components:
       type: object
       properties:
         context:
-          type: string
-          enum:
-            - "oasis-core/address: staking"
-            - "oasis-runtime-sdk/address: secp256k1eth"
-            - "oasis-runtime-sdk/address: sr25519"
-            - "oasis-runtime-sdk/address: multisig"
-            - "oasis-runtime-sdk/address: module"
+          $ref: "#/components/schemas/AddressDerivationContext"
           description: |
             The method by which the oasis address was derived from `address_data`.
           example: "oasis-runtime-sdk/address: secp256k1eth"
@@ -1295,10 +1296,10 @@ components:
           type: string
           format: hex
           description: |
-            The hex-encoded data from which the oasis address was derived. 
+            The hex-encoded data from which the oasis address was derived.
             When `context = "oasis-runtime-sdk/address: secp256k1eth"`, this
-            is the Ethereum address (without the leading `0x`).
-          example: '9907A0cF64Ec9Fbf6Ed8FD4971090DE88222a9aC'
+            is the Ethereum address (without the leading `0x`). All-lowercase.
+          example: '9907a0cf64ec9fbf6ed8fd4971090de88222a9ac'
 
     RuntimeBalance:
       description: Balance of an account in a runtime.
@@ -1326,7 +1327,7 @@ components:
 
     Account:
       type: object
-      properties: 
+      properties:
         address:
           type: string
           description: The staking address for this account.
@@ -1339,7 +1340,7 @@ components:
           description: A nonce used to prevent replay.
           example: 0
         # TODO: limit this to 1000 entries. If folks have more,
-        # we can eventually open up a separate, paginable endpoint just for balances. 
+        # we can eventually open up a separate, paginable endpoint just for balances.
         runtime_balances:
           type: array
           items:
@@ -1376,7 +1377,7 @@ components:
           description: The allowances made by this account.
       description: |
         A consensus layer account.
-    
+
     Allowance:
       type: object
       properties:
@@ -1389,7 +1390,7 @@ components:
           format: int64
           description: The amount allowed for the allowed account.
           example: 10000000000
-    
+
     EpochList:
       type: object
       properties:
@@ -1399,10 +1400,10 @@ components:
             $ref: '#/components/schemas/Epoch'
       description: |
         A list of consensus epochs.
-    
+
     Epoch:
       type: object
-      properties: 
+      properties:
         id:
           type: integer
           format: int64
@@ -1420,7 +1421,7 @@ components:
           example: *block_height_2
       description: |
         A consensus epoch.
-    
+
     ProposalList:
       type: object
       properties:
@@ -1430,10 +1431,10 @@ components:
             $ref: '#/components/schemas/Proposal'
       description: |
         A list of governance proposals.
-    
+
     Proposal:
       type: object
-      properties: 
+      properties:
         id:
           type: integer
           format: int64
@@ -1475,7 +1476,7 @@ components:
           format: int64
           description: |
             The proposal to cancel, if this proposal proposes
-            cancelling an existing proposal. 
+            cancelling an existing proposal.
         created_at:
           type: integer
           format: int64
@@ -1511,7 +1512,7 @@ components:
 
     ProposalVote:
       type: object
-      properties: 
+      properties:
         address:
           type: string
           description: The staking address casting this vote.
@@ -1589,7 +1590,7 @@ components:
           format: date-time
           # TODO REVIEW: Is this the time the block was _proposed_, or agreed on, or some other time?
           description: The second-granular consensus time when this tx's block was proposed.
-          example: *iso_timestamp_3          
+          example: *iso_timestamp_3
         hash:
           type: string
           description: The Oasis cryptographic hash of this transaction's encoding.
@@ -1606,7 +1607,8 @@ components:
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
             However, the great majority of transactions only have a single signer in practice.
-          # TODO: To access the other signers, ...
+            Retrieving the other signers is currently not supported by this API.
+          # NOTE: To expose the other signers, use the transaction_signers table.
           example: oasis1qz670t637yyxshnlxhjj5074wgwl94d0x5x69zqd
         nonce_0:
           type: integer
@@ -1638,7 +1640,12 @@ components:
           type: string
           description: |
             A reasonable "to" Oasis address associated with this transaction,
-            if applicable. The meaning varies based on the transaction method.
+            if applicable. The meaning varies based on the transaction method. Some notable examples:
+              - For `method = "accounts.Transfer"`, this is the paratime account receiving the funds.
+              - For `method = "consensus.Deposit"`, this is the paratime account receiving the funds.
+              - For `method = "consensus.Withdraw"`, this is a consensus (!) account receiving the funds.
+              - For `method = "evm.Create"`, this is the address of the newly created smart contract.
+              - For `method = "evm.Call"`, this is the address of the called smart contract
           example: "oasis1qq6ulxmcagnp5nr56ylva7nhmwnxtf0krumg9dkq"
         amount:
           type: string
@@ -1718,7 +1725,7 @@ components:
 
     Volume:
       type: object
-      properties: 
+      properties:
         date:
           type: string
           format: date-time

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/schemas/v3.1/schema.json
+
 openapi: 3.0.3
 info:
   title: Oasis Indexer API V1
@@ -285,6 +287,16 @@ paths:
             type: string
           description: The transaction hash of the transaction to return.
           example: *tx_hash_1
+        - in: query
+          name: rel
+          schema:
+            type: string
+          # TODO: Implement autodetection of Eth addresses, get rid of last sentence.
+          description: |
+            A filter on related accounts. Every returned transaction will refer to
+            this account in a way. For example, for an `accounts.Transfer` tx, this will be the
+            the sender or the recipient of tokens.
+          example: *staking_address_1
       responses:
         '200':
           description: A JSON object containing a consensus transaction.
@@ -791,7 +803,8 @@ paths:
             A filter on related accounts. Every returned transaction will refer to
             this account in a way. For example, for an `accounts.Transfer` tx, this will be the
             the sender or the recipient of tokens.
-            We detect related accounts inside EVM transactions and events on a best-effort basis.
+            The indexer detects related accounts inside EVM transactions and events on a
+            best-effort basis. For example, it inspects ERC20 methods inside `evm.Call` txs.
             However, you must provide the oasis-style derived address here, not the Eth address.
           example: *staking_address_1
       responses:

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -36,13 +36,13 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (Run
 		Hash:    storageTransaction.Hash,
 		EthHash: storageTransaction.EthHash,
 		// TODO: Get timestamp from that round's block
-		Sender0:   sender0,
-		Nonce0:    tx.AuthInfo.SignerInfo[0].Nonce,
-		FeeAmount: tx.AuthInfo.Fee.Amount.Amount.String(),
-		FeeGas:    tx.AuthInfo.Fee.Gas,
-		Method:    tx.Call.Method,
-		Body:      tx.Call.Body,
-		Success:   cr.IsSuccess(),
+		Sender0:  sender0,
+		Nonce0:   tx.AuthInfo.SignerInfo[0].Nonce,
+		Fee:      tx.AuthInfo.Fee.Amount.Amount.String(),
+		GasLimit: tx.AuthInfo.Fee.Gas,
+		Method:   tx.Call.Method,
+		Body:     tx.Call.Body,
+		Success:  cr.IsSuccess(),
 	}
 	if err = uncategorized.VisitCall(&tx.Call, &cr, &uncategorized.CallHandler{
 		AccountsTransfer: func(body *accounts.Transfer) error {

--- a/api/v1/types.go
+++ b/api/v1/types.go
@@ -12,13 +12,13 @@ type RuntimeTransaction struct {
 	Hash    string  `json:"hash"`
 	EthHash *string `json:"eth_hash"`
 	// TODO: timestamp
-	Sender0   string  `json:"sender_0"`
-	Nonce0    uint64  `json:"nonce_0"`
-	FeeAmount string  `json:"fee_amount"`
-	FeeGas    uint64  `json:"fee_gas"`
-	Method    string  `json:"method"`
-	Body      []byte  `json:"body"`
-	To        *string `json:"to"`
-	Amount    *string `json:"amount"`
-	Success   bool    `json:"success"`
+	Sender0  string  `json:"sender_0"`
+	Nonce0   uint64  `json:"nonce_0"`
+	Fee      string  `json:"fee"`
+	GasLimit uint64  `json:"gas_limit"`
+	Method   string  `json:"method"`
+	Body     []byte  `json:"body"`
+	To       *string `json:"to"`
+	Amount   *string `json:"amount"`
+	Success  bool    `json:"success"`
 }

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1344,7 +1344,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, r *RuntimeTokensReque
 	for rows.Next() {
 		var t RuntimeToken
 		if err := rows.Scan(
-			&t.TokenAddr,
+			&t.ContractAddr,
 			&t.NumHolders,
 		); err != nil {
 			c.logger.Info("row scan failed",

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -244,8 +244,8 @@ type RuntimeTokenList struct {
 }
 
 type RuntimeToken struct {
-	TokenAddr  string `json:"token_addr"`
-	NumHolders int64  `json:"num_holders"`
+	ContractAddr string `json:"contract_addr"`
+	NumHolders   int64  `json:"num_holders"`
 }
 
 // TxVolumeList is the storage response for GetVolumes.


### PR DESCRIPTION
This PR adds various fields to our API that are required for an explorer MVP.

On the openapi side, some of the additions are commented out. That's because their underlying data is not something we have in the DB yet; they will therefore be more work to implement. But I want to float them here, and even merge them in their commented-out state, so that frontend folks can code against something.

**Note on account activity:**
For the "account activity" explorer page, this PR takes a double approach. In consensus, I was more ambitious and prepared #246 that sets the stage for displaying activity based on _events_. This is the preferred approach, but takes more work. But then for emerald I didn't go through with it (yet). As a lower-effort approach, I added a filter (by "related accounts") to the txs endpoints for now, on both the emerald and consensus side.

**WIP:** openapi only for now; implementation is TODO in this PR. Except for the parts that are commented out in openapi; those will take more work and will be a separate PR.