### PR TITLE
api: Implement missing/empty fields for MVP

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -373,6 +373,7 @@ func (m *Main) queueBlockInserts(batch *storage.QueryBatch, data *storage.Consen
 		data.BlockHeader.Height,
 		data.BlockHeader.Hash.Hex(),
 		data.BlockHeader.Time.UTC(),
+		len(data.Transactions),
 		data.BlockHeader.StateRoot.Namespace.String(),
 		int64(data.BlockHeader.StateRoot.Version),
 		data.BlockHeader.StateRoot.Type.String(),

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -46,8 +46,8 @@ func (qf QueryFactory) GenesisIndexingProgressQuery() string {
 
 func (qf QueryFactory) ConsensusBlockInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.blocks (height, block_hash, time, namespace, version, type, root_hash)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID)
+		INSERT INTO %s.blocks (height, block_hash, time, num_txs, namespace, version, type, root_hash)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, qf.chainID)
 }
 
 func (qf QueryFactory) ConsensusEpochInsertQuery() string {

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -411,10 +411,10 @@ func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
 
 func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_native_balances (runtime, account_address, symbol, balance)
+		INSERT INTO %[1]s.runtime_sdk_balances (runtime, account_address, symbol, balance)
 		  VALUES ('%[2]s', $1, $2, $3)
 		ON CONFLICT (runtime, account_address, symbol) DO
-		UPDATE SET balance = %[1]s.runtime_native_balances.balance + $3`, qf.chainID, qf.runtime)
+		UPDATE SET balance = %[1]s.runtime_sdk_balances.balance + $3`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1804,7 +1804,7 @@ components:
             ERC-1363 token might be labeled as ERC-20 here. If the type cannot be
             detected or is not supported, this field will be null/absent.
         total_supply:
-          type: string
+          <<: *BigIntType
           description: The total number of base units available.
         num_holders:
           type: integer

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1354,12 +1354,12 @@ components:
           description: Version of the `context`.
         address_data:
           type: string
-          format: hex
+          format: byte
           description: |
-            The hex-encoded data from which the oasis address was derived.
+            The base64-encoded data from which the oasis address was derived.
             When `context = "oasis-runtime-sdk/address: secp256k1eth"`, this
-            is the Ethereum address (without the leading `0x`). All-lowercase.
-          example: '9907a0cf64ec9fbf6ed8fd4971090de88222a9ac'
+            is the Ethereum address (in base64, not hex!).
+          example: 'INLp2Ih3YIdcA+zFNhM+SIGyFgKsYYc9SKQeKRKe2uI='
 
     RuntimeName:
       description: |
@@ -1394,7 +1394,7 @@ components:
 
     Account:
       type: object
-      required: [address, address_preimage, nonce, runtime_balances, available, escrow, debonding, delegations_balance, debonding_delegations_balance, allowances]
+      required: [address, nonce, available, escrow, debonding, allowances]
       properties:
         address:
           type: string
@@ -1407,9 +1407,11 @@ components:
           format: int64
           description: A nonce used to prevent replay.
           example: 0
-        # TODO: limit this to 1000 entries. If folks have more,
-        # we can eventually open up a separate, paginable endpoint just for balances.
         runtime_balances:
+          description: |
+            The balances of this account in various denominations in each runtime.
+            NOTE 1: This field is omitted for efficiency when listing multiple accounts.
+            NOTE 2: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
           type: array
           items:
             $ref: '#/components/schemas/RuntimeBalance'
@@ -1424,10 +1426,14 @@ components:
           description: The debonding escrow balance, in base units.
         delegations_balance:
           <<: *BigIntType
-          description: The delegations balance, in base units.
+          description: |
+            The delegations balance, in base units.
+            For efficiency, this field is omitted when listing multiple-accounts.
         debonding_delegations_balance:
           <<: *BigIntType
-          description: The debonding delegations balance, in base units.
+          description: |
+            The debonding delegations balance, in base units.
+            For efficiency, this field is omitted when listing multiple-accounts.
           example: 10000000000
         allowances:
           type: array
@@ -1504,7 +1510,7 @@ components:
         runtime_committee_protocol:
           type: string
       description: The target propotocol versions for this upgrade proposal.
-      
+
     Proposal:
       type: object
       # TODO: Revise required fields. Most fields are required for actual proposals, and only absent

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1371,26 +1371,30 @@ components:
       example: emerald
 
     RuntimeBalance:
-      description: Balance of an account in a runtime.
+      description: Balances of an account in runtimes.
       type: object
-      required: [amount, runtime, token_id, token_symbol]
+      required: [balance, runtime, token_id, token_symbol]
       properties:
-        amount:
+        balance:
           <<: *BigIntType
-          description: Number of base units held; as a string.
+          description: Number of tokens held; as a string.
         runtime:
           $ref: "#/components/schemas/RuntimeName"
         # TODO:
         # - How do we handle NFTs? Add another field?
-        # - We do not handle non-native tokens from the `accounts` SDK module. The plan is to use
-        #   their denomination name for both `token_id` and `token_symbol`, or update the SDK to have tickers.
         token_id:
           x-go-name: TokenID
           type: string
-          description: Unique identifier for the token. For EVM tokens, this is their eth address.
+          description: |
+            Unique identifier for the token. For EVM tokens, this is their eth address.
+            For oasis-native tokens (see token_type), this is a string of the form
+            `"oasis-sdk:<token_symbol>"`.
         token_symbol:
           type: string
-          description: The token ticker symbol. Not guaranteed to be unique across distinct tokens.
+          description: The token ticker symbol. Not guaranteed to be unique across distinct EVM tokens.
+        token_type:
+          $ref: "#/components/schemas/RuntimeTokenType"
+
 
     Account:
       type: object
@@ -1746,13 +1750,18 @@ components:
       description: |
         A runtime transaction.
 
-    EvmTokenType:
+    RuntimeTokenType:
       type: string
       enum:
         - ERC20
         - ERC721
         - ERC1155
-
+        - OasisSdk
+      description: |
+        The type of a Runtime token. Values starting with "ERC" represent the corresponding
+        EVM token. "OasisSdk" represents a runtime token tracked by the oasis-sdk `accounts`
+        module, i.e. the recommended way for runtimes to track account balances.
+        In EVM runtimes, typically ROSE is the only OasisSdk token.
     RuntimeTokenList:
       type: object
       required: [tokens]
@@ -1788,7 +1797,7 @@ components:
             Affects display only. Often equals 18, to match ETH.
           example: 18
         type:
-          $ref: '#/components/schemas/EvmTokenType'
+          $ref: '#/components/schemas/RuntimeTokenType'
           description: |
             The heuristically determined interface that the token contract implements.
             A less specialized variant of the token might be detected; for example, an

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1653,13 +1653,18 @@ components:
     RuntimeTransaction:
       type: object
       # NOTE: Not guaranteed to be present: eth_hash, to, amount.
-      required: [round, timestamp, hash, sender_0, nonce_0, fee, gas_limit, method, body, success]
+      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, gas_limit, method, body, success]
       properties:
         round:
           type: integer
           format: int64
           description: The block round at which this transaction was executed.
           example: 3379702
