### PR TITLE
db client: Simplify, clean up

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -235,9 +235,15 @@ func RuntimeFromURLMiddleware(baseURL string) func(next http.Handler) http.Handl
 			// The first part of the path (after the version) determines the runtime.
 			// Recognize only whitelisted runtimes.
 			runtime := ""
-			switch { //nolint:gocritic // allow single-case switch for future expansions
+			switch {
+			case strings.HasPrefix(path, "/consensus/"):
+				runtime = "consensus"
 			case strings.HasPrefix(path, "/emerald/"):
 				runtime = "emerald"
+			case strings.HasPrefix(path, "/sapphire/"):
+				runtime = "sapphire"
+			case strings.HasPrefix(path, "/cipher/"):
+				runtime = "cipher"
 			}
 
 			if runtime != "" {

--- a/common/types.go
+++ b/common/types.go
@@ -46,7 +46,7 @@ func (b *BigInt) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
 		return err
 	}
 
-	bigInt, err := numericToBigInt(numeric)
+	bigInt, err := NumericToBigInt(numeric)
 	*b = bigInt
 	return err
 }
@@ -56,11 +56,9 @@ func (b BigInt) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, er
 	return numeric.EncodeBinary(ci, buf)
 }
 
-// TODO: DEDUPLICATE - DO NOT SUBMIT PR BEFORE FIXING THIS
-//
-// numericToBigInt converts a pgtype.Numeric to a BigInt similar to the
+// NumericToBigInt converts a pgtype.Numeric to a BigInt similar to the
 // private method found at https://github.com/jackc/pgtype/blob/master/numeric.go#L398
