### PR TITLE
api: Support CORS

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/metrics"
+	"github.com/rs/cors"
 )
 
 var (
@@ -249,3 +250,16 @@ func RuntimeFromURLMiddleware(baseURL string) func(next http.Handler) http.Handl
 		})
 	}
 }
+
+// CorsMiddleware is a restrictive CORS middleware that only allows GET requests.
+//
+// NOTE: To support other methods (e.g. POST), we'd also need to support OPTIONS
+// preflight requests, in which case this would have to be the outermost handler
+// to run; the openapi-generated handler will reject OPTIONS requests because
+// they are not in the openapi spec.
+var CorsMiddleware func(http.Handler) http.Handler = cors.New(cors.Options{
+	AllowedMethods: []string{
+		http.MethodGet,
+	},
+	AllowCredentials: false,
+}).Handler

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -150,6 +150,7 @@ func (s *Service) Start() {
 			Middlewares: []apiTypes.MiddlewareFunc{
 				api.ChainMiddleware(s.chainID),
 				api.RuntimeFromURLMiddleware(v1BaseURL),
+				api.CorsMiddleware,
 			},
 			BaseRouter:       staticFileRouter,
 			ErrorHandlerFunc: api.HumanReadableJsonErrorHandler,

--- a/go.mod
+++ b/go.mod
@@ -142,5 +142,6 @@ require (
 	github.com/deepmap/oapi-codegen v1.12.4
 	github.com/jackc/pgtype v1.11.0
 	github.com/oasisprotocol/metadata-registry-tools v0.0.0-20220406100644-7e9a2b991920
+	github.com/rs/cors v1.8.3
 	golang.org/x/crypto v0.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1258,6 +1258,8 @@ github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rs/cors v1.8.3 h1:O+qNyWn7Z+F9M0ILBHgMVPuB1xTOucVd5gtaYyXBpRo=
+github.com/rs/cors v1.8.3/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=


### PR DESCRIPTION
Resolves #249

@lukaw3d if you're willing to test the frontend against this branch, the following should bring up a functional API server (backed by an empty DB):
```
make postgres
make oasis-indexer && ./oasis-indexer --config=config/local-dev.yml serve
```

Sample output:
```
$ curl -i -H 'Origin: example.com' 'localhost:8008/v1/consensus/blocks?limit=1'
HTTP/1.1 200 OK
Access-Control-Allow-Origin: *
Content-Type: application/json
Vary: Origin
Date: Mon, 23 Jan 2023 12:48:57 GMT
Content-Length: 162

...
```