+        index:
+          type: integer
+          format: int64
+          description: The 0-based index of this transaction in the block.
+          example: 0
         timestamp:
           type: string
           format: date-time

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1372,7 +1372,7 @@ components:
     RuntimeSdkBalance:
       description: Balance of an account for a specific runtime and oasis-sdk token (e.g. ROSE).
       type: object
-      required: [balance, runtime, token_symbol]
+      required: [balance, runtime, token_symbol, token_decimals]
       properties:
         balance:
           <<: *BigIntType
@@ -1383,11 +1383,15 @@ components:
           type: string
           description: The token ticker symbol. Unique across all oasis-sdk tokens in the same runtime.
           example: ROSE
+        token_decimals:
+          type: integer
+          description: The number of decimals of precision for this token.
+          example: 18
 
     RuntimeEvmBalance:
       description: Balance of an account for a specific runtime and EVM token.
       type: object
-      required: [balance, runtime, token_contract_addr]
+      required: [balance, runtime, token_contract_addr, token_decimals]
       properties:
         balance:
           <<: *BigIntType
@@ -1406,6 +1410,10 @@ components:
           description: The name of the token. Not guaranteed to be unique across distinct EVM tokens.
         token_type:
           $ref: "#/components/schemas/EvmTokenType"
+        token_decimals:
+          type: integer
+          description: The number of decimals of precision for this token.
+          example: 18
 
     Account:
       type: object

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1775,12 +1775,16 @@ components:
 
     EvmToken:
       type: object
