### PR TITLE
genesis-test: Create DB snapshot using full tx isolation

### DIFF
--- a/storage/api.go
+++ b/storage/api.go
@@ -40,6 +40,9 @@ type QueryResults = pgx.Rows
 // QueryResult represents the result from a read query.
 type QueryResult = pgx.Row
 
+// TxOptions encodes the way DB transactions are executed.
+type TxOptions = pgx.TxOptions
+
 // Queue adds query to a batch.
 func (b *QueryBatch) Queue(cmd string, args ...interface{}) {
 	b.items = append(b.items, &batchItem{
@@ -282,6 +285,9 @@ type ConsensusAccountsData struct {
 type TargetStorage interface {
 	// SendBatch sends a batch of queries to be applied to target storage.
 	SendBatch(ctx context.Context, batch *QueryBatch) error
+
+	// SendBatchWithOptions is like SendBatch, with custom DB options (e.g. level of tx isolation).
+	SendBatchWithOptions(ctx context.Context, batch *QueryBatch, opts TxOptions) error
 
 	// Query submits a query to fetch data from target storage.
 	Query(ctx context.Context, sql string, args ...interface{}) (QueryResults, error)


### PR DESCRIPTION
As discussed on Slack, `mainnet-indexer-statecheck` (the cron job that runs genesis_test on consensus) consistently fails. A possible cause for failure is that the test creates an inconsistent snapshot of the indexer state, due to not using a strong enough DB tx isolation level.

This PR uses `SERIALIZABLE`, the strongest tx isolation level, for snapshot creation. 

More about DB tx isolation levels:
https://www.postgresql.org/docs/current/transaction-iso.html

I created a dev docker image and I'm deploying this now to see what the effect is.
```
kubectl -n monitoring create job --from=cronjobs/mainnet-indexer-statecheck manual-indexer-statecheck-mitjat
```