### PR TITLE
analyzer: Refactor configs

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -32,25 +32,10 @@ func (a *AggregateStatsAnalyzer) Name() string {
 	return AggregateStatsAnalyzerName
 }
 
-func NewAggregateStatsAnalyzer(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
-	// Parse config
-	var interval time.Duration
-	var err error
-	if cfg.Interval == "" {
-		interval = 1 * time.Hour // default interval
-	} else {
-		interval, err = time.ParseDuration(cfg.Interval)
-		if err != nil {
-			logger.Error("error parsing analysis interval",
-				"err", err.Error(),
-			)
-			return nil, err
-		}
-	}
-
+func NewAggregateStatsAnalyzer(cfg *config.IntervalBasedAnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
 	logger.Info("Starting aggregate_stats analyzer")
 	return &AggregateStatsAnalyzer{
-		interval: interval,
+		interval: cfg.ParsedInterval(),
 		qf:       NewQueryFactory("" /*chainID*/, "" /*runtime*/),
 		target:   target,
 		logger:   logger.With("analyzer", AggregateStatsAnalyzerName),

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -58,15 +58,15 @@ type Main struct {
 var _ analyzer.Analyzer = (*Main)(nil)
 
 // NewMain returns a new main analyzer for the consensus layer.
-func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
+func NewMain(nodeCfg config.NodeConfig, cfg *config.BlockBasedAnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
 	ctx := context.Background()
 
 	// Initialize source storage.
 	networkCfg := oasisConfig.Network{
-		ChainContext: cfg.ChainContext,
-		RPC:          cfg.RPC,
+		ChainContext: nodeCfg.ChainContext,
+		RPC:          nodeCfg.RPC,
 	}
-	factory, err := source.NewClientFactory(ctx, &networkCfg, cfg.FastStartup)
+	factory, err := source.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
 	if err != nil {
 		logger.Error("error creating client factory",
 			"err", err.Error(),
@@ -87,7 +87,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		To:   cfg.To,
 	}
 	ac := analyzer.ConsensusConfig{
-		ChainID: cfg.ChainID,
+		ChainID: nodeCfg.ChainID,
 		Range:   blockRange,
 		Source:  client,
 	}
@@ -95,7 +95,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 	logger.Info("Starting consensus analyzer", "config", ac)
 	return &Main{
 		cfg:     ac,
-		qf:      analyzer.NewQueryFactory(strcase.ToSnake(cfg.ChainID), "" /* no runtime identifier for the consensus layer */),
+		qf:      analyzer.NewQueryFactory(strcase.ToSnake(nodeCfg.ChainID), "" /* no runtime identifier for the consensus layer */),
 		target:  target,
 		logger:  logger.With("analyzer", ConsensusDamaskAnalyzerName),
 		metrics: metrics.NewDefaultDatabaseMetrics(ConsensusDamaskAnalyzerName),

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -41,15 +41,15 @@ type Main struct {
 
 var _ analyzer.Analyzer = (*Main)(nil)
 
-func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
+func NewMain(nodeCfg *config.NodeConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
 	ctx := context.Background()
 
 	// Initialize source storage.
 	networkCfg := oasisConfig.Network{
-		ChainContext: cfg.ChainContext,
-		RPC:          cfg.RPC,
+		ChainContext: nodeCfg.ChainContext,
+		RPC:          nodeCfg.RPC,
 	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg, cfg.FastStartup)
+	factory, err := oasis.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
 	if err != nil {
 		logger.Error("error creating client factory",
 			"err", err,
@@ -57,7 +57,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		return nil, err
 	}
 
-	network, err := analyzer.FromChainContext(cfg.ChainContext)
+	network, err := analyzer.FromChainContext(nodeCfg.ChainContext)
 	if err != nil {
 		return nil, err
 	}

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -29,29 +29,15 @@ func (a *MetadataRegistryAnalyzer) Name() string {
 	return MetadataRegistryAnalyzerName
 }
 
-func NewMetadataRegistryAnalyzer(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*MetadataRegistryAnalyzer, error) {
-	// Parse config
-	var interval time.Duration
-	var err error
-	if cfg.Interval == "" {
-		interval = 1 * time.Minute // default interval
-	} else {
-		interval, err = time.ParseDuration(cfg.Interval)
-		if err != nil {
-			logger.Error("error parsing analysis interval",
-				"err", err.Error(),
-			)
-			return nil, err
-		}
-	}
-	if cfg.ChainID == "" {
+func NewMetadataRegistryAnalyzer(chainID string, cfg *config.IntervalBasedAnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*MetadataRegistryAnalyzer, error) {
+	if chainID == "" {
 		return nil, fmt.Errorf("metadata_registry analyzer: `ChainID` must be specified in the config")
 	}
 
 	logger.Info("Starting metadata_registry analyzer")
 	return &MetadataRegistryAnalyzer{
-		interval: interval,
-		qf:       NewQueryFactory(strcase.ToSnake(cfg.ChainID), "" /*runtime*/),
+		interval: cfg.ParsedInterval(),
+		qf:       NewQueryFactory(strcase.ToSnake(chainID), "" /*runtime*/),
 		target:   target,
 		logger:   logger.With("analyzer", MetadataRegistryAnalyzerName),
 		metrics:  metrics.NewDefaultDatabaseMetrics(MetadataRegistryAnalyzerName),

--- a/analyzer/runtime/incoming.go
+++ b/analyzer/runtime/incoming.go
@@ -1,4 +1,4 @@
-package emerald
+package runtime
 
 import (
 	"bytes"

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -1,4 +1,4 @@
-package emerald
+package runtime
 
 import (
 	"context"

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -44,16 +44,16 @@ type Main struct {
 
 var _ analyzer.Analyzer = (*Main)(nil)
 
-// NewMain returns a new main analyzer for the Emerald Runtime.
-func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
+// NewRuntimeAnalyzer returns a new main analyzer for the Emerald Runtime.
+func NewRuntimeAnalyzer(nodeCfg config.NodeConfig, cfg *config.BlockBasedAnalyzerConfig, target storage.TargetStorage, logger *log.Logger) (*Main, error) {
 	ctx := context.Background()
 
 	// Initialize source storage.
 	networkCfg := oasisConfig.Network{
-		ChainContext: cfg.ChainContext,
-		RPC:          cfg.RPC,
+		ChainContext: nodeCfg.ChainContext,
+		RPC:          nodeCfg.RPC,
 	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg, cfg.FastStartup)
+	factory, err := oasis.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
 	if err != nil {
 		logger.Error("error creating client factory",
 			"err", err,
@@ -61,7 +61,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		return nil, err
 	}
 
-	network, err := analyzer.FromChainContext(cfg.ChainContext)
+	network, err := analyzer.FromChainContext(nodeCfg.ChainContext)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func NewMain(cfg *config.AnalyzerConfig, target storage.TargetStorage, logger *l
 		Source: client,
 	}
 
-	qf := analyzer.NewQueryFactory(strcase.ToSnake(cfg.ChainID), emerald.String())
+	qf := analyzer.NewQueryFactory(strcase.ToSnake(nodeCfg.ChainID), emerald.String())
 
 	return &Main{
 		cfg:     ac,

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -3,7 +3,6 @@ package analyzer
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"sync"
 
@@ -85,7 +84,7 @@ func Init(cfg *config.AnalysisConfig) (*Service, error) {
 	}
 
 	m, err := migrate.New(
-		cfg.Migrations,
+		cfg.Storage.Migrations,
 		cfg.Storage.Endpoint,
 	)
 	if err != nil {
@@ -139,6 +138,25 @@ type Service struct {
 	logger *log.Logger
 }
 
+type A = analyzer.Analyzer
+
+// addAnalyzer adds the analyzer produced by `analyzerGenerator()` to `analyzers`.
+// It expects an initial state (analyzers, errSoFar) and returns the updated state, which
+// should be fed into subsequent call to the function.
+// As soon as an analyzerGenerator returns an error, all subsequent calls will
+// short-circuit and return the same error, leaving `analyzers` unchanged.
+func addAnalyzer(analyzers map[string]A, errSoFar error, analyzerGenerator func() (A, error)) (map[string]A, error) {
+	if errSoFar != nil {
+		return analyzers, errSoFar
+	}
+	a, errSoFar := analyzerGenerator()
+	if errSoFar != nil {
+		return analyzers, errSoFar
+	}
+	analyzers[a.Name()] = a
+	return analyzers, nil
+}
+
 // NewService creates new Service.
 func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	logger := common.Logger().WithModule(moduleName)
@@ -150,32 +168,47 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	}
 
 	// Initialize analyzers.
-	analyzers := map[string]analyzer.Analyzer{}
-	for _, analyzerCfg := range cfg.Analyzers {
-		// Parse analyzer name.
-		var a analyzer.Analyzer
-		switch analyzerCfg.Name {
-		case consensus.ConsensusDamaskAnalyzerName, "consensus_main_damask": // TODO: drop "main" variant; as of Oct 2022, it exists only to support legacy helmfiles
-			a, err = consensus.NewMain(analyzerCfg, client, logger)
-		case runtime.EmeraldDamaskAnalyzerName, "emerald_main_damask": // TODO: drop "main" variant; as of Oct 2022, it exists only to support legacy helmfiles
-			a, err = runtime.NewMain(analyzerCfg, client, logger)
-		case evmtokens.EmeraldDamaskTokensAnalyzerName:
-			a, err = evmtokens.NewMain(analyzerCfg, client, logger)
-		case analyzer.MetadataRegistryAnalyzerName:
-			a, err = analyzer.NewMetadataRegistryAnalyzer(analyzerCfg, client, logger)
-		case analyzer.AggregateStatsAnalyzerName:
-			a, err = analyzer.NewAggregateStatsAnalyzer(analyzerCfg, client, logger)
-		default:
-			return nil, fmt.Errorf("unsupported analyzer name: %s", analyzerCfg.Name)
-		}
-
-		if err != nil {
-			return nil, err
-		}
-		analyzers[a.Name()] = a
+	analyzers := map[string]A{}
+	if cfg.Analyzers.Consensus != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return consensus.NewMain(cfg.Node, cfg.Analyzers.Consensus, client, logger)
+		})
+	}
+	if cfg.Analyzers.Emerald != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return runtime.NewRuntimeAnalyzer(cfg.Node, cfg.Analyzers.Emerald, client, logger)
+		})
+	}
+	if cfg.Analyzers.Sapphire != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return runtime.NewRuntimeAnalyzer(cfg.Node, cfg.Analyzers.Sapphire, client, logger)
+		})
+	}
+	if cfg.Analyzers.Cipher != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return runtime.NewRuntimeAnalyzer(cfg.Node, cfg.Analyzers.Cipher, client, logger)
+		})
+	}
+	if cfg.Analyzers.EvmTokens != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return evmtokens.NewMain(&cfg.Node, client, logger)
+		})
+	}
+	if cfg.Analyzers.MetadataRegistry != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return analyzer.NewMetadataRegistryAnalyzer(cfg.Node.ChainID, cfg.Analyzers.MetadataRegistry, client, logger)
+		})
+	}
+	if cfg.Analyzers.AggregateStats != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return analyzer.NewAggregateStatsAnalyzer(cfg.Analyzers.MetadataRegistry, client, logger)
+		})
+	}
+	if err != nil {
+		return nil, err
 	}
 