-func numericToBigInt(n pgtype.Numeric) (BigInt, error) {
+func NumericToBigInt(n pgtype.Numeric) (BigInt, error) {
 	if n.Exp == 0 {
 		return BigInt{Int: *n.Int}, nil
 	}

--- a/common/types.go
+++ b/common/types.go
@@ -1,9 +1,12 @@
 package common
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
+
+	"github.com/jackc/pgtype"
 )
 
 // Arbitrary-precision integer. Wrapper around big.Int to allow for
@@ -31,6 +34,56 @@ func (b BigInt) MarshalJSON() ([]byte, error) {
 func (b *BigInt) UnmarshalJSON(text []byte) error {
 	v := strings.Trim(string(text), "\"")
 	return b.Int.UnmarshalJSON([]byte(v))
+}
+
+func (b *BigInt) DecodeBinary(ci *pgtype.ConnInfo, src []byte) error {
+	if src == nil {
+		return errors.New("NULL values can't be decoded. Scan into a **BigInt to handle NULLs")
+	}
+
+	numeric := pgtype.Numeric{}
+	if err := numeric.DecodeBinary(ci, src); err != nil {
+		return err
+	}
+
+	bigInt, err := numericToBigInt(numeric)
+	*b = bigInt
+	return err
+}
+
+func (b BigInt) EncodeBinary(ci *pgtype.ConnInfo, buf []byte) (newBuf []byte, err error) {
+	numeric := pgtype.Numeric{Int: &b.Int, Exp: 0, Status: pgtype.Present}
+	return numeric.EncodeBinary(ci, buf)
+}
+
+// TODO: DEDUPLICATE - DO NOT SUBMIT PR BEFORE FIXING THIS
+//
+// numericToBigInt converts a pgtype.Numeric to a BigInt similar to the
+// private method found at https://github.com/jackc/pgtype/blob/master/numeric.go#L398
+func numericToBigInt(n pgtype.Numeric) (BigInt, error) {
+	if n.Exp == 0 {
+		return BigInt{Int: *n.Int}, nil
+	}
+
+	big0 := big.NewInt(0)
+	big10 := big.NewInt(10)
+	bi := &big.Int{}
+	bi.Set(n.Int)
+	if n.Exp > 0 {
+		mul := &big.Int{}
+		mul.Exp(big10, big.NewInt(int64(n.Exp)), nil)
+		bi.Mul(bi, mul)
+		return BigInt{Int: *bi}, nil
+	}
+
+	div := &big.Int{}
+	div.Exp(big10, big.NewInt(int64(-n.Exp)), nil)
+	remainder := &big.Int{}
+	bi.DivMod(bi, div, remainder)
+	if remainder.Cmp(big0) != 0 {
+		return BigInt{Int: *big0}, fmt.Errorf("cannot convert %v to integer", n)
+	}
+	return BigInt{Int: *big0}, nil
 }
 
 // Key used to set values in a web request context. API uses this to set

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -89,10 +89,6 @@ func (c *StorageClient) Status(ctx context.Context) (*Status, error) {
 		ctx,
 		qf.StatusQuery(),
 	).Scan(&s.LatestBlock, &s.LatestUpdate); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	// oasis-node control status returns time truncated to the second
@@ -121,10 +117,6 @@ func (c *StorageClient) Blocks(ctx context.Context, r apiTypes.GetConsensusBlock
 		r.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -135,10 +127,6 @@ func (c *StorageClient) Blocks(ctx context.Context, r apiTypes.GetConsensusBlock
 	for rows.Next() {
 		var b Block
 		if err := rows.Scan(&b.Height, &b.Hash, &b.Timestamp, &b.NumTransactions); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		b.Timestamp = b.Timestamp.UTC()
@@ -169,10 +157,6 @@ func (c *StorageClient) Block(ctx context.Context, height int64) (*Block, error)
 		qf.BlockQuery(),
 		height,
 	).Scan(&b.Height, &b.Hash, &b.Timestamp, &b.NumTransactions); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	b.Timestamp = b.Timestamp.UTC()
@@ -208,10 +192,6 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -234,10 +214,6 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 			&code,
 			&t.Timestamp,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		if code == oasisErrors.CodeNoError {
@@ -282,10 +258,6 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 		&code,
 		&t.Timestamp,
 	); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	if code == oasisErrors.CodeNoError {
@@ -324,10 +296,6 @@ func (c *StorageClient) Events(ctx context.Context, p apiTypes.GetConsensusEvent
 	)
 
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -339,9 +307,6 @@ func (c *StorageClient) Events(ctx context.Context, p apiTypes.GetConsensusEvent
 	for rows.Next() {
 		var e Event
 		if err := rows.Scan(&e.Block, &e.TxIndex, &e.TxHash, &e.Type, &e.Body); err != nil {
-			c.logger.Info("query failed",
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		es.Events = append(es.Events, e)
@@ -365,10 +330,6 @@ func (c *StorageClient) Entities(ctx context.Context, p apiTypes.GetConsensusEnt
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -379,9 +340,6 @@ func (c *StorageClient) Entities(ctx context.Context, p apiTypes.GetConsensusEnt
 	for rows.Next() {
 		var e Entity
 		if err := rows.Scan(&e.ID, &e.Address); err != nil {
-			c.logger.Info("query failed",
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -405,10 +363,6 @@ func (c *StorageClient) Entity(ctx context.Context, entityID signature.PublicKey
 		qf.EntityQuery(),
 		entityID.String(),
 	).Scan(&e.ID, &e.Address); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -418,10 +372,6 @@ func (c *StorageClient) Entity(ctx context.Context, entityID signature.PublicKey
 		entityID.String(),
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer nodeRows.Close()
@@ -429,10 +379,6 @@ func (c *StorageClient) Entity(ctx context.Context, entityID signature.PublicKey
 	for nodeRows.Next() {
 		var nid string
 		if err := nodeRows.Scan(&nid); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -458,10 +404,6 @@ func (c *StorageClient) EntityNodes(ctx context.Context, entityID signature.Publ
 		r.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -481,10 +423,6 @@ func (c *StorageClient) EntityNodes(ctx context.Context, entityID signature.Publ
 			&n.ConsensusPubkey,
 			&n.Roles,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -519,10 +457,6 @@ func (c *StorageClient) EntityNode(ctx context.Context, entityID signature.Publi
 		&n.ConsensusPubkey,
 		&n.Roles,
 	); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -552,10 +486,6 @@ func (c *StorageClient) Accounts(ctx context.Context, r apiTypes.GetConsensusAcc
 		r.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -576,10 +506,6 @@ func (c *StorageClient) Accounts(ctx context.Context, r apiTypes.GetConsensusAcc
 			&a.AddressPreimage.ContextVersion,
 			&a.AddressPreimage.AddressData,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		if preimageContext != nil {
@@ -665,10 +591,6 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 		address.String(),
 	)
 	if queryErr != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", queryErr.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer allowanceRows.Close()
@@ -679,10 +601,6 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 			&al.Address,
 			&al.Amount,
 		); err2 != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -762,10 +680,6 @@ func (c *StorageClient) Delegations(ctx context.Context, address staking.Address
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -782,10 +696,6 @@ func (c *StorageClient) Delegations(ctx context.Context, address staking.Address
 			&escrowBalanceActive,
 			&escrowTotalSharesActive,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		amount := new(big.Int).Mul(&shares.Int, &escrowBalanceActive.Int)
@@ -815,10 +725,6 @@ func (c *StorageClient) DebondingDelegations(ctx context.Context, address stakin
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -836,10 +742,6 @@ func (c *StorageClient) DebondingDelegations(ctx context.Context, address stakin
 			&escrowBalanceDebonding,
 			&escrowTotalSharesDebonding,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -869,10 +771,6 @@ func (c *StorageClient) Epochs(ctx context.Context, p apiTypes.GetConsensusEpoch
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -882,10 +780,6 @@ func (c *StorageClient) Epochs(ctx context.Context, p apiTypes.GetConsensusEpoch
 	for rows.Next() {
 		var e Epoch
 		if err := rows.Scan(&e.ID, &e.StartHeight, &e.EndHeight); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -909,10 +803,6 @@ func (c *StorageClient) Epoch(ctx context.Context, epoch int64) (*Epoch, error) 
 		qf.EpochQuery(),
 		epoch,
 	).Scan(&e.ID, &e.StartHeight, &e.EndHeight); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -936,10 +826,6 @@ func (c *StorageClient) Proposals(ctx context.Context, p apiTypes.GetConsensusPr
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -965,10 +851,6 @@ func (c *StorageClient) Proposals(ctx context.Context, p apiTypes.GetConsensusPr
 			&p.ClosesAt,
 			&invalidVotesNum,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -1006,10 +888,6 @@ func (c *StorageClient) Proposal(ctx context.Context, proposalID uint64) (*Propo
 		&p.ClosesAt,
 		&p.InvalidVotes,
 	); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -1032,10 +910,6 @@ func (c *StorageClient) ProposalVotes(ctx context.Context, proposalID uint64, p 
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1049,10 +923,6 @@ func (c *StorageClient) ProposalVotes(ctx context.Context, proposalID uint64, p 
 			&v.Address,
 			&v.Vote,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -1076,10 +946,6 @@ func (c *StorageClient) Validators(ctx context.Context, p apiTypes.GetConsensusV
 		ctx,
 		qf.ValidatorsQuery(),
 	).Scan(&epoch.ID, &epoch.StartHeight); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -1090,10 +956,6 @@ func (c *StorageClient) Validators(ctx context.Context, p apiTypes.GetConsensusV
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1114,9 +976,6 @@ func (c *StorageClient) Validators(ctx context.Context, p apiTypes.GetConsensusV
 			&v.Status,
 			&v.Media,
 		); err != nil {
-			c.logger.Info("query failed",
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -1156,10 +1015,6 @@ func (c *StorageClient) Validator(ctx context.Context, entityID signature.Public
 		ctx,
 		qf.ValidatorQuery(),
 	).Scan(&epoch.ID, &epoch.StartHeight); err != nil {
-		c.logger.Info("row scan failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -1181,9 +1036,6 @@ func (c *StorageClient) Validator(ctx context.Context, entityID signature.Public
 		&v.Status,
 		&v.Media,
 	); err != nil {
-		c.logger.Info("query failed",
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -1230,10 +1082,6 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, p apiTypes.GetEmerald
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1244,10 +1092,6 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, p apiTypes.GetEmerald
 	for rows.Next() {
 		var b RuntimeBlock
 		if err := rows.Scan(&b.Round, &b.Hash, &b.Timestamp, &b.NumTransactions, &b.Size, &b.GasUsed); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 		b.Timestamp = b.Timestamp.UTC()
@@ -1279,10 +1123,6 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetE
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1300,10 +1140,6 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetE
 			&t.Raw,
 			&t.ResultRaw,
 		); err != nil {
-			c.logger.Info("row scan failed",
-				"request_id", ctx.Value(common.RequestIDContextKey),
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 
@@ -1342,10 +1178,6 @@ func (c *StorageClient) RuntimeTransaction(ctx context.Context, txHash string) (
 		&t.ResultRaw,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 
@@ -1370,10 +1202,6 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetEmerald
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1430,10 +1258,6 @@ func (c *StorageClient) TxVolumes(ctx context.Context, layer apiTypes.Layer, p a
 		p.Offset,
 	)
 	if err != nil {
-		c.logger.Info("query failed",
-			"request_id", ctx.Value(common.RequestIDContextKey),
-			"err", err.Error(),
-		)
 		return nil, apiCommon.ErrStorageError
 	}
 	defer rows.Close()
@@ -1451,9 +1275,6 @@ func (c *StorageClient) TxVolumes(ctx context.Context, layer apiTypes.Layer, p a
 			&d.BucketStart,
 			&d.TxVolume,
 		); err != nil {
-			c.logger.Info("query failed",
-				"err", err.Error(),
-			)
 			return nil, apiCommon.ErrStorageError
 		}
 


### PR DESCRIPTION
This PR cleans up a bunch of small things around our DB client that have been bothering me for months, but even more so lately when I've been interacting with the DB more.
Changes/improvements:
- Removes copy-pasted error logs when a SQL query fails. We log these errors in our DB wrapper library, and `pgx` proper logs them also, so they were triple-logged previously. (For QueryRow(), `pgx` design is a little different and we cannot easily have a wrapper there, so we don't log the error ourselves. Those errors used to be double-logged, and are now single-logged, by pgx.)
- Obviates manual decoding of BigInts when pulled from the DB; I added a method to `BigInt` that `pgx` can use to do the decoding automatically. It doesn't work for `*BigInt` (= API fields that are nillable) due to a pgx bug/restriction. I spent way too much time trying alternatives, including pgx v5 (which has a different API for custom types), but it looks like we best stick with what we have.
- Propagates "no row found" from QueryRow() into a HTTP 404. This resolves #279 . This commit is also a good starting point for anybody wanting to create more custom errors.
- Simplifies the construction of QueryFactory objects. We had a bunch of copy-pasted code that always fetched the chainId and runtime from the `ctx`; now, this happens in a helper func. 