### PR TITLE
storage: source storage timeout

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -34,6 +34,8 @@ import (
 
 const (
 	ConsensusDamaskAnalyzerName = "consensus_damask"
+
+	ProcessBlockTimeout = 61 * time.Second
 )
 
 type EventType = apiTypes.ConsensusEventType // alias for brevity
@@ -266,13 +268,16 @@ func (m *Main) processGenesis(ctx context.Context) error {
 // from source storage and committing an atomically-executed batch of queries
 // to target storage.
 func (m *Main) processBlock(ctx context.Context, height int64) error {
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, ProcessBlockTimeout)
+	defer cancel()
+
 	// Fetch all data.
 	source, err := m.source(height)
 	if err != nil {
 		return err
 	}
 
-	data, err := source.AllData(ctx, height)
+	data, err := source.AllData(ctxWithTimeout, height)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
adding a timeout to 'routine' grpc requests

- https://grpc.io/blog/deadlines/#go grpc recommends using the usual go context timeout/deadline system
- #267 reports that requests freeze (thousands of minutes)
- selected timeout in this PR is 61 seconds, a little longer than the usual minute-long timeout used in common proxies
- only grpc requests are subject to the timeout. other analysis stuff including writing to the db are still able to hang \\: feel free to open an alternate PR that puts an entire loop iteration under a timeout
- not exposed in configuration :face_with_spiral_eyes: 
- 'routine' grpc requests only, exempting methods that get entire genesis documents. consensus `AllData` gives each subcomponent a timeout