### PR TITLE
db: Rename fields txn_* -> tx_*

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -66,7 +66,7 @@ func (qf QueryFactory) ConsensusEpochUpdateQuery() string {
 
 func (qf QueryFactory) ConsensusTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.transactions (block, txn_hash, txn_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
+		INSERT INTO %s.transactions (block, tx_hash, tx_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID)
 }
 
@@ -89,7 +89,7 @@ func (qf QueryFactory) ConsensusCommissionsUpsertQuery() string {
 
 func (qf QueryFactory) ConsensusEventInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.events (backend, type, body, txn_block, txn_hash, txn_index)
+		INSERT INTO %s.events (backend, type, body, tx_block, tx_hash, tx_index)
 			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID)
 }
 

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -44,7 +44,7 @@ func (qf QueryFactory) BlockQuery() string {
 
 func (qf QueryFactory) TransactionsQuery() string {
 	return fmt.Sprintf(`
-		SELECT block, txn_hash, sender, nonce, fee_amount, method, body, code
+		SELECT block, tx_hash, sender, nonce, fee_amount, method, body, code
 			FROM %s.transactions
 			WHERE ($1::bigint IS NULL OR block = $1::bigint) AND
 						($2::text IS NULL OR method = $2::text) AND
@@ -52,16 +52,16 @@ func (qf QueryFactory) TransactionsQuery() string {
 						($4::bigint IS NULL OR fee_amount >= $4::bigint) AND
 						($5::bigint IS NULL OR fee_amount <= $5::bigint) AND
 						($6::bigint IS NULL OR code = $6::bigint)
-		ORDER BY block DESC, txn_index
+		ORDER BY block DESC, tx_index
 		LIMIT $7::bigint
 		OFFSET $8::bigint`, qf.chainID)
 }
 
 func (qf QueryFactory) TransactionQuery() string {
 	return fmt.Sprintf(`
-		SELECT block, txn_hash, sender, nonce, fee_amount, method, body, code
+		SELECT block, tx_hash, sender, nonce, fee_amount, method, body, code
 			FROM %s.transactions
-			WHERE txn_hash = $1::text`, qf.chainID)
+			WHERE tx_hash = $1::text`, qf.chainID)
 }
 
 func (qf QueryFactory) EntitiesQuery() string {

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -36,9 +36,9 @@ CREATE TABLE oasis_3.blocks
 CREATE TABLE oasis_3.transactions
 (
   block BIGINT NOT NULL REFERENCES oasis_3.blocks(height) DEFERRABLE INITIALLY DEFERRED,
-  txn_index  UINT31 NOT NULL,
+  tx_index  UINT31 NOT NULL,
   
-  txn_hash   HEX64 NOT NULL,
+  tx_hash   HEX64 NOT NULL,
   nonce      UINT63 NOT NULL,
   fee_amount UINT_NUMERIC,
   max_gas    UINT_NUMERIC, -- uint64 in go; because the value might conceivably be >2^63, we use UINT_NUMERIC over UINT63 here.
@@ -54,22 +54,22 @@ CREATE TABLE oasis_3.transactions
 
   -- We require a composite primary key since duplicate transactions (with identical hashes) can
   -- be included within blocks for this chain.
-  PRIMARY KEY (block, txn_index)
+  PRIMARY KEY (block, tx_index)
 );
 -- Queries by sender are common, and unusably slow without an index.
 CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);
 
 CREATE TABLE oasis_3.events
 (
-  txn_block  UINT63 NOT NULL,
-  txn_index  UINT31,
+  tx_block  UINT63 NOT NULL,
+  tx_index  UINT31,
   
   backend TEXT NOT NULL,  -- E.g. registry, staking
   type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/oasis-indexer/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
   body    JSON,
-  txn_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency
+  tx_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency
 
-  FOREIGN KEY (txn_block, txn_index) REFERENCES oasis_3.transactions(block, txn_index) DEFERRABLE INITIALLY DEFERRED
+  FOREIGN KEY (tx_block, tx_index) REFERENCES oasis_3.transactions(block, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
 
 -- Beacon Backend Data


### PR DESCRIPTION
Resolves https://github.com/oasisprotocol/oasis-indexer/pull/246#discussion_r1047909347

The `txn_*` naming style is used almost nowhere in the indexer or oasis-core; `tx_` is pretty much the convention. This is a breaking change, but let's live fast (and let the db die young) while we can.