### PR TITLE
event enums: Rename to conform with oasis-core

### DIFF
--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -162,43 +162,43 @@ const (
 func (e *Event) String() string {
 	switch *e {
 	case EventStakingTransfer:
-		return "Transfer"
+		return "staking.transfer"
 	case EventStakingBurn:
-		return "Burn"
+		return "staking.burn"
 	case EventStakingAddEscrow:
-		return "AddEscrow"
+		return "staking.escrow.add"
 	case EventStakingTakeEscrow:
-		return "TakeEscrow"
+		return "staking.escrow.take"
 	case EventStakingDebondingStart:
-		return "DebondingStart"
+		return "staking.escrow.debonding_start"
 	case EventStakingReclaimEscrow:
-		return "ReclaimEscrow"
+		return "staking.escrow.reclaim"
 	case EventStakingAllowanceChange:
-		return "AllowanceChange"
+		return "staking.allowance_change"
 	case EventRegistryRuntime:
-		return "Runtime"
+		return "registry.runtime"
 	case EventRegistryEntity:
-		return "Entity"
+		return "registry.entity"
 	case EventRegistryNode:
-		return "Node"
+		return "registry.node"
 	case EventRegistryNodeUnfrozen:
-		return "NodeUnfrozen"
+		return "registry.node_unfrozen"
 	case EventRoothashExecutorCommitted:
-		return "ExecutorCommitted"
+		return "roothash.executor_committed"
 	case EventRoothashExecutionDiscrepancyDetected:
-		return "ExecutionDiscrepancyDetected"
+		return "roothash.execution_discrepancy_detected"
 	case EventRoothashFinalized:
-		return "Finalized"
+		return "roothash.finalized"
 	case EventGovernanceProposalSubmitted:
-		return "ProposalSubmitted"
+		return "governance.proposal_submitted"
 	case EventGovernanceProposalExecuted:
-		return "ProposalExecuted"
+		return "governance.proposal_executed"
 	case EventGovernanceProposalFinalized:
-		return "ProposalFinalized"
+		return "governance.proposal_finalized"
 	case EventGovernanceVote:
-		return "Vote"
+		return "governance.vote"
 	default:
-		return "Unknown"
+		return "unknown"
 	}
 }
 

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -142,8 +142,8 @@ const (
 	EventRegistryNodeUnfrozen
 	// EventRoothashExecutorCommitted is an executor committed event.
 	EventRoothashExecutorCommitted
-	// EventRoothashDiscrepancyDetected is a discrepancy detected event.
-	EventRoothashDiscrepancyDetected
+	// EventRoothashExecutionDiscrepancyDetected is a discrepancy detected event.
+	EventRoothashExecutionDiscrepancyDetected
 	// EventRoothashFinalizedEvent is a roothash finalization event.
 	EventRoothashFinalized
 	// EventGovernanceProposalSubmitted is a proposal submission event.
@@ -185,8 +185,8 @@ func (e *Event) String() string {
 		return "NodeUnfrozen"
 	case EventRoothashExecutorCommitted:
 		return "ExecutorCommitted"
-	case EventRoothashDiscrepancyDetected:
-		return "DiscrepancyDetected"
+	case EventRoothashExecutionDiscrepancyDetected:
+		return "ExecutionDiscrepancyDetected"
 	case EventRoothashFinalized:
 		return "Finalized"
 	case EventGovernanceProposalSubmitted:

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -142,7 +142,7 @@ const (
 	EventRegistryNodeUnfrozen
 	// EventRoothashExecutorCommitted is an executor committed event.
 	EventRoothashExecutorCommitted
-	// EventRoothashExecutionDiscrepancyDetected is a discrepancy detected event.
+	// EventRoothashExecutionDiscrepancyDetected is a runtime discrepancy detected event.
 	EventRoothashExecutionDiscrepancyDetected
 	// EventRoothashFinalizedEvent is a roothash finalization event.
 	EventRoothashFinalized

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -438,13 +438,12 @@ func (m *Main) queueEventInserts(batch *storage.QueryBatch, data *storage.Consen
 
 	for i := 0; i < len(data.Results); i++ {
 		for j := 0; j < len(data.Results[i].Events); j++ {
-			backend, ty, body, err := extractEventData(data.Results[i].Events[j])
+			_, ty, body, err := extractEventData(data.Results[i].Events[j])
 			if err != nil {
 				return err
 			}
 
 			batch.Queue(eventInsertQuery,
-				backend.String(),
 				ty.String(),
 				string(body),
 				data.BlockHeader.Height,

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -870,7 +870,7 @@ func extractEventData(event *results.Event) (backend analyzer.Backend, ty analyz
 			body, err = json.Marshal(event.RootHash.ExecutorCommitted)
 			return
 		case b.ExecutionDiscrepancyDetected != nil:
-			ty = analyzer.EventRoothashDiscrepancyDetected
+			ty = analyzer.EventRoothashExecutionDiscrepancyDetected
 			body, err = json.Marshal(event.RootHash.ExecutionDiscrepancyDetected)
 			return
 		case b.Finalized != nil:

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -89,8 +89,8 @@ func (qf QueryFactory) ConsensusCommissionsUpsertQuery() string {
 
 func (qf QueryFactory) ConsensusEventInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.events (backend, type, body, tx_block, tx_hash, tx_index)
-			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID)
+		INSERT INTO %s.events (type, body, tx_block, tx_hash, tx_index)
+			VALUES ($1, $2, $3, $4, $5)`, qf.chainID)
 }
 
 func (qf QueryFactory) ConsensusRuntimeUpsertQuery() string {

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -107,24 +107,24 @@ x-common-types:
     - beacon.PVSSReveal
     - beacon.VRFProve
   consensus-event-types: &consensus_event_types
-    - AddEscrow
-    - AllowanceChange
-    - Burn
-    - DebondingStart
-    - ExecutionDiscrepancyDetected
-    - Entity
-    - ExecutorCommitted
-    - Finalized
-    - Node
-    - NodeUnfrozen
-    - ProposalExecuted
-    - ProposalFinalized
-    - ProposalSubmitted
-    - ReclaimEscrow
-    - Runtime
-    - TakeEscrow
-    - Transfer
-    - Vote
+    - governance.proposal_executed
+    - governance.proposal_finalized
+    - governance.proposal_submitted
+    - governance.vote
+    - registry.entity
+    - registry.node_unfrozen
+    - registry.node
+    - registry.runtime
+    - roothash.execution_discrepancy
+    - roothash.executor_committed
+    - roothash.finalized
+    - staking.allowance_change
+    - staking.burn
+    - staking.escrow.add
+    - staking.escrow.debonding_start
+    - staking.escrow.reclaim
+    - staking.escrow.take
+    - staking.transfer
   evm-token-types: &evm_token_types
     - ERC20
     - ERC721

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -111,7 +111,7 @@ x-common-types:
     - AllowanceChange
     - Burn
     - DebondingStart
-    - DiscrepancyDetected
+    - ExecutionDiscrepancyDetected
     - Entity
     - ExecutorCommitted
     - Finalized

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -63,8 +63,7 @@ CREATE TABLE oasis_3.events
 (
   tx_block  UINT63 NOT NULL,
   tx_index  UINT31,
-  
-  backend TEXT NOT NULL,  -- E.g. registry, staking
+
   type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/oasis-indexer/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
   body    JSON,
   tx_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency


### PR DESCRIPTION
This came up in https://github.com/oasisprotocol/oasis-indexer/pull/246/files#r1048033749

Unlike the indexer, oasis-core does not have an enum of all event types. Instead, events are represented in a [nested struct that is used as a union type](https://github.com/oasisprotocol/oasis-core/blob/7f38a068c21160094ce11be1644b08cfb82b53a1/go/consensus/api/transaction/results/results.go#L13-L13). So to represent a Transfer event, for example, oasis-core use an object like `Event { Staking: { Transfer: { ... } } }`. There's no explicit enumeration/names for event types. The indexer, OTOH, needs an enum so that clients can somehow say "give me only events of type X".

Enums were named somewhat arbitrarily. They were named after the last element of the "path" in the above composite object. In addition, the first element of the path (in practice, the originating tendermint app) was saved as a separate `backend` column in the DB, but it only ever makes sense to expose both `backend` and `type` at the same time, or neither. 

This PR changes the enum value scheme as follows:
- `backend` and `type` are merged into a single field, simplifying handling and understanding
-  JSON/CBOR names of fields are used, rather than Go-internal struct field names
- When the "path" from the top-level `Event` to the leaf event struct has more than two elements, all elements are included in the enum name (e.g. `staking.escrow.take`)