### PR TITLE
bugfix: Autogenerate code before packaging a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,8 @@ jobs:
         uses: actions/setup-go@v2.2.0
         with:
           go-version: 1.18
+      - name: Install Go tools
+        run: go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.12
 
       # Prepare the GitHub release.
       - name: Install GoReleaser

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ psql:
 shutdown-postgres:
 	@docker rm indexer-postgres --force
 
-release-build:
+release-build: codegen-go
 	@goreleaser release --rm-dist
 
 # List of targets that are not actual files.


### PR DESCRIPTION
#280  introduces the use of autogenerated files that are not checked into the repo. It also fixed the CI targets to build those autogeenrated files before doign linting, building etc, but it forgot to update the CI rule for making a release.

I _think_ this PR fixes hings, but I also think the only way to verify is to merge the PR and try creating another release :/