### PR TITLE
bugfix: Convert bigint params to string before passing to DB

### DIFF
--- a/api/v1/client.go
+++ b/api/v1/client.go
@@ -45,9 +45,9 @@ func validateUint64(param string) (uint64, error) {
 // validateBigInt parses a big.Int url parameter.
 func validateBigInt(param string) (*storage.BigInt, error) {
 	i := big.NewInt(0)
-	i, err := i.SetString(param, 10)
-	if err {
-		return nil, common.ErrBadRequest
+	i, ok := i.SetString(param, 10)
+	if !ok {
+		return nil, fmt.Errorf("invalid big.Int: %+v", param)
 	}
 	return &storage.BigInt{Int: *i}, nil
 }

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -70,6 +70,14 @@ func (c *StorageClient) numericToBigInt(ctx context.Context, n *pgtype.Numeric) 
 	return BigInt{*big0}, nil
 }
 
+func toString(b *BigInt) *string {
+	if b == nil {
+		return nil
+	}
+	s := b.String()
+	return &s
+}
+
 // NewStorageClient creates a new storage client.
 func NewStorageClient(chainID string, db storage.TargetStorage, l *log.Logger) (*StorageClient, error) {
 	blockCache, err := ristretto.NewCache(&ristretto.Config{
@@ -222,8 +230,8 @@ func (c *StorageClient) Transactions(ctx context.Context, r *TransactionsRequest
 		r.Block,
 		r.Method,
 		r.Sender,
-		r.MinFee,
-		r.MaxFee,
+		toString(r.MinFee),
+		toString(r.MaxFee),
 		r.Code,
 		p.Limit,
 		p.Offset,
@@ -395,7 +403,7 @@ func (c *StorageClient) Entity(ctx context.Context, r *EntityRequest) (*Entity, 
 	nodeRows, err := c.db.Query(
 		ctx,
 		qf.EntityNodeIdsQuery(),
-		r.EntityID,
+		r.EntityID.String(),
 	)
 	if err != nil {
 		c.logger.Info("query failed",
@@ -520,14 +528,14 @@ func (c *StorageClient) Accounts(ctx context.Context, r *AccountsRequest, p *com
 	rows, err := c.db.Query(
 		ctx,
 		qf.AccountsQuery(),
-		r.MinAvailable,
-		r.MaxAvailable,
-		r.MinEscrow,
-		r.MaxEscrow,
-		r.MinDebonding,
-		r.MaxDebonding,
-		r.MinTotalBalance,
-		r.MaxTotalBalance,
+		toString(r.MinAvailable),
+		toString(r.MaxAvailable),
+		toString(r.MinEscrow),
+		toString(r.MaxEscrow),
+		toString(r.MinDebonding),
+		toString(r.MaxDebonding),
+		toString(r.MinTotalBalance),
+		toString(r.MaxTotalBalance),
 		p.Limit,
 		p.Offset,
 	)


### PR DESCRIPTION
Fixes two bugs around BigInts and the HTTP interface that I discovered accidentally:
- When parsing BigInt params, we rejected all well-formed params, and accepted others
- When we try to pass a BigInt into a DB query as a param, it fails to convert automatically and causes the query to fail. So we just have to know to convert the bigints to strings manually before passing them to the DB. Go's type system enforces/checks nothing at that layer.

While these fixes work, they are a bandaid. Proper solutions:
- (1st bug) Have a regression test that hits our HTTP API with a reasonable number of different requests. (filed #273)
- (2nd bug) Implement custom postgres serialization for BigInt (filed #274)
- (2nd bug) Refactor DB queries so that they cannot be called with arbitrarily-typed params; enforce param types.
