### PR TITLE
api: make epoch end height optional

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1425,7 +1425,7 @@ components:
 
     Epoch:
       type: object
-      required: [id, start_height, end_height]
+      required: [id, start_height]
       properties:
         id:
           x-go-name: ID
@@ -1441,7 +1441,7 @@ components:
         end_height:
           type: integer
           format: uint64
-          description: The (inclusive) height at which this epoch ended.
+          description: The (inclusive) height at which this epoch ended. Omitted if the epoch is still active.
           example: *block_height_2
       description: |
         A consensus epoch.

--- a/api/v1/types/openapi.gen.go
+++ b/api/v1/types/openapi.gen.go
@@ -274,8 +274,8 @@ type EntityList struct {
 
 // Epoch A consensus epoch.
 type Epoch struct {
-	// EndHeight The (inclusive) height at which this epoch ended.
-	EndHeight uint64 `json:"end_height"`
+	// EndHeight The (inclusive) height at which this epoch ended. Omitted if the epoch is still active.
+	EndHeight *uint64 `json:"end_height,omitempty"`
 
 	// Id The epoch number.
 	ID int64 `json:"id"`

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -850,16 +850,12 @@ func (c *StorageClient) Epochs(ctx context.Context, p *apiCommon.Pagination) (*E
 	}
 	for rows.Next() {
 		var e Epoch
-		var endHeight *uint64
-		if err := rows.Scan(&e.ID, &e.StartHeight, &endHeight); err != nil {
+		if err := rows.Scan(&e.ID, &e.StartHeight, &e.EndHeight); err != nil {
 			c.logger.Info("row scan failed",
 				"request_id", ctx.Value(common.RequestIDContextKey),
 				"err", err.Error(),
 			)
 			return nil, apiCommon.ErrStorageError
-		}
-		if endHeight != nil {
-			e.EndHeight = *endHeight
 		}
 
 		es.Epochs = append(es.Epochs, e)


### PR DESCRIPTION
Fixes an oversight in original API design.

Querying `/v1/consensus/epochs` -- before (note the first epoch, i.e. the active one):
```
{"epochs":[{"id":13404,"start_height":8050156,"end_height":0},{"end_height":8050156,"id":13403,"start_height":8049556},{"end_height":8049556,"id":13402,"start_height":8048956}]}
```

After:
```
{"epochs":[{"id":13404,"start_height":8050156},{"end_height":8050156,"id":13403,"start_height":8049556},{"end_height":8049556,"id":13402,"start_height":8048956}]}
```