### PR TITLE
bugfix: Process fee accumulator disbursements last

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -163,6 +163,9 @@ func (m *Main) Start() {
 		backoff.Success()
 		height++
 	}
+	m.logger.Info(
+		fmt.Sprintf("finished processing all blocks in the configured range [%d, %d]",
+			m.cfg.Range.From, m.cfg.Range.To))
 }
 
 // Name returns the name of the Main.
@@ -285,7 +288,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		m.queueRuntimeRegistrations,
 		m.queueEntityEvents,
 		m.queueNodeEvents,
-		m.queueRegistryEvents,
+		m.queueRegistryEventInserts,
 	} {
 		if err := f(batch, data.RegistryData); err != nil {
 			return err
@@ -297,7 +300,7 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		m.queueBurns,
 		m.queueEscrows,
 		m.queueAllowanceChanges,
-		m.queueStakingEvents,
+		m.queueStakingEventInserts,
 		m.queueDisbursementTransfers,
 	} {
 		if err := f(batch, data.StakingData); err != nil {
@@ -319,14 +322,14 @@ func (m *Main) processBlock(ctx context.Context, height int64) error {
 		m.queueExecutions,
 		m.queueFinalizations,
 		m.queueVotes,
-		m.queueGovernanceEvents,
+		m.queueGovernanceEventInserts,
 	} {
 		if err := f(batch, data.GovernanceData); err != nil {
 			return err
 		}
 	}
 
-	if err := m.queueRootHashEvents(batch, data.RootHashData); err != nil {
+	if err := m.queueRootHashEventInserts(batch, data.RootHashData); err != nil {
 		return err
 	}
 
@@ -567,7 +570,7 @@ func (m *Main) queueNodeEvents(batch *storage.QueryBatch, data *storage.Registry
 	return nil
 }
 
-func (m *Main) queueRegistryEvents(batch *storage.QueryBatch, data *storage.RegistryData) error {
+func (m *Main) queueRegistryEventInserts(batch *storage.QueryBatch, data *storage.RegistryData) error {
 	eventInsertQuery := m.qf.ConsensusEventInsertQuery()
 
 	for _, event := range data.Events {
@@ -593,7 +596,7 @@ func (m *Main) queueRegistryEvents(batch *storage.QueryBatch, data *storage.Regi
 	return nil
 }
 
-func (m *Main) queueRootHashEvents(batch *storage.QueryBatch, data *storage.RootHashData) error {
+func (m *Main) queueRootHashEventInserts(batch *storage.QueryBatch, data *storage.RootHashData) error {
 	eventInsertQuery := m.qf.ConsensusEventInsertQuery()
 
 	for _, event := range data.Events {
@@ -790,7 +793,7 @@ func (m *Main) queueAllowanceChanges(batch *storage.QueryBatch, data *storage.St
 	return nil
 }
 
-func (m *Main) queueStakingEvents(batch *storage.QueryBatch, data *storage.StakingData) error {
+func (m *Main) queueStakingEventInserts(batch *storage.QueryBatch, data *storage.StakingData) error {
 	eventInsertQuery := m.qf.ConsensusEventInsertQuery()
 
 	for _, event := range data.Events {
@@ -931,7 +934,7 @@ func (m *Main) queueVotes(batch *storage.QueryBatch, data *storage.GovernanceDat
 	return nil
 }
 
-func (m *Main) queueGovernanceEvents(batch *storage.QueryBatch, data *storage.GovernanceData) error {
+func (m *Main) queueGovernanceEventInserts(batch *storage.QueryBatch, data *storage.GovernanceData) error {
 	eventInsertQuery := m.qf.ConsensusEventInsertQuery()
 
 	for _, event := range data.Events {


### PR DESCRIPTION
The special fee accumulator account can temporarily attain negative balance due to the order in which we process events. When that happens, the indexer grinds to a halt (first at height 8049946) because negative balances violate DB constraints.

This PR fixes the order of event processing to avoid that situation. 

An alternative solution discussed in Slack is to special-case the fee accumulator account, and not track it at all.
Another alternative (slow) is to try and change oasis-core so it returns events in the "right" order (see comment in the code diff).

*Testing:* Ran locally to height 8050256 without problems.