### PR TITLE
Add account on new allowance owner

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -272,6 +272,13 @@ func (qf QueryFactory) ConsensusAllowanceChangeDeleteQuery() string {
 			WHERE owner = $1 AND beneficiary = $2`, qf.chainID)
 }
 
+func (qf QueryFactory) ConsensusAllowanceOwnerUpsertQuery() string {
+	return fmt.Sprintf(`
+		INSERT INTO %[1]s.accounts (address)
+			VALUES ($1)
+		ON CONFLICT (address) DO NOTHING`, qf.chainID)
+}
+
 func (qf QueryFactory) ConsensusAllowanceChangeUpdateQuery() string {
 	return fmt.Sprintf(`
 		INSERT INTO %s.allowances (owner, beneficiary, allowance)


### PR DESCRIPTION
#### Description
Fix a foreign key constraint violation on the `allowances` table from the helpful change https://github.com/oasisprotocol/oasis-indexer/pull/217.

Our logs show:

```
["\n\t\tINSERT INTO oasis_3.allowances (owner, beneficiary, allowance)\n\t\t\tVALUES ($1, $2, $3)\n\t\tON CONFLICT (owner, beneficiary) DO\n\t\t\tUPDATE SET allowance = excluded.allowance","oasis1qq2n4alcafedvrp76sr9h8cw9y6kacxz3gtyyump","oasis1qzvlg0grjxwgjj58tx2xvmv26era6t2csqn22pte","100000000000"],
```
#### Related
Hopefully this doesn't bother us here as well. I don't think so.
https://github.com/oasisprotocol/oasis-indexer/blob/825bf5046e73456cf87f95d24dc9d6433c1998d4/storage/migrations/01_oasis_3_consensus.up.sql#L191-L192

#### Question
Potentially we may want to better document this behavior.