-	logger.Info("initialized analyzers")
+	logger.Info("initialized all analyzers")
 
 	return &Service{
 		Analyzers: analyzers,

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/consensus"
-	"github.com/oasisprotocol/oasis-indexer/analyzer/emerald"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/evmtokens"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime"
 	"github.com/oasisprotocol/oasis-indexer/cmd/common"
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -157,8 +157,8 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 		switch analyzerCfg.Name {
 		case consensus.ConsensusDamaskAnalyzerName, "consensus_main_damask": // TODO: drop "main" variant; as of Oct 2022, it exists only to support legacy helmfiles
 			a, err = consensus.NewMain(analyzerCfg, client, logger)
-		case emerald.EmeraldDamaskAnalyzerName, "emerald_main_damask": // TODO: drop "main" variant; as of Oct 2022, it exists only to support legacy helmfiles
-			a, err = emerald.NewMain(analyzerCfg, client, logger)
+		case runtime.EmeraldDamaskAnalyzerName, "emerald_main_damask": // TODO: drop "main" variant; as of Oct 2022, it exists only to support legacy helmfiles
+			a, err = runtime.NewMain(analyzerCfg, client, logger)
 		case evmtokens.EmeraldDamaskTokensAnalyzerName:
 			a, err = evmtokens.NewMain(analyzerCfg, client, logger)
 		case analyzer.MetadataRegistryAnalyzerName:

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -1,24 +1,21 @@
 analysis:
+  node:
+    chain_id: oasis-3
+    rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
+    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
   analyzers:
-    - name: metadata_registry
-      chain_id: oasis-3
+    metadata_registry:
       interval: 1h
-    - name: aggregate_stats
-      interval: 10m  
-    - name: consensus_main_damask
-      chain_id: oasis-3
-      rpc: unix:/node/data/internal.sock
-      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
-      from: 8048956
-    - name: emerald_main_damask
-      chain_id: oasis-3
-      rpc: unix:/node/data/internal.sock
-      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
-      from: 2550000
+    aggregate_stats:
+      interval: 10m
+    consensus:
+      from: 8_048_956  # Damask genesis
+    emerald:
+      from: 1_003_298  # round at Damask genesis
   storage:
-    endpoint: postgresql://rwuser:password@indexer-postgres:5432/indexer?sslmode=disable
     backend: postgres
-  migrations: file:///storage/migrations
+    endpoint: postgresql://rwuser:password@indexer-postgres:5432/indexer?sslmode=disable
+    migrations: file://storage/migrations
 
 server:
   chain_id: oasis-3

--- a/config/local-dev.yml
+++ b/config/local-dev.yml
@@ -1,24 +1,21 @@
 analysis:
+  node:
+    chain_id: oasis-3
+    rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
+    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
   analyzers:
-    - name: metadata_registry
-      chain_id: oasis-3
+    metadata_registry:
       interval: 1h
-    - name: aggregate_stats
+    aggregate_stats:
       interval: 10m
-    - name: consensus_main_damask
-      chain_id: oasis-3
-      rpc: unix:/node/data/internal.sock
-      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+    consensus:
       from: 8_048_956  # Damask genesis
-    - name: emerald_main_damask
-      chain_id: oasis-3
-      rpc: unix:/node/data/internal.sock
-      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+    emerald:
       from: 1_003_298  # round at Damask genesis
   storage:
-    endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable
     backend: postgres
-  migrations: file://storage/migrations
+    endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable
+    migrations: file://storage/migrations
 
 server:
   chain_id: oasis-3

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -22,7 +22,7 @@ type ClientFactory struct {
 }
 
 // NewClientFactory creates a new oasis-node client factory.
-// Unless `skipChainContextCheck` is false, it also checks that
+// If `skipChainContextCheck` is true, it also checks that
 // the RPC endpoint in `network` serves the chain context specified
 // in `network`.
 func NewClientFactory(ctx context.Context, network *config.Network, skipChainContextCheck bool) (*ClientFactory, error) {

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -1,15 +1,16 @@
 analysis:
-  analyzers:
-    - name: consensus_damask
+  node:
       chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner
       rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
       chaincontext: 59e65fd10f3057cb8009998c5e6288db40b32a3a37f3c3a7c769fd84ed4c63c9
+  analyzers:
+    consensus:
       from: 1
       to: 86400
   storage:
     endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable
     backend: postgres
-  migrations: file:///storage/migrations
+    migrations: file:///storage/migrations
 
 server:
   chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner

--- a/tests/e2e_regression/reindex_and_run.sh
+++ b/tests/e2e_regression/reindex_and_run.sh
@@ -7,18 +7,20 @@ set -euo pipefail
 
 cat >/tmp/e2e_config.yaml <<EOF
 analysis:
+  node:
+    chain_id: oasis-3
+    rpc: unix:/tmp/node.sock
+    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
   analyzers:
-    - name: emerald_damask
-      chain_id: oasis-3
-      rpc: unix:/tmp/node.sock
-      chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+    emerald:
       from: 1_003_298  # round at Damask genesis
       to: 1_003_308  # 10 blocks; very fast, for early testing
+    evm_tokens: {}
   storage:
     endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable
     backend: postgres
     DANGER__WIPE_STORAGE_ON_STARTUP: true
-  migrations: file://storage/migrations
+    migrations: file://storage/migrations
 
 server:
   chain_id: oasis-3
@@ -39,9 +41,19 @@ EOF
 trap 'trap - SIGTERM && kill -- -$$' SIGINT SIGTERM EXIT
 
 make oasis-indexer
-./oasis-indexer --config=/tmp/e2e_config.yaml analyze
+./oasis-indexer --config=/tmp/e2e_config.yaml analyze | tee /tmp/analyze.out &
+analyzer_pid=$!
+
+# Wait for the analyzer to be done, then kill it.
+# It won't terminate on its own because the evm_tokens analyzer is always looking for more work.
+while ! grep -q "finished processing all blocks" /tmp/analyze.out; do
+  echo "Waiting for analyzer to finish..."
+  sleep 1
+done
+sleep 2  # Give evm_tokens analyzer a chance to finish.
+kill $analyzer_pid
+
 ./oasis-indexer --config=/tmp/e2e_config.yaml serve &
-sleep 1
 while ! curl --silent localhost:8008/v1/ >/dev/null; do
   echo "Waiting for API server to start..."
   sleep 1


### PR DESCRIPTION
This PR restructures configs, with two goals in mind:
- Allow different configs (wrt their type/attributes) for different analyzers. Now that we have runtime analyzers but also various metadata analyzers, the lowest-common-denominator config structure has been getting confusing, with each analyzer using only some of its fields.
- Factor out node connection config. Previously, every runtime (+ consensus) had to specify it separately, which invites typos and discrepancies, especially with the upcoming multiple runtimes.

This is working towards https://app.clickup.com/t/3u9y285
