### PR TITLE
db: Add index for consensus tx hash

### DIFF
--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -56,8 +56,9 @@ CREATE TABLE oasis_3.transactions
   -- be included within blocks for this chain.
   PRIMARY KEY (block, tx_index)
 );
--- Queries by sender are common, and unusably slow without an index.
+-- Queries by sender and/or tx_hash are available via the API.
 CREATE INDEX ix_transactions_sender ON oasis_3.transactions (sender);
+CREATE INDEX ix_transactions_tx_hash ON oasis_3.transactions (tx_hash);
 
 CREATE TABLE oasis_3.events
 (


### PR DESCRIPTION
@lukaw3d reported a case of a query timing out:
https://index.oasislabs.com/v1/consensus/transactions/fa0a6600c5c1c20aaf192fb0519067e250f983ea1536ee10c95b7a4f0e738a91 (exists), 200ms, 200 OK
https://index.oasislabs.com/v1/consensus/transactions/fa0a6600c5c1c20aaf192fb0519067e250f983ea1536ee10c95b7a4f0e738a92 (doesn't exist), 2min, 524 Timeout

There's nothing complex in our Go codebase, so the DB was the obvious culprit. Sure enough, there was no index on the tx hash, and I guess the fast response for the existing tx was just thanks to that tx being recent, and thus hit quickly by the postgres sequential table scan.

I added the index from this PR to both staging and prod dbs; the second query now fails quickly, as it should.
It still does not fail with 404 because of https://github.com/oasisprotocol/oasis-indexer/issues/279, but at least it's fast.