### PR TITLE
Track native balances in runtimes. Per-denomination events from `accounts` module. 

### DIFF
--- a/analyzer/emerald/incoming.go
+++ b/analyzer/emerald/incoming.go
@@ -433,7 +433,7 @@ func emitRoundBatch(batch *storage.QueryBatch, qf *analyzer.QueryFactory, round 
 		batch.Queue(qf.AddressPreimageInsertQuery(), addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
 	}
 	for key, change := range blockData.TokenBalanceChanges {
-		batch.Queue(qf.RuntimeTokenBalanceUpdateQuery(), key.TokenAddress, key.AccountAddress, change.String())
+		batch.Queue(qf.RuntimeEvmBalanceUpdateQuery(), key.TokenAddress, key.AccountAddress, change.String())
 	}
 	for tokenAddr, tokenData := range blockTokenData.TokenData {
 		batch.Queue(

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -73,6 +73,8 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 			errorModule,
 			errorCode,
 		)
+		// Do not increase the recipient's runtime balance at this point;
+		// the deposit will trigger a mint event in the runtime, and we'll update the balance then.
 	}
 
 	return nil
@@ -99,7 +101,8 @@ func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, dat
 			errorModule,
 			errorCode,
 		)
-
+		// Do not decrease the recipient's runtime balance at this point;
+		// the withdraw will trigger a burn event in the runtime, and we'll update the balance then.
 	}
 
 	return nil

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -399,23 +399,11 @@ func (qf QueryFactory) RuntimeTransferInsertQuery() string {
 
 func (qf QueryFactory) RuntimeDepositInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_deposits (round, sender, receiver, amount, nonce)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
-}
-
-func (qf QueryFactory) RuntimeDepositErrorInsertQuery() string {
-	return fmt.Sprintf(`
 		INSERT INTO %s.%s_deposits (round, sender, receiver, amount, nonce, module, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
-}
-
-func (qf QueryFactory) RuntimeWithdrawErrorInsertQuery() string {
 	return fmt.Sprintf(`
 		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce, module, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -381,20 +381,20 @@ func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
-			VALUES ($1, NULL, $2, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
+			VALUES ($1, NULL, $2, $3, $4)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeBurnInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
-			VALUES ($1, $2, NULL, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
+			VALUES ($1, $2, NULL, $3, $4)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransferInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, amount)
-			VALUES ($1, $2, $3, $4)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
+			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeDepositInsertQuery() string {
@@ -407,6 +407,14 @@ func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
 	return fmt.Sprintf(`
 		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce, module, code)
 			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+}
+
+func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {
+	return fmt.Sprintf(`
+		INSERT INTO %[1]s.runtime_native_balances (runtime, account_address, symbol, balance)
+		  VALUES ('%[2]s', $1, $2, $3)
+		ON CONFLICT (runtime, account_address, symbol) DO
+		UPDATE SET balance = %[1]s.runtime_native_balances.balance + $3`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {
@@ -422,7 +430,7 @@ func (qf QueryFactory) AddressPreimageInsertQuery() string {
 		ON CONFLICT DO NOTHING`, qf.chainID)
 }
 
-func (qf QueryFactory) RuntimeTokenBalanceUpdateQuery() string {
+func (qf QueryFactory) RuntimeEvmBalanceUpdateQuery() string {
 	return fmt.Sprintf(`
 		INSERT INTO %[1]s.%[2]s_token_balances (token_address, account_address, balance)
 			VALUES ($1, $2, $3)

--- a/storage/api.go
+++ b/storage/api.go
@@ -228,6 +228,11 @@ type RuntimeSourceStorage interface {
 
 	// Name returns the name of the source storage.
 	Name() string
+
+	// StringifyDenomination returns a string representation of the given denomination.
+	// This is simply the denomination's symbol; notably, for the native denomination,
+	// this is looked up from network config.
+	StringifyDenomination(d types.Denomination) string
 }
 
 // RuntimeBlockData represents data for a runtime block during a given round.

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -21,7 +21,7 @@ type RuntimeClient struct {
 	client  connection.RuntimeClient
 	network *config.Network
 
-	info  *types.RuntimeInfo
+	info  *sdkTypes.RuntimeInfo
 	rtCtx runtimeSignature.Context
 }
 
@@ -145,4 +145,26 @@ func (rc *RuntimeClient) Name() string {
 		}
 	}
 	return fmt.Sprintf("%s_runtime", paratimeName)
+}
+
+func (rc *RuntimeClient) nativeTokenSymbol() string {
+	for _, network := range config.DefaultNetworks.All {
+		if network.ChainContext != rc.network.ChainContext {
+			continue
+		}
+		for _, paratime := range network.ParaTimes.All {
+			if paratime.ID == rc.info.ID.Hex() {
+				return paratime.Denominations[config.NativeDenominationKey].Symbol
+			}
+		}
+	}
+	panic("Cannot find native token symbol for runtime")
+}
+
+func (rc *RuntimeClient) StringifyDenomination(d sdkTypes.Denomination) string {
+	if d.IsNative() {
+		return rc.nativeTokenSymbol()
+	}
+
+	return d.String()
 }


### PR DESCRIPTION
Pre-work for #256 . It turns out not all data was "readily available"  :|

The PR brings two new features:
- A table with dead-reckoned balances for "oasis-sdk native" runtime balances. This is separate from Warren's work on runtime balances, which tracks ERC-20 tokens and is limited to runtimes using the `evm` module. This PR is for runtimes using the `accounts` module, which so far is all of them.
- Expands logged runtime events  (transfers, burns, mints) to include the denomination, which we completely ignored so far. Right now all runtimes only have a single denomination (ROSE or TEST), but it would be painful to expand the APIs later.