### PR TITLE
/runtime/transactions: Populate the timestamp

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -375,8 +375,8 @@ func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, raw, result_raw)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, timestamp, raw, result_raw)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeEventInsertQuery() string {

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -37,18 +37,18 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 		return apiTypes.RuntimeTransaction{}, fmt.Errorf("body unmarshal: %w", err)
 	}
 	apiTransaction := apiTypes.RuntimeTransaction{
-		Round:   storageTransaction.Round,
-		Index:   storageTransaction.Index,
-		Hash:    storageTransaction.Hash,
-		EthHash: storageTransaction.EthHash,
-		// TODO: Get timestamp from that round's block
-		Sender0:  sender0,
-		Nonce0:   tx.AuthInfo.SignerInfo[0].Nonce,
-		Fee:      tx.AuthInfo.Fee.Amount.Amount.String(),
-		GasLimit: tx.AuthInfo.Fee.Gas,
-		Method:   tx.Call.Method,
-		Body:     body,
-		Success:  cr.IsSuccess(),
+		Round:     storageTransaction.Round,
+		Index:     storageTransaction.Index,
+		Hash:      storageTransaction.Hash,
+		EthHash:   storageTransaction.EthHash,
+		Timestamp: storageTransaction.Timestamp,
+		Sender0:   sender0,
+		Nonce0:    tx.AuthInfo.SignerInfo[0].Nonce,
+		Fee:       tx.AuthInfo.Fee.Amount.Amount.String(),
+		GasLimit:  tx.AuthInfo.Fee.Gas,
+		Method:    tx.Call.Method,
+		Body:      body,
+		Success:   cr.IsSuccess(),
 	}
 	if err = uncategorized.VisitCall(&tx.Call, &cr, &uncategorized.CallHandler{
 		AccountsTransfer: func(body *accounts.Transfer) error {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1002,6 +1002,7 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 			&t.Index,
 			&t.Hash,
 			&t.EthHash,
+			&t.Timestamp,
 			&t.Raw,
 			&t.ResultRaw,
 		); err != nil {
@@ -1029,6 +1030,7 @@ func (c *StorageClient) RuntimeTransaction(ctx context.Context, txHash string) (
 		&t.Index,
 		&t.Hash,
 		&t.EthHash,
+		&t.Timestamp,
 		&t.Raw,
 		&t.ResultRaw,
 	)

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -394,7 +394,7 @@ func (qf QueryFactory) RuntimeBlocksQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionsQuery() string {
 	return fmt.Sprintf(`
-		SELECT round, tx_index, tx_hash, tx_eth_hash, raw, result_raw
+		SELECT round, tx_index, tx_hash, tx_eth_hash, timestamp, raw, result_raw
 			FROM %[1]s.runtime_transactions
 			WHERE (runtime = '%[2]s') AND
 						($1::bigint IS NULL OR round = $1::bigint) AND

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -2,6 +2,8 @@
 package client
 
 import (
+	"time"
+
 	api "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 )
 
@@ -117,6 +119,7 @@ type RuntimeTransaction struct {
 	Index     int64
 	Hash      string
 	EthHash   *string
+	Timestamp time.Time
 	Raw       []byte
 	ResultRaw []byte
 }

--- a/storage/migrations/02_oasis_3_runtimes.up.sql
+++ b/storage/migrations/02_oasis_3_runtimes.up.sql
@@ -35,6 +35,7 @@ CREATE TABLE oasis_3.runtime_transactions
   tx_index    UINT31 NOT NULL,
   tx_hash     HEX64 NOT NULL,
   tx_eth_hash HEX64,
+  timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
   -- raw is cbor(UnverifiedTransaction). If you're unable to get a copy of the
   -- transaction from the node itself, parse from here. Remove this if we
   -- later store sufficiently detailed data in other columns or if we turn out


### PR DESCRIPTION
After this PR:
- analyzer saves block timestamp into the tx DB table (this is denormailzed, but I opted for this rather than a JOIN every time we're serving txs)
- API reads it from the DB, presents it

Resolves https://app.clickup.com/t/861maqp0p