### PR TITLE
evm tokens: remove Emerald references

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -189,9 +189,14 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeCipher, cfg.Node, cfg.Analyzers.Cipher, client, logger)
 		})
 	}
-	if cfg.Analyzers.EvmTokens != nil {
+	if cfg.Analyzers.EmeraldEvmTokens != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return evmtokens.NewMain(&cfg.Node, client, logger)
+			return evmtokens.NewMain(analyzer.RuntimeEmerald, &cfg.Node, client, logger)
+		})
+	}
+	if cfg.Analyzers.SapphireEvmTokens != nil {
+		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
+			return evmtokens.NewMain(analyzer.RuntimeSapphire, &cfg.Node, client, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -100,7 +100,8 @@ type AnalyzersList struct {
 	Sapphire  *BlockBasedAnalyzerConfig `koanf:"sapphire"`
 	Cipher    *BlockBasedAnalyzerConfig `koanf:"cipher"`
 
-	EvmTokens *EvmTokensAnalyzerConfig `koanf:"evm_tokens"`
+	EmeraldEvmTokens  *EvmTokensAnalyzerConfig `koanf:"evm_tokens_emerald"`
+	SapphireEvmTokens *EvmTokensAnalyzerConfig `koanf:"evm_tokens_sapphire"`
 
 	MetadataRegistry *IntervalBasedAnalyzerConfig `koanf:"metadata_registry"`
 	AggregateStats   *IntervalBasedAnalyzerConfig `koanf:"aggregate_stats"`


### PR DESCRIPTION
for #305 

resync boilerplate with runtime analyzer.

evm tokens analyzer is now split into emerald- and sapphire-specific ones