-      required: [contract_addr, num_holders, type]
+      required: [contract_addr, evm_contract_addr, num_holders, type]
       properties:
         contract_addr:
           type: string
           description: The Oasis address of this token's contract.
           example: 'oasis1qp2hssandc7dekjdr6ygmtzt783k3gn38uupdeys'
+        evm_contract_addr:
+          type: string
+          description: The EVM address of this token's contract. Encoded as a lowercase hex string.
+          example: 'dc19a122e268128b5ee20366299fc7b5b199c8e3'
         name:
           type: string
           description: Name of the token, as provided by token contract's `name()` method.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1369,31 +1369,43 @@ components:
         - emerald
       example: emerald
 
-    RuntimeBalance:
-      description: Balances of an account in runtimes.
+    RuntimeSdkBalance:
+      description: Balance of an account for a specific runtime and oasis-sdk token (e.g. ROSE).
       type: object
-      required: [balance, runtime, token_id, token_symbol]
+      required: [balance, runtime, token_symbol]
       properties:
         balance:
           <<: *BigIntType
-          description: Number of tokens held; as a string.
+          description: Number of tokens held, in base units.
         runtime:
           $ref: "#/components/schemas/RuntimeName"
-        # TODO:
-        # - How do we handle NFTs? Add another field?
-        token_id:
-          x-go-name: TokenID
+        token_symbol:
           type: string
-          description: |
-            Unique identifier for the token. For EVM tokens, this is their eth address.
-            For oasis-native tokens (see token_type), this is a string of the form
-            `"oasis-sdk:<token_symbol>"`.
+          description: The token ticker symbol. Unique across all oasis-sdk tokens in the same runtime.
+          example: ROSE
+
+    RuntimeEvmBalance:
+      description: Balance of an account for a specific runtime and EVM token.
+      type: object
+      required: [balance, runtime, token_contract_addr]
+      properties:
+        balance:
+          <<: *BigIntType
+          description: Number of tokens held, in base units.
+        runtime:
+          $ref: "#/components/schemas/RuntimeName"
+        token_contract_addr:
+          type: string
+          description: The EVM address of this token's contract. Encoded as a lowercase hex string.
+          example: 'dc19a122e268128b5ee20366299fc7b5b199c8e3'
         token_symbol:
           type: string
           description: The token ticker symbol. Not guaranteed to be unique across distinct EVM tokens.
+        token_name:
+          type: string
+          description: The name of the token. Not guaranteed to be unique across distinct EVM tokens.
         token_type:
-          $ref: "#/components/schemas/RuntimeTokenType"
-
+          $ref: "#/components/schemas/EvmTokenType"
 
     Account:
       type: object
@@ -1410,14 +1422,22 @@ components:
           format: int64
           description: A nonce used to prevent replay.
           example: 0
-        runtime_balances:
+        runtime_sdk_balances:
           description: |
-            The balances of this account in various denominations in each runtime.
+            The balances of this account in each runtime, as managed by oasis-sdk.
             NOTE 1: This field is omitted for efficiency when listing multiple accounts.
             NOTE 2: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
           type: array
           items:
-            $ref: '#/components/schemas/RuntimeBalance'
+            $ref: '#/components/schemas/RuntimeSdkBalance'
+        runtime_evm_balances:
+          description: |
+            The balances of this account in each runtime, as managed by EVM smart contracts (notably, ERC-20).
+            NOTE 1: This field is omitted for efficiency when listing multiple accounts.
+            NOTE 2: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeEvmBalance'
         available:
           <<: *BigIntType
           description: The available balance, in base units.
@@ -1749,7 +1769,7 @@ components:
       description: |
         A runtime transaction.
 
-    RuntimeTokenType:
+    EvmTokenType:
       type: string
       enum:
         - ERC20
