### PR TITLE
EVM: remove chain ID check

### DIFF
--- a/analyzer/uncategorized/evm_raw_tx.go
+++ b/analyzer/uncategorized/evm_raw_tx.go
@@ -11,7 +11,7 @@ import (
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-func decodeEthRawTx(body []byte, expectedChainID uint64) (*sdkTypes.Transaction, error) {
+func decodeEthRawTx(body []byte) (*sdkTypes.Transaction, error) {
 	var ethTx ethTypes.Transaction
 	if err := ethTx.UnmarshalBinary(body); err != nil {
 		return nil, fmt.Errorf("rlp decode bytes: %w", err)
@@ -24,9 +24,6 @@ func decodeEthRawTx(body []byte, expectedChainID uint64) (*sdkTypes.Transaction,
 		tb = evmV1.Create(ethTx.Value().Bytes(), ethTx.Data())
 	}
 	chainIDBI := ethTx.ChainId()
-	if !chainIDBI.IsUint64() || chainIDBI.Uint64() != expectedChainID {
-		return nil, fmt.Errorf("chain ID %v, expected %v", chainIDBI, expectedChainID)
-	}
 	signer := ethTypes.LatestSignerForChainID(chainIDBI)
 	pubUncompressed, err := LondonSenderPub(signer, &ethTx)
 	if err != nil {

--- a/analyzer/uncategorized/evm_raw_tx_test.go
+++ b/analyzer/uncategorized/evm_raw_tx_test.go
@@ -17,7 +17,6 @@ import (
 // These tests are based on oasis-sdk/runtime-sdk/modules/evm/src/raw_tx.rs.
 
 type commonDetails struct {
-	chainID  uint64
 	value    uint64
 	gasLimit uint64
 	gasPrice uint64
@@ -43,7 +42,7 @@ func decodeExpectCall(
 ) {
 	rawBytes, err := hex.DecodeString(raw)
 	require.NoError(t, err)
-	tx, err := decodeEthRawTx(rawBytes, expected.chainID)
+	tx, err := decodeEthRawTx(rawBytes)
 	require.NoError(t, err)
 	t.Logf("%#v\n", tx)
 	require.Equal(t, tx.Call.Method, "evm.Call")
@@ -80,7 +79,7 @@ func decodeExpectCreate(
 ) {
 	rawBytes, err := hex.DecodeString(raw)
 	require.NoError(t, err)
-	tx, err := decodeEthRawTx(rawBytes, expected.chainID)
+	tx, err := decodeEthRawTx(rawBytes)
 	require.NoError(t, err)
 	t.Logf("%#v\n", tx)
 	require.Equal(t, tx.Call.Method, "evm.Create")
@@ -107,10 +106,10 @@ func decodeExpectCreate(
 	require.Equal(t, expected.gasLimit, tx.AuthInfo.Fee.Gas)
 }
 
-func decodeExpectInvalid(t *testing.T, raw string, expectedChainID uint64) {
+func decodeExpectInvalid(t *testing.T, raw string) {
 	rawBytes, err := hex.DecodeString(raw)
 	require.NoError(t, err)
-	_, err = decodeEthRawTx(rawBytes, expectedChainID)
+	_, err = decodeEthRawTx(rawBytes)
 	require.Error(t, err)
 	t.Logf("%#v\n", err)
 }
@@ -118,12 +117,11 @@ func decodeExpectInvalid(t *testing.T, raw string, expectedChainID uint64) {
 func decodeExpectFromMismatch(
 	t *testing.T,
 	raw string,
-	expectedChainID uint64,
 	unexpectedFrom string,
 ) {
 	rawBytes, err := hex.DecodeString(raw)
 	require.NoError(t, err)
-	tx, err := decodeEthRawTx(rawBytes, expectedChainID)
+	tx, err := decodeEthRawTx(rawBytes)
 	require.NoError(t, err)
 	t.Logf("%#v\n", tx)
 	require.Len(t, tx.AuthInfo.SignerInfo, 1)
@@ -139,7 +137,6 @@ func TestDecodeBasic(t *testing.T) {
 		"f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1",
 		&callDetails{
 			commonDetails: commonDetails{
-				chainID:  0,
 				value:    10_000_000_000_000_000,
 				gasLimit: 10_000,
 				gasPrice: 1_000_000_000_000,
@@ -158,7 +155,6 @@ func TestDecodeBasic(t *testing.T) {
 		"f87f8085e8d4a510008227108080af6025515b525b600a37f260003556601b596020356000355760015b525b54602052f260255860005b525b54602052f21ca05afed0244d0da90b67cf8979b0f246432a5112c0d31e8d5eedd2bc17b171c694a044efca37cb9883d1ee7a47236f3592df152931a930566933de2dc6e341c11426",
 		&createDetails{
 			commonDetails: commonDetails{
-				chainID:  0,
 				value:    0,
 				gasLimit: 10_000,
 				gasPrice: 1_000_000_000_000,
@@ -171,16 +167,6 @@ func TestDecodeBasic(t *testing.T) {
 	)
 }
 
-func TestDecodeChainId(t *testing.T) {
-	// Test with mismatching expect_chain_id to exercise our check.
-	decodeExpectInvalid(
-		t,
-		// Taken from test_decode_basic.
-		"f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1",
-		5,
-	)
-}
-
 func TestDecodeTypes(t *testing.T) {
 	// https://github.com/ethereum/tests/blob/v10.0/BlockchainTests/ValidBlocks/bcEIP1559/transType.json
 	decodeExpectCall(
@@ -188,7 +174,6 @@ func TestDecodeTypes(t *testing.T) {
 		"f861018203e882c35094cccccccccccccccccccccccccccccccccccccccc80801ca021539ef96c70ab75350c594afb494458e211c8c722a7a0ffb7025c03b87ad584a01d5395fe48edb306f614f0cd682b8c2537537f5fd3e3275243c42e9deff8e93d",
 		&callDetails{
 			commonDetails: commonDetails{
-				chainID:  0,
 				value:    0,
 				gasLimit: 50_000,
 				gasPrice: 1_000,
@@ -204,7 +189,6 @@ func TestDecodeTypes(t *testing.T) {
 		"01f86301028203e882c35094cccccccccccccccccccccccccccccccccccccccc8080c080a0260f95e555a1282ef49912ff849b2007f023c44529dc8fb7ecca7693cccb64caa06252cf8af2a49f4cb76fd7172feaece05124edec02db242886b36963a30c2606",
 		&callDetails{
 			commonDetails: commonDetails{
-				chainID:  1,
 				value:    0,
 				gasLimit: 50_000,
 				gasPrice: 1_000,
@@ -220,7 +204,6 @@ func TestDecodeTypes(t *testing.T) {
 		"02f8640103648203e882c35094cccccccccccccccccccccccccccccccccccccccc8080c001a08480e6848952a15ae06192b8051d213d689bdccdf8f14cf69f61725e44e5e80aa057c2af627175a2ac812dab661146dfc7b9886e885c257ad9c9175c3fcec2202e",
 		&callDetails{
 			commonDetails: commonDetails{
-				chainID:  1,
 				value:    0,
 				gasLimit: 50_000,
 				gasPrice: 100,
@@ -238,19 +221,16 @@ func TestDecodeVerify(t *testing.T) {
 	decodeExpectInvalid(
 		t,
 		"f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f1",
-		0,
 	)
 	// Altered signature, high s.
 	decodeExpectInvalid(
 		t,
 		"f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ca0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a0eb5a962cd82325b4d608b06c3f168d618b652f7440d8609ee6c4a37d10cff750",
-		0,
 	)
 	// Altered signature, s decreased by one.
 	decodeExpectFromMismatch(
 		t,
 		"f86b8085e8d4a510008227109413978aee95f38490e9769c39b2773ed763d9cd5f872386f26fc10000801ba0eab47c1a49bf2fe5d40e01d313900e19ca485867d462fe06e139e3a536c6d4f4a014a569d327dcda4b29f74f93c0e9729d2f49ad726e703f9cd90dbb0fbf6649f0",
-		0,
 		"cd2a3d9f938e13cd947ec05abc7fe734df8dd826",
 	)
 }

--- a/analyzer/uncategorized/runtimes.go
+++ b/analyzer/uncategorized/runtimes.go
@@ -15,7 +15,7 @@ func OpenUtxNoVerify(utx *sdkTypes.UnverifiedTransaction) (*sdkTypes.Transaction
 	if len(utx.AuthProofs) == 1 && utx.AuthProofs[0].Module != "" {
 		switch utx.AuthProofs[0].Module {
 		case "evm.ethereum.v0":
-			tx, err := decodeEthRawTx(utx.Body, 42262)
+			tx, err := decodeEthRawTx(utx.Body)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
for #305 

remove the chain ID check. it's arguably part of verifying an transaction, which we don't do in the indexer for runtimes

this makes the `decodeEthRawTx` function a little more footgun if anyone else discovers it though