### PR TITLE
Generalize emerald tables to multiple runtimes 

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -432,17 +432,17 @@ func (qf QueryFactory) AddressPreimageInsertQuery() string {
 
 func (qf QueryFactory) RuntimeEvmBalanceUpdateQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %[1]s.%[2]s_token_balances (token_address, account_address, balance)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (token_address, account_address) DO
-			UPDATE SET balance = %[1]s.%[2]s_token_balances.balance + $3`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.evm_token_balances (runtime, token_address, account_address, balance)
+			VALUES ('%[2]s', $1, $2, $3)
+		ON CONFLICT (runtime, token_address, account_address) DO
+			UPDATE SET balance = %[1]s.evm_token_balances.balance + $3`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTokenUpdateQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_tokens (token_address, token_name, symbol, decimals, total_supply)
-			VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (token_address) DO
+		INSERT INTO %[1]s.evm_tokens (runtime, token_address, token_name, symbol, decimals, total_supply)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5)
+		ON CONFLICT (runtime, token_address) DO
 			UPDATE SET
 				token_name = excluded.token_name,
 				symbol = excluded.symbol,

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -419,8 +419,8 @@ func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {
 
 func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_gas_used (round, sender, amount)
-			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_gas_used (runtime, round, sender, amount)
+			VALUES ('%[2]s', $1, $2, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) AddressPreimageInsertQuery() string {

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -363,14 +363,14 @@ func (qf QueryFactory) RuntimeBlockInsertQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionSignerInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transaction_signers (round, tx_index, signer_index, signer_address, nonce)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transaction_signers (runtime, round, tx_index, signer_index, signer_address, nonce)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_related_transactions (account_address, tx_round, tx_index)
-			VALUES ($1, $2, $3)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
+			VALUES ('%[2]s', $1, $2, $3)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -357,8 +357,8 @@ func (qf QueryFactory) ConsensusVoteInsertQuery() string {
 
 func (qf QueryFactory) RuntimeBlockInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_rounds (round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID, qf.runtime)
+		INSERT INTO %s.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
+			VALUES ('%s', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransactionSignerInsertQuery() string {

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -381,32 +381,32 @@ func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
-			VALUES ($1, NULL, $2, $3, $4)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ('%[2]s', $1, NULL, $2, $3, $4)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeBurnInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
-			VALUES ($1, $2, NULL, $3, $4)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ('%[2]s', $1, $2, NULL, $3, $4)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeTransferInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transfers (round, sender, receiver, symbol, amount)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeDepositInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_deposits (round, sender, receiver, amount, nonce, module, code)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_deposits (runtime, round, sender, receiver, amount, nonce, module, code)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_withdraws (round, sender, receiver, amount, nonce, module, code)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_withdraws (runtime, round, sender, receiver, amount, nonce, module, code)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -375,8 +375,8 @@ func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %s.%s_transactions (round, tx_index, tx_hash, tx_eth_hash, raw, result_raw)
-			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, raw, result_raw)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -773,13 +773,9 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 	}
 
 	// Get paratime balances.
-	//
-	// XXX: This method needs to return balances across all paratimes.
-	// For now, we manually query "each" runtime in turn (= just Emerald for now).
-	// TODO: Refactor emerald tables to contain all paratimes.
 	runtimeSdkRows, queryErr := c.db.Query(
 		ctx,
-		NewQueryFactory(cid, "emerald").AccountRuntimeSdkBalancesQuery(),
+		NewQueryFactory(cid, "(ignored)").AccountRuntimeSdkBalancesQuery(),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -789,7 +785,6 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 
 	for runtimeSdkRows.Next() {
 		b := RuntimeSdkBalance{
-			Runtime: "emerald",
 			// HACK: 18 is accurate for Emerald and Sapphire, but Cipher has 9.
 			// Once we add a non-18-decimals runtime, we'll need to query the runtime for this
 			// at analysis time and store it in a table, similar to how we store the EVM token metadata.
@@ -797,6 +792,7 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 		}
 		var balanceNum pgtype.Numeric
 		if err := runtimeSdkRows.Scan(
+			&b.Runtime,
 			&balanceNum,
 			&b.TokenSymbol,
 		); err != nil {
@@ -812,7 +808,7 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 
 	runtimeEvmRows, queryErr := c.db.Query(
 		ctx,
-		NewQueryFactory(cid, "emerald").AccountRuntimeEvmBalancesQuery(),
+		NewQueryFactory(cid, "(ignored)").AccountRuntimeEvmBalancesQuery(),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -821,11 +817,10 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 	defer runtimeEvmRows.Close()
 
 	for runtimeEvmRows.Next() {
-		b := RuntimeEvmBalance{
-			Runtime: "emerald",
-		}
+		b := RuntimeEvmBalance{}
 		var balanceNum pgtype.Numeric
 		if err := runtimeEvmRows.Scan(
+			&b.Runtime,
 			&balanceNum,
 			&b.TokenContractAddr,
 			&b.TokenSymbol,

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -363,8 +363,9 @@ func (qf QueryFactory) RuntimeBlocksQuery() string {
 func (qf QueryFactory) RuntimeTransactionsQuery() string {
 	return fmt.Sprintf(`
 		SELECT round, tx_index, tx_hash, tx_eth_hash, raw, result_raw
-			FROM %s.%s_transactions
-			WHERE ($1::bigint IS NULL OR round = $1::bigint) AND
+			FROM %[1]s.runtime_transactions
+			WHERE (runtime = '%[2]s') AND
+						($1::bigint IS NULL OR round = $1::bigint) AND
 						($2::text IS NULL OR tx_hash = $2::text)
 		ORDER BY round DESC, tx_index DESC
 		LIMIT $3::bigint

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -349,8 +349,9 @@ func (qf QueryFactory) ValidatorsDataQuery() string {
 func (qf QueryFactory) RuntimeBlocksQuery() string {
 	return fmt.Sprintf(`
 		SELECT round, block_hash, timestamp, num_transactions, size, gas_used
-			FROM %s.%s_rounds
-			WHERE ($1::bigint IS NULL OR round >= $1::bigint) AND
+			FROM %[1]s.runtime_blocks
+			WHERE (runtime = '%[2]s') AND
+						($1::bigint IS NULL OR round >= $1::bigint) AND
 						($2::bigint IS NULL OR round <= $2::bigint) AND
 						($3::timestamptz IS NULL OR timestamp >= $3::timestamptz) AND
 						($4::timestamptz IS NULL OR timestamp <= $4::timestamptz)

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -114,6 +114,7 @@ func (qf QueryFactory) EntitiesQuery() string {
 	return fmt.Sprintf(`
 		SELECT id, address
 			FROM %s.entities
+		ORDER BY id
 		LIMIT $1::bigint
 		OFFSET $2::bigint`, qf.chainID)
 }
@@ -137,6 +138,7 @@ func (qf QueryFactory) EntityNodesQuery() string {
 		SELECT id, entity_id, expiration, tls_pubkey, tls_next_pubkey, p2p_pubkey, consensus_pubkey, roles
 			FROM %s.nodes
 			WHERE entity_id = $1::text
+		ORDER BY id
 		LIMIT $2::bigint
 		OFFSET $3::bigint`, qf.chainID)
 }
@@ -169,6 +171,7 @@ func (qf QueryFactory) AccountsQuery() string {
 					($6::numeric IS NULL OR escrow_balance_debonding <= $6::numeric) AND
 					($7::numeric IS NULL OR general_balance + escrow_balance_active + escrow_balance_debonding >= $7::numeric) AND
 					($8::numeric IS NULL OR general_balance + escrow_balance_active + escrow_balance_debonding <= $8::numeric)
+		ORDER BY address
 		LIMIT $9::bigint
 		OFFSET $10::bigint`, qf.chainID)
 }
@@ -214,6 +217,7 @@ func (qf QueryFactory) DelegationsQuery() string {
 			FROM %[1]s.delegations
 			JOIN %[1]s.accounts ON %[1]s.delegations.delegatee = %[1]s.accounts.address
 			WHERE delegator = $1::text
+		ORDER BY delegatee, shares
 		LIMIT $2::bigint
 		OFFSET $3::bigint`, qf.chainID)
 }

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -40,13 +40,14 @@ CREATE TABLE oasis_3.runtime_transactions
   raw         BYTEA NOT NULL,
   -- result_raw is cbor(CallResult).
   result_raw  BYTEA NOT NULL,
-  PRIMARY KEY (round, tx_index)
+  PRIMARY KEY (runtime, round, tx_index)
 );
 CREATE INDEX ix_runtime_transactions_tx_hash ON oasis_3.runtime_transactions USING hash (tx_hash);
 CREATE INDEX ix_runtime_transactions_tx_eth_hash ON oasis_3.runtime_transactions USING hash (tx_eth_hash);
 
-CREATE TABLE oasis_3.emerald_transaction_signers
+CREATE TABLE oasis_3.runtime_transaction_signers
 (
+  runtime        runtime NOT NULL,
   round          UINT63 NOT NULL,
   tx_index       UINT31 NOT NULL,
   -- Emerald processes mainly Ethereum-format transactions with only one
@@ -56,19 +57,20 @@ CREATE TABLE oasis_3.emerald_transaction_signers
   signer_index   UINT31 NOT NULL,
   signer_address oasis_addr NOT NULL,
   nonce          UINT31 NOT NULL,
-  PRIMARY KEY (round, tx_index, signer_index),
-  FOREIGN KEY (round, tx_index) REFERENCES oasis_3.runtime_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
+  PRIMARY KEY (runtime, round, tx_index, signer_index),
+  FOREIGN KEY (runtime, round, tx_index) REFERENCES oasis_3.runtime_transactions(runtime, round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX ix_emerald_transaction_signers_signer_address_signer_nonce ON oasis_3.emerald_transaction_signers (signer_address, nonce);
+CREATE INDEX ix_runtime_transaction_signers_signer_address_signer_nonce ON oasis_3.runtime_transaction_signers (signer_address, nonce);
 
-CREATE TABLE oasis_3.emerald_related_transactions
+CREATE TABLE oasis_3.runtime_related_transactions
 (
+  runtime         runtime NOT NULL,
   account_address oasis_addr NOT NULL,
   tx_round        UINT63 NOT NULL,
   tx_index        UINT31 NOT NULL,
-  FOREIGN KEY (tx_round, tx_index) REFERENCES oasis_3.runtime_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
+  FOREIGN KEY (runtime, tx_round, tx_index) REFERENCES oasis_3.runtime_transactions(runtime, round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
-CREATE INDEX ix_emerald_related_transactions_address_height_index ON oasis_3.emerald_related_transactions (account_address, tx_round, tx_index);
+CREATE INDEX ix_runtime_related_transactions_address_height_index ON oasis_3.runtime_related_transactions (account_address, tx_round, tx_index);
 
 -- Oasis addresses are derived from a derivation "context" and a piece of
 -- data, such as an ed25519 public key or an Ethereum address. The derivation

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -140,8 +140,9 @@ CREATE INDEX ix_runtime_gas_used_sender ON oasis_3.runtime_gas_used(sender);
 
 -- This table encapsulates transfers, burns, and mints (at the level of the `accounts` SDK module; NOT evm transfers).
 -- Burns are denoted by NULL as the receiver and mints are denoted by NULL as the sender.
-CREATE TABLE oasis_3.emerald_transfers
+CREATE TABLE oasis_3.runtime_transfers
 (
+  runtime  runtime NOT NULL,
   round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- Any paratime account. This almost always REFERENCES oasis_3.address_preimages(address)
   -- because the sender signed the Transfer tx and was inserted into address_preimages then.
@@ -158,14 +159,15 @@ CREATE TABLE oasis_3.emerald_transfers
 
   CHECK (NOT (sender IS NULL AND receiver IS NULL))
 );
-CREATE INDEX ix_emerald_transfers_sender ON oasis_3.emerald_transfers(sender);
-CREATE INDEX ix_emerald_transfers_receiver ON oasis_3.emerald_transfers(receiver);
+CREATE INDEX ix_runtime_transfers_sender ON oasis_3.runtime_transfers(sender);
+CREATE INDEX ix_runtime_transfers_receiver ON oasis_3.runtime_transfers(receiver);
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- Module consensusaccounts -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
 -- Deposits from the consensus layer into the paratime.
-CREATE TABLE oasis_3.emerald_deposits
+CREATE TABLE oasis_3.runtime_deposits
 (
+  runtime  runtime NOT NULL, 
   round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
   -- that consensus and paratimes can be indexed independently.
@@ -188,12 +190,13 @@ CREATE TABLE oasis_3.emerald_deposits
   module TEXT,
   code   UINT63
 );
-CREATE INDEX ix_emerald_deposits_sender ON oasis_3.emerald_deposits(sender);
-CREATE INDEX ix_emerald_deposits_receiver ON oasis_3.emerald_deposits(receiver);
+CREATE INDEX ix_runtime_deposits_sender ON oasis_3.runtime_deposits(sender);
+CREATE INDEX ix_runtime_deposits_receiver ON oasis_3.runtime_deposits(receiver);
 
 -- Withdrawals from the paratime into consensus layer.
-CREATE TABLE oasis_3.emerald_withdraws
+CREATE TABLE oasis_3.runtime_withdraws
 (
+  runtime  runtime NOT NULL,
   round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` can be any paratime address. (i.e. secp256k1eth-backed OR ed25519-backed;
   -- other are options unlikely in an EVM paratime)
@@ -209,8 +212,8 @@ CREATE TABLE oasis_3.emerald_withdraws
   module TEXT,
   code   UINT63
 );
-CREATE INDEX ix_emerald_withdraws_sender ON oasis_3.emerald_withdraws(sender);
-CREATE INDEX ix_emerald_withdraws_receiver ON oasis_3.emerald_withdraws(receiver);
+CREATE INDEX ix_runtime_withdraws_sender ON oasis_3.runtime_withdraws(sender);
+CREATE INDEX ix_runtime_withdraws_receiver ON oasis_3.runtime_withdraws(receiver);
 
 -- Balance of the oasis-sdk native tokens (notably ROSE) in paratimes.
 CREATE TABLE oasis_3.runtime_sdk_balances (

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -26,8 +26,9 @@ CREATE TABLE oasis_3.runtime_blocks
 CREATE INDEX ix_runtime_blocks_block_hash ON oasis_3.runtime_blocks USING hash (block_hash);  -- Hash indexes cannot span two colmns (runtime, block_hash). Not a problem for efficiency because block_hash is globally uniqueish.
 CREATE INDEX ix_runtime_blocks_timestamp ON oasis_3.runtime_blocks (runtime, timestamp);
 
-CREATE TABLE oasis_3.emerald_transactions
+CREATE TABLE oasis_3.runtime_transactions
 (
+  runtime     runtime NOT NULL,
   round       UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   tx_index    UINT31 NOT NULL,
   tx_hash     HEX64 NOT NULL,
@@ -41,8 +42,8 @@ CREATE TABLE oasis_3.emerald_transactions
   result_raw  BYTEA NOT NULL,
   PRIMARY KEY (round, tx_index)
 );
-CREATE INDEX ix_emerald_transactions_tx_hash ON oasis_3.emerald_transactions USING hash (tx_hash);
-CREATE INDEX ix_emerald_transactions_tx_eth_hash ON oasis_3.emerald_transactions USING hash (tx_eth_hash);
+CREATE INDEX ix_runtime_transactions_tx_hash ON oasis_3.runtime_transactions USING hash (tx_hash);
+CREATE INDEX ix_runtime_transactions_tx_eth_hash ON oasis_3.runtime_transactions USING hash (tx_eth_hash);
 
 CREATE TABLE oasis_3.emerald_transaction_signers
 (
@@ -56,7 +57,7 @@ CREATE TABLE oasis_3.emerald_transaction_signers
   signer_address oasis_addr NOT NULL,
   nonce          UINT31 NOT NULL,
   PRIMARY KEY (round, tx_index, signer_index),
-  FOREIGN KEY (round, tx_index) REFERENCES oasis_3.emerald_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
+  FOREIGN KEY (round, tx_index) REFERENCES oasis_3.runtime_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
 CREATE INDEX ix_emerald_transaction_signers_signer_address_signer_nonce ON oasis_3.emerald_transaction_signers (signer_address, nonce);
 
@@ -65,7 +66,7 @@ CREATE TABLE oasis_3.emerald_related_transactions
   account_address oasis_addr NOT NULL,
   tx_round        UINT63 NOT NULL,
   tx_index        UINT31 NOT NULL,
-  FOREIGN KEY (tx_round, tx_index) REFERENCES oasis_3.emerald_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
+  FOREIGN KEY (tx_round, tx_index) REFERENCES oasis_3.runtime_transactions(round, tx_index) DEFERRABLE INITIALLY DEFERRED
 );
 CREATE INDEX ix_emerald_related_transactions_address_height_index ON oasis_3.emerald_related_transactions (account_address, tx_round, tx_index);
 

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -102,18 +102,21 @@ CREATE TABLE oasis_3.address_preimages
 
 -- -- -- -- -- -- -- -- -- -- -- -- -- Module evm -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
-CREATE TABLE oasis_3.emerald_token_balances
+CREATE TABLE oasis_3.evm_token_balances
 (
+  runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
   account_address oasis_addr NOT NULL,
-  balance NUMERIC(1000,0) NOT NULL,  -- TODO: Use UINT_NUMERIC once we are processing Emerald from round 0.
-  PRIMARY KEY (token_address, account_address)
+  PRIMARY KEY (runtime, token_address, account_address),
+  balance NUMERIC(1000,0) NOT NULL  -- TODO: Use UINT_NUMERIC once we are processing Emerald from round 0.
 );
-CREATE INDEX ix_emerald_token_address ON oasis_3.emerald_token_balances (token_address) WHERE balance != 0;
+CREATE INDEX ix_emerald_token_address ON oasis_3.evm_token_balances (token_address) WHERE balance != 0;
 
-CREATE TABLE oasis_3.emerald_tokens
+CREATE TABLE oasis_3.evm_tokens
 (
-  token_address oasis_addr PRIMARY KEY,
+  runtime runtime NOT NULL,
+  token_address oasis_addr,
+  PRIMARY KEY (runtime, token_address),
   token_name TEXT,
   -- TODO: Add token type (ERC20, ERC721, etc.). See EvmTokenType enum
   symbol TEXT,

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -120,14 +120,15 @@ CREATE TABLE oasis_3.emerald_tokens
 );
 
 -- Core Module Data
-CREATE TABLE oasis_3.emerald_gas_used
+CREATE TABLE oasis_3.runtime_gas_used
 (
-  round  UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
-  sender oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
-  amount UINT_NUMERIC NOT NULL
+  runtime runtime NOT NULL,
+  round   UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  sender  oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
+  amount  UINT_NUMERIC NOT NULL
 );
 
-CREATE INDEX ix_emerald_gas_used_sender ON oasis_3.emerald_gas_used(sender);
+CREATE INDEX ix_runtime_gas_used_sender ON oasis_3.runtime_gas_used(sender);
 
 -- Accounts Module Data
 

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -2,8 +2,11 @@
 
 BEGIN;
 
-CREATE TABLE oasis_3.emerald_rounds
+CREATE TYPE runtime AS ENUM ('emerald', 'sapphire', 'cipher');
+
+CREATE TABLE oasis_3.runtime_blocks
 (
+  runtime   runtime NOT NULL,
   round     UINT63 PRIMARY KEY,
   version   UINT63 NOT NULL,
   timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -20,12 +23,12 @@ CREATE TABLE oasis_3.emerald_rounds
   gas_used         UINT63 NOT NULL,
   size             UINT31 NOT NULL  -- Total byte size of all transactions in the block.
 );
-CREATE INDEX ix_emerald_rounds_block_hash ON oasis_3.emerald_rounds USING hash (block_hash);
-CREATE INDEX ix_emerald_rounds_timestamp ON oasis_3.emerald_rounds (timestamp);
+CREATE INDEX ix_runtime_blocks_block_hash ON oasis_3.runtime_blocks USING hash (block_hash);  -- Hash indexes cannot span two colmns (runtime, block_hash). Not a problem for efficiency because block_hash is globally uniqueish.
+CREATE INDEX ix_runtime_blocks_timestamp ON oasis_3.runtime_blocks (runtime, timestamp);
 
 CREATE TABLE oasis_3.emerald_transactions
 (
-  round       UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  round       UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   tx_index    UINT31 NOT NULL,
   tx_hash     HEX64 NOT NULL,
   tx_eth_hash HEX64,
@@ -116,7 +119,7 @@ CREATE TABLE oasis_3.emerald_tokens
 -- Core Module Data
 CREATE TABLE oasis_3.emerald_gas_used
 (
-  round  UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  round  UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   sender oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
   amount UINT_NUMERIC NOT NULL
 );
@@ -129,7 +132,7 @@ CREATE INDEX ix_emerald_gas_used_sender ON oasis_3.emerald_gas_used(sender);
 -- Burns are denoted by NULL as the receiver and mints are denoted by NULL as the sender.
 CREATE TABLE oasis_3.emerald_transfers
 (
-  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- Any paratime account. This almost always REFERENCES oasis_3.address_preimages(address)
   -- because the sender signed the Transfer tx and was inserted into address_preimages then.
   -- Exceptions are special addresses; see e.g. the rewards-pool address.
@@ -152,7 +155,7 @@ CREATE INDEX ix_emerald_transfers_receiver ON oasis_3.emerald_transfers(receiver
 -- Deposits from the consensus layer into the paratime.
 CREATE TABLE oasis_3.emerald_deposits
 (
-  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
   -- that consensus and paratimes can be indexed independently.
   -- It also REFERENCES oasis_3.address_preimages because the sender signed at least the Deposit tx.
@@ -180,7 +183,7 @@ CREATE INDEX ix_emerald_deposits_receiver ON oasis_3.emerald_deposits(receiver);
 -- Withdrawals from the paratime into consensus layer.
 CREATE TABLE oasis_3.emerald_withdraws
 (
-  round    UINT63 NOT NULL REFERENCES oasis_3.emerald_rounds DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` can be any paratime address. (i.e. secp256k1eth-backed OR ed25519-backed;
   -- other are options unlikely in an EVM paratime)
   -- It REFERENCES oasis_3.address_preimages because the sender signed at least the Withdraw tx.

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -100,6 +100,8 @@ CREATE TABLE oasis_3.address_preimages
   address_data       BYTEA NOT NULL
 );
 
+-- -- -- -- -- -- -- -- -- -- -- -- -- Module evm -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
 CREATE TABLE oasis_3.emerald_token_balances
 (
   token_address oasis_addr NOT NULL,
@@ -119,7 +121,8 @@ CREATE TABLE oasis_3.emerald_tokens
   total_supply uint_numeric
 );
 
--- Core Module Data
+-- -- -- -- -- -- -- -- -- -- -- -- -- Module core -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
 CREATE TABLE oasis_3.runtime_gas_used
 (
   runtime runtime NOT NULL,
@@ -130,9 +133,9 @@ CREATE TABLE oasis_3.runtime_gas_used
 
 CREATE INDEX ix_runtime_gas_used_sender ON oasis_3.runtime_gas_used(sender);
 
--- Accounts Module Data
+-- -- -- -- -- -- -- -- -- -- -- -- -- Module accounts -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
 
--- The emerald_transfers table encapsulates transfers, burns, and mints.
+-- This table encapsulates transfers, burns, and mints (at the level of the `accounts` SDK module; NOT evm transfers).
 -- Burns are denoted by NULL as the receiver and mints are denoted by NULL as the sender.
 CREATE TABLE oasis_3.emerald_transfers
 (
@@ -155,7 +158,8 @@ CREATE TABLE oasis_3.emerald_transfers
 CREATE INDEX ix_emerald_transfers_sender ON oasis_3.emerald_transfers(sender);
 CREATE INDEX ix_emerald_transfers_receiver ON oasis_3.emerald_transfers(receiver);
 
--- Consensus Accounts Module Data
+-- -- -- -- -- -- -- -- -- -- -- -- -- Module consensusaccounts -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- --
+
 -- Deposits from the consensus layer into the paratime.
 CREATE TABLE oasis_3.emerald_deposits
 (

--- a/storage/migrations/02_oasis_3_emerald.up.sql
+++ b/storage/migrations/02_oasis_3_emerald.up.sql
@@ -7,7 +7,8 @@ CREATE TYPE runtime AS ENUM ('emerald', 'sapphire', 'cipher');
 CREATE TABLE oasis_3.runtime_blocks
 (
   runtime   runtime NOT NULL,
-  round     UINT63 PRIMARY KEY,
+  round     UINT63,
+  PRIMARY KEY (runtime, round),
   version   UINT63 NOT NULL,
   timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
 
@@ -29,7 +30,8 @@ CREATE INDEX ix_runtime_blocks_timestamp ON oasis_3.runtime_blocks (runtime, tim
 CREATE TABLE oasis_3.runtime_transactions
 (
   runtime     runtime NOT NULL,
-  round       UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  round       UINT63 NOT NULL,
+  FOREIGN KEY (runtime, round) REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   tx_index    UINT31 NOT NULL,
   tx_hash     HEX64 NOT NULL,
   tx_eth_hash HEX64,
@@ -129,7 +131,8 @@ CREATE TABLE oasis_3.evm_tokens
 CREATE TABLE oasis_3.runtime_gas_used
 (
   runtime runtime NOT NULL,
-  round   UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  round   UINT63 NOT NULL,
+  FOREIGN KEY (runtime, round) REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   sender  oasis_addr REFERENCES oasis_3.address_preimages,  -- TODO: add NOT NULL; but analyzer is only putting NULLs here for now because it doesn't have the data
   amount  UINT_NUMERIC NOT NULL
 );
@@ -143,7 +146,8 @@ CREATE INDEX ix_runtime_gas_used_sender ON oasis_3.runtime_gas_used(sender);
 CREATE TABLE oasis_3.runtime_transfers
 (
   runtime  runtime NOT NULL,
-  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL,
+  FOREIGN KEY (runtime, round) REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- Any paratime account. This almost always REFERENCES oasis_3.address_preimages(address)
   -- because the sender signed the Transfer tx and was inserted into address_preimages then.
   -- Exceptions are special addresses; see e.g. the rewards-pool address.
@@ -168,7 +172,8 @@ CREATE INDEX ix_runtime_transfers_receiver ON oasis_3.runtime_transfers(receiver
 CREATE TABLE oasis_3.runtime_deposits
 (
   runtime  runtime NOT NULL, 
-  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL,
+  FOREIGN KEY (runtime, round) REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` is a consensus account, so this REFERENCES oasis_3.accounts; we omit the FK so
   -- that consensus and paratimes can be indexed independently.
   -- It also REFERENCES oasis_3.address_preimages because the sender signed at least the Deposit tx.
@@ -197,7 +202,8 @@ CREATE INDEX ix_runtime_deposits_receiver ON oasis_3.runtime_deposits(receiver);
 CREATE TABLE oasis_3.runtime_withdraws
 (
   runtime  runtime NOT NULL,
-  round    UINT63 NOT NULL REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
+  round    UINT63 NOT NULL,
+  FOREIGN KEY (runtime, round) REFERENCES oasis_3.runtime_blocks DEFERRABLE INITIALLY DEFERRED,
   -- The `sender` can be any paratime address. (i.e. secp256k1eth-backed OR ed25519-backed;
   -- other are options unlikely in an EVM paratime)
   -- It REFERENCES oasis_3.address_preimages because the sender signed at least the Withdraw tx.

--- a/storage/migrations/03_agg_stats.up.sql
+++ b/storage/migrations/03_agg_stats.up.sql
@@ -28,12 +28,12 @@ CREATE MATERIALIZED VIEW stats.min5_tx_volume AS
   UNION ALL
   
   SELECT
-    'emerald' AS layer,
+    b.runtime::text AS layer,
     floor_5min(b.timestamp) AS window_start,
     COUNT(*) AS tx_volume
-  FROM oasis_3.emerald_rounds AS b
-  JOIN oasis_3.emerald_transactions AS t ON b.round = t.round
-  GROUP BY 2;
+  FROM oasis_3.runtime_blocks AS b
+  JOIN oasis_3.runtime_transactions AS t ON (b.round = t.round AND b.runtime = t.runtime)
+  GROUP BY 1, 2;
 
 -- daily_tx_volume stores the number of transactions per day
 -- at the consensus layer.

--- a/tests/e2e_regression/reindex_and_run.sh
+++ b/tests/e2e_regression/reindex_and_run.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Wrapper around run.sh that reindexes the database (from scratch to a fixed height)
+# before running the e2e regression tests.
+
+set -euo pipefail
+
+cat >/tmp/e2e_config.yaml <<EOF
+analysis:
+  analyzers:
+    - name: emerald_damask
+      chain_id: oasis-3
+      rpc: unix:/tmp/node.sock
+      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+      from: 1_003_298  # round at Damask genesis
+      to: 1_003_308  # 10 blocks; very fast, for early testing
+  storage:
+    endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable
+    backend: postgres
+    DANGER__WIPE_STORAGE_ON_STARTUP: true
+  migrations: file://storage/migrations
+
+server:
+  chain_id: oasis-3
+  endpoint: localhost:8008
+  storage:
+    endpoint: postgresql://api:password@localhost:5432/indexer?sslmode=disable
+    backend: postgres
+
+log:
+  level: debug
+  format: json
+
+metrics:
+  pull_endpoint: localhost:8009
+EOF
+
+# Kill background processes on exit. (In our case the indexer API server.)
+trap 'trap - SIGTERM && kill -- -$$' SIGINT SIGTERM EXIT
+
+make oasis-indexer
+./oasis-indexer --config=/tmp/e2e_config.yaml analyze
+./oasis-indexer --config=/tmp/e2e_config.yaml serve &
+sleep 1
+while ! curl --silent localhost:8008/v1/ >/dev/null; do
+  echo "Waiting for API server to start..."
+  sleep 1
+done
+tests/e2e_regression/run.sh
+


### PR DESCRIPTION
Generalize former emerald tables so they can store data from multiple runtimes:
- adds a `runtime` column to all of them
- renames them appropriately
- udpates SQL queries appropriately

This is the first step towards https://app.clickup.com/t/3u9y285
The main benefit of this PR is that we can support new runtimes without copy-pasting `CREATE TABLE` and `CREATE INDEX` from e.g. Emerald. 

The first two commits are only vaguely related to the rest of the PR:
- The first one improves the ergonomy of e2e regression tests, so I was able to test every change.
- The second one adds an `ORDER BY` to all `SELECT` statements that use `LIMIT`. Without `ORDER BY`, an arbitrary subset is returned, which is a serious bug for windowed queries. Thanks, regression tests (they found this bug because the API output was not stable).  

Testing: 
Before and after this PR, indexed 200 blocks of emerald. With `tests/e2e_regression/run.sh`, compared the API output for endpoints that exercise most of the API (see list in `run.sh`). No regressions/changes detected.