@@ -1757,10 +1777,7 @@ components:
         - ERC1155
         - OasisSdk
       description: |
-        The type of a Runtime token. Values starting with "ERC" represent the corresponding
-        EVM token. "OasisSdk" represents a runtime token tracked by the oasis-sdk `accounts`
-        module, i.e. the recommended way for runtimes to track account balances.
-        In EVM runtimes, typically ROSE is the only OasisSdk token.
+        The type of a EVM token.
 
     EvmTokenList:
       type: object
@@ -1801,7 +1818,7 @@ components:
             Affects display only. Often equals 18, to match ETH.
           example: 18
         type:
-          $ref: '#/components/schemas/RuntimeTokenType'
+          $ref: '#/components/schemas/EvmTokenType'
           description: |
             The heuristically determined interface that the token contract implements.
             A less specialized variant of the token might be detected; for example, an

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -788,20 +788,19 @@ paths:
                 $ref: '#/components/schemas/RuntimeTransaction'
         <<: *common_error_responses
 
-  /emerald/tokens:
+  /emerald/evm_tokens:
     get:
-      summary: Returns a list of ERC-20 tokens on Emerald.
+      summary: Returns a list of EVM (ERC-20, ...) tokens on Emerald.
       parameters:
         - *limit
         - *offset
       responses:
         '200':
-          description: |
-            A JSON object containing a list of ERC-20 tokens on Emerald.
+          description: The requested tokens.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/RuntimeTokenList'
+                $ref: '#/components/schemas/EvmTokenList'
         <<: *common_error_responses
 
   /{layer}/stats/tx_volume:
@@ -1762,18 +1761,19 @@ components:
         EVM token. "OasisSdk" represents a runtime token tracked by the oasis-sdk `accounts`
         module, i.e. the recommended way for runtimes to track account balances.
         In EVM runtimes, typically ROSE is the only OasisSdk token.
-    RuntimeTokenList:
+
+    EvmTokenList:
       type: object
-      required: [tokens]
+      required: [evm_tokens]
       properties:
-        tokens:
+        evm_tokens:
           type: array
           items:
-            $ref: '#/components/schemas/RuntimeToken'
-      description: |
-        A list of ERC-20 tokens on a runtime.
+            $ref: '#/components/schemas/EvmToken'
+          description: A list of L2 EVM tokens (ERC-20, ERC-271, ...).
+      description: A list of tokens in a runtime.
 
-    RuntimeToken:
+    EvmToken:
       type: object
       required: [contract_addr, num_holders, type]
       properties:
@@ -1788,7 +1788,7 @@ components:
         symbol:
           type: string
           description: Symbol of the token, as provided by token contract's `symbol()` method.
-          example: UNI
+          example: USDT
         decimals:
           type: integer
           description: |

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -37,6 +37,7 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 	}
 	apiTransaction := apiTypes.RuntimeTransaction{
 		Round:   storageTransaction.Round,
+		Index:   storageTransaction.Index,
 		Hash:    storageTransaction.Hash,
 		EthHash: storageTransaction.EthHash,
 		// TODO: Get timestamp from that round's block

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -227,12 +227,12 @@ func (srv *StrictServerImpl) GetEmeraldBlocks(ctx context.Context, request apiTy
 	return apiTypes.GetEmeraldBlocks200JSONResponse(*blocks), nil
 }
 
-func (srv *StrictServerImpl) GetEmeraldTokens(ctx context.Context, request apiTypes.GetEmeraldTokensRequestObject) (apiTypes.GetEmeraldTokensResponseObject, error) {
+func (srv *StrictServerImpl) GetEmeraldEvmTokens(ctx context.Context, request apiTypes.GetEmeraldEvmTokensRequestObject) (apiTypes.GetEmeraldEvmTokensResponseObject, error) {
 	tokens, err := srv.dbClient.RuntimeTokens(ctx, request.Params)
 	if err != nil {
 		return nil, err
 	}
-	return apiTypes.GetEmeraldTokens200JSONResponse(*tokens), nil
+	return apiTypes.GetEmeraldEvmTokens200JSONResponse(*tokens), nil
 }
 
 func (srv *StrictServerImpl) GetEmeraldTransactions(ctx context.Context, request apiTypes.GetEmeraldTransactionsRequestObject) (apiTypes.GetEmeraldTransactionsResponseObject, error) {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -790,6 +790,10 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 	for runtimeSdkRows.Next() {
 		b := RuntimeSdkBalance{
 			Runtime: "emerald",
+			// HACK: 18 is accurate for Emerald and Sapphire, but Cipher has 9.
+			// Once we add a non-18-decimals runtime, we'll need to query the runtime for this
+			// at analysis time and store it in a table, similar to how we store the EVM token metadata.
+			TokenDecimals: 18,
 		}
 		var balanceNum pgtype.Numeric
 		if err := runtimeSdkRows.Scan(
@@ -827,6 +831,7 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 			&b.TokenSymbol,
 			&b.TokenName,
 			&b.TokenType,
+			&b.TokenDecimals,
 		); err != nil {
 			return nil, apiCommon.ErrStorageError
 		}

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1511,11 +1511,24 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 	}
 	for rows.Next() {
 		var t RuntimeToken
+		var totalSupplyNum pgtype.Numeric
 		if err2 := rows.Scan(
 			&t.ContractAddr,
+			&t.Name,
+			&t.Symbol,
+			&t.Decimals,
+			&totalSupplyNum,
+			&t.Type,
 			&t.NumHolders,
 		); err2 != nil {
 			return nil, apiCommon.ErrStorageError
+		}
+		if totalSupplyNum.Status == pgtype.Present {
+			t.TotalSupply = &common.BigInt{}
+			*t.TotalSupply, err = c.numericToBigInt(ctx, &totalSupplyNum)
+			if err != nil {
+				return nil, apiCommon.ErrStorageError
+			}
 		}
 
 		ts.Tokens = append(ts.Tokens, t)

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1480,7 +1480,7 @@ func (c *StorageClient) RuntimeTransaction(ctx context.Context, txHash string) (
 	return &t, nil
 }
 
-func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmeraldTokensParams) (*RuntimeTokenList, error) {
+func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmeraldEvmTokensParams) (*EvmTokenList, error) {
 	cid, ok := ctx.Value(common.ChainIDContextKey).(string)
 	if !ok {
 		return nil, apiCommon.ErrBadChainID
@@ -1493,7 +1493,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 
 	rows, err := c.db.Query(
 		ctx,
-		qf.RuntimeTokensQuery(),
+		qf.EvmTokensQuery(),
 		p.Limit,
 		p.Offset,
 	)
@@ -1506,11 +1506,11 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 	}
 	defer rows.Close()
 
-	ts := RuntimeTokenList{
-		Tokens: []RuntimeToken{},
+	ts := EvmTokenList{
+		EvmTokens: []EvmToken{},
 	}
 	for rows.Next() {
-		var t RuntimeToken
+		var t EvmToken
 		var totalSupplyNum pgtype.Numeric
 		if err2 := rows.Scan(
 			&t.ContractAddr,
@@ -1531,7 +1531,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 			}
 		}
 
-		ts.Tokens = append(ts.Tokens, t)
+		ts.EvmTokens = append(ts.EvmTokens, t)
 	}
 
 	return &ts, nil

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -168,7 +168,7 @@ func (c *StorageClient) Blocks(ctx context.Context, r apiTypes.GetConsensusBlock
 	}
 	for rows.Next() {
 		var b Block
-		if err := rows.Scan(&b.Height, &b.Hash, &b.Timestamp); err != nil {
+		if err := rows.Scan(&b.Height, &b.Hash, &b.Timestamp, &b.NumTransactions); err != nil {
 			c.logger.Info("row scan failed",
 				"request_id", ctx.Value(common.RequestIDContextKey),
 				"err", err.Error(),
@@ -202,7 +202,7 @@ func (c *StorageClient) Block(ctx context.Context, height int64) (*Block, error)
 		ctx,
 		qf.BlockQuery(),
 		height,
-	).Scan(&b.Height, &b.Hash, &b.Timestamp); err != nil {
+	).Scan(&b.Height, &b.Hash, &b.Timestamp, &b.NumTransactions); err != nil {
 		c.logger.Info("row scan failed",
 			"request_id", ctx.Value(common.RequestIDContextKey),
 			"err", err.Error(),

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -259,6 +259,7 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 		var feeNum pgtype.Numeric
 		if err := rows.Scan(
 			&t.Block,
+			&t.Index,
 			&t.Hash,
 			&t.Sender,
 			&t.Nonce,
@@ -266,6 +267,7 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 			&t.Method,
 			&t.Body,
 			&code,
+			&t.Timestamp,
 		); err != nil {
 			c.logger.Info("row scan failed",
 				"request_id", ctx.Value(common.RequestIDContextKey),
@@ -311,6 +313,7 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 		txHash,
 	).Scan(
 		&t.Block,
+		&t.Index,
 		&t.Hash,
 		&t.Sender,
 		&t.Nonce,
@@ -318,6 +321,7 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 		&t.Method,
 		&t.Body,
 		&code,
+		&t.Timestamp,
 	); err != nil {
 		c.logger.Info("row scan failed",
 			"request_id", ctx.Value(common.RequestIDContextKey),

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -730,6 +730,7 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 		// but it's still valid, and it might have balances in the runtimes.
 		// Leave the consensus-specific info initialized to defaults.
 		a.Address = address.String()
+		a.AddressPreimage = nil
 	} else {
 		return nil, apiCommon.ErrStorageError
 	}

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1514,6 +1514,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 		var totalSupplyNum pgtype.Numeric
 		if err2 := rows.Scan(
 			&t.ContractAddr,
+			&t.EvmContractAddr,
 			&t.Name,
 			&t.Symbol,
 			&t.Decimals,

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -46,14 +46,17 @@ func (qf QueryFactory) TransactionsQuery() string {
 	return fmt.Sprintf(`
 		SELECT 
 				%[1]s.transactions.block as block,
+				%[1]s.transactions.tx_index as tx_index,
 				%[1]s.transactions.tx_hash as tx_hash,
 				%[1]s.transactions.sender as sender,
 				%[1]s.transactions.nonce as nonce,
 				%[1]s.transactions.fee_amount as fee_amount,
 				%[1]s.transactions.method as method,
 				%[1]s.transactions.body as body,
-				%[1]s.transactions.code as code
+				%[1]s.transactions.code as code,
+				%[1]s.blocks.time as time
 			FROM %[1]s.transactions
+			JOIN %[1]s.blocks ON %[1]s.transactions.block = %[1]s.blocks.height
 			LEFT JOIN %[1]s.accounts_related_transactions ON %[1]s.transactions.block = %[1]s.accounts_related_transactions.tx_block 
 				AND %[1]s.transactions.tx_index = %[1]s.accounts_related_transactions.tx_index
 				-- When related_address ($4) is NULL and hence we do no filtering on it, avoid the join altogether.
@@ -73,8 +76,9 @@ func (qf QueryFactory) TransactionsQuery() string {
 
 func (qf QueryFactory) TransactionQuery() string {
 	return fmt.Sprintf(`
-		SELECT block, tx_hash, sender, nonce, fee_amount, method, body, code
-			FROM %s.transactions
+		SELECT block, tx_index, tx_hash, sender, nonce, fee_amount, method, body, code, %[1]s.blocks.time
+			FROM %[1]s.transactions
+			JOIN %[1]s.blocks ON %[1]s.transactions.block = %[1]s.blocks.height
 			WHERE tx_hash = $1::text`, qf.chainID)
 }
 

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -411,7 +411,8 @@ func (qf QueryFactory) AccountRuntimeEvmBalancesQuery() string {
 			%[1]s.%[2]s_token_balances.token_address AS token_address,
 			%[1]s.%[2]s_tokens.symbol AS token_symbol,
 			%[1]s.%[2]s_tokens.symbol AS token_name,
-			'ERC20' AS token_type  -- TODO: fetch from the table once available
+			'ERC20' AS token_type,  -- TODO: fetch from the table once available
+			%[1]s.%[2]s_tokens.decimals AS token_decimals
 		FROM %[1]s.%[2]s_token_balances
 		JOIN %[1]s.%[2]s_tokens USING (token_address)
 		WHERE account_address = $1::text

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -24,7 +24,7 @@ func (qf QueryFactory) StatusQuery() string {
 
 func (qf QueryFactory) BlocksQuery() string {
 	return fmt.Sprintf(`
-		SELECT height, block_hash, time
+		SELECT height, block_hash, time, num_txs
 			FROM %s.blocks
 			WHERE ($1::bigint IS NULL OR height >= $1::bigint) AND
 						($2::bigint IS NULL OR height <= $2::bigint) AND
@@ -37,7 +37,7 @@ func (qf QueryFactory) BlocksQuery() string {
 
 func (qf QueryFactory) BlockQuery() string {
 	return fmt.Sprintf(`
-		SELECT height, block_hash, time
+		SELECT height, block_hash, time, num_txs
 			FROM %s.blocks
 			WHERE height = $1::bigint`, qf.chainID)
 }

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -366,7 +366,7 @@ func (qf QueryFactory) RuntimeTransactionsQuery() string {
 		OFFSET $4::bigint`, qf.chainID, qf.runtime)
 }
 
-func (qf QueryFactory) RuntimeTokensQuery() string {
+func (qf QueryFactory) EvmTokensQuery() string {
 	return fmt.Sprintf(`
 		WITH token_holders AS (
 			SELECT token_address, COUNT(*) AS cnt

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -48,6 +48,7 @@ type Account = api.Account
 type (
 	AddressPreimage          = api.AddressPreimage
 	AddressDerivationContext = api.AddressDerivationContext
+	RuntimeBalance           = api.RuntimeBalance
 )
 
 // DebondingDelegationList is the storage response for ListDebondingDelegations.

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -48,7 +48,8 @@ type Account = api.Account
 type (
 	AddressPreimage          = api.AddressPreimage
 	AddressDerivationContext = api.AddressDerivationContext
-	RuntimeBalance           = api.RuntimeBalance
+	RuntimeSdkBalance        = api.RuntimeSdkBalance
+	RuntimeEvmBalance        = api.RuntimeEvmBalance
 )
 
 // DebondingDelegationList is the storage response for ListDebondingDelegations.

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -44,6 +44,12 @@ type AccountList = api.AccountList
 // Account is the storage response for GetAccount.
 type Account = api.Account
 
+// Types that are a part of the storage response for GetAccount.
+type (
+	AddressPreimage          = api.AddressPreimage
+	AddressDerivationContext = api.AddressDerivationContext
+)
+
 // DebondingDelegationList is the storage response for ListDebondingDelegations.
 type DebondingDelegationList = api.DebondingDelegationList
 

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -120,9 +120,9 @@ type RuntimeTransaction struct {
 	ResultRaw []byte
 }
 
-type RuntimeTokenList = api.RuntimeTokenList
+type EvmTokenList = api.EvmTokenList
 
-type RuntimeToken = api.RuntimeToken
+type EvmToken = api.EvmToken
 
 // TxVolumeList is the storage response for GetVolumes.
 type TxVolumeList = api.TxVolumeList

--- a/storage/migrations/01_oasis_3_consensus.up.sql
+++ b/storage/migrations/01_oasis_3_consensus.up.sql
@@ -22,6 +22,7 @@ CREATE TABLE oasis_3.blocks
   height     UINT63 PRIMARY KEY,
   block_hash HEX64 NOT NULL,
   time       TIMESTAMP WITH TIME ZONE NOT NULL,
+  num_txs    UINT31 NOT NULL,
 
   -- State Root Info
   namespace TEXT NOT NULL,

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -98,7 +98,7 @@ CREATE TABLE oasis_3.emerald_token_balances
 (
   token_address oasis_addr NOT NULL,
   account_address oasis_addr NOT NULL,
-  balance NUMERIC(1000,0) NOT NULL,
+  balance NUMERIC(1000,0) NOT NULL,  -- TODO: Use UINT_NUMERIC once we are processing Emerald from round 0.
   PRIMARY KEY (token_address, account_address)
 );
 CREATE INDEX ix_emerald_token_address ON oasis_3.emerald_token_balances (token_address) WHERE balance != 0;
@@ -107,6 +107,7 @@ CREATE TABLE oasis_3.emerald_tokens
 (
   token_address oasis_addr PRIMARY KEY,
   token_name TEXT,
+  -- TODO: Add token type (ERC20, ERC721, etc.). See RuntimeTokenType enum
   symbol TEXT,
   decimals INT,
   total_supply uint_numeric
@@ -117,7 +118,7 @@ CREATE TABLE oasis_3.emerald_gas_used
 (
   round  UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
   sender oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
-  amount NUMERIC NOT NULL
+  amount UINT_NUMERIC NOT NULL
 );
 
 CREATE INDEX ix_emerald_gas_used_sender ON oasis_3.emerald_gas_used(sender);

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -107,7 +107,7 @@ CREATE TABLE oasis_3.emerald_tokens
 (
   token_address oasis_addr PRIMARY KEY,
   token_name TEXT,
-  -- TODO: Add token type (ERC20, ERC721, etc.). See RuntimeTokenType enum
+  -- TODO: Add token type (ERC20, ERC721, etc.). See EvmTokenType enum
   symbol TEXT,
   decimals INT,
   total_supply uint_numeric
@@ -199,7 +199,7 @@ CREATE INDEX ix_emerald_withdraws_sender ON oasis_3.emerald_withdraws(sender);
 CREATE INDEX ix_emerald_withdraws_receiver ON oasis_3.emerald_withdraws(receiver);
 
 -- Balance of the oasis-sdk native tokens (notably ROSE) in paratimes.
-CREATE TABLE oasis_3.runtime_native_balances (
+CREATE TABLE oasis_3.runtime_sdk_balances (
   runtime TEXT,  -- 'emerald' | 'sapphire'
   account_address oasis_addr,
   symbol   TEXT NOT NULL,  -- called `Denomination` in the SDK

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -103,11 +103,17 @@ func TestIndexer(t *testing.T) {
 		t.Errorf("account funding failure: %v", err)
 	}
 
-	// Bob account does not exist
+	// Bob account "does not exist". Technically, every valid account exists, but it has no balance or activity.
 	var account storage.Account
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
-	require.Empty(t, account.Address)
+	require.Equal(t, account.Address, bobAddress.String())
+	require.Nil(t, account.AddressPreimage)
+	require.Zero(t, account.Nonce)
+	require.Zero(t, account.Available)
+	require.Zero(t, *account.DelegationsBalance)
+	require.Zero(t, *account.DebondingDelegationsBalance)
+	require.Zero(t, account.Escrow)
 
 	// Transfer to Bob account
 	if err := bw.TransferFunds(ctx, aliceAccount, bobAddress, 100000000); err != nil {
@@ -145,7 +151,7 @@ func TestIndexer(t *testing.T) {
 	require.Nil(t, err)
 	expectedDelegationsBalance := common.NewBigInt(25000000)
 	expectedAvailable := common.NewBigInt(75000000)
-	require.Equal(t, expectedDelegationsBalance, account.DelegationsBalance)
+	require.Equal(t, expectedDelegationsBalance, *account.DelegationsBalance)
 	require.Equal(t, expectedAvailable, account.Available)
 
 	// Alice account has correct escrow balance


### PR DESCRIPTION
Resolves #256 

Implements all the fields that were added to the API in #247.

Most of the fields were straightforward, except for runtime balances. Changes introduced there:
- Spin-off PR #288 to implement tracking of oasis-sdk balances in runtimes
- Moved `/emerald/tokens` to `/emerald/evm_tokens`; the former should be reserved for oasis-sdk tokens (currently only ROSE); internally renamed `RuntimeToken`->`EvmToken`
- Expanded `/consensus/account` to return the balances across all paratimes, simultaneously for oasis-sdk tokens and EVM tokens.

The last two points are not entirely coherent with each other: one splits the two kinds of tokens across two different URLs, while the other one unifies them. Both approaches have pluses and minuses; in the end, I decided for this combo because I think it best mirrors what the frontend needs, and we can always add endpoints that slice and dice and present (almost) the same information slightly differently.

I recommend reviewing commit by commit, as many of them are boilerplate.