### PR TITLE
Add `/runtime/accounts/{addr}`; add stats to runtime account endpoint

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -895,6 +895,26 @@ paths:
                 $ref: '#/components/schemas/EvmTokenList'
         <<: *common_error_responses
 
+  /{runtime}/accounts/{address}:
+    get:
+      summary: Returns a runtime account.
+      parameters:
+        - *runtime
+        - in: path
+          name: address
+          required: true
+          schema:
+            <<: *StakingAddressType
+          description: The staking address of the account to return.
+      responses:
+        '200':
+          description: A JSON object containing a runtime layer account.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeAccount'
+        <<: *common_error_responses
+
   /{layer}/stats/tx_volume:
     get:
       summary: |
@@ -1490,25 +1510,14 @@ components:
             is the Ethereum address (in base64, not hex!).
           example: 'INLp2Ih3YIdcA+zFNhM+SIGyFgKsYYc9SKQeKRKe2uI='
 
-    RuntimeName:
-      description: |
-        The name of a runtime. This is a human-readable identifier, and should
-        stay stable across runtime upgrades/versions.
-      type: string
-      enum:
-        - emerald
-      example: emerald
-
     RuntimeSdkBalance:
       description: Balance of an account for a specific runtime and oasis-sdk token (e.g. ROSE).
       type: object
-      required: [balance, runtime, token_symbol, token_decimals]
+      required: [balance, token_symbol, token_decimals]
       properties:
         balance:
           <<: *BigIntType
           description: Number of tokens held, in base units.
-        runtime:
-          $ref: "#/components/schemas/RuntimeName"
         token_symbol:
           type: string
           description: The token ticker symbol. Unique across all oasis-sdk tokens in the same runtime.
@@ -1521,13 +1530,11 @@ components:
     RuntimeEvmBalance:
       description: Balance of an account for a specific runtime and EVM token.
       type: object
-      required: [balance, runtime, token_contract_addr, token_decimals]
+      required: [balance, token_contract_addr, token_decimals]
       properties:
         balance:
           <<: *BigIntType
           description: Number of tokens held, in base units.
-        runtime:
-          $ref: "#/components/schemas/RuntimeName"
         token_contract_addr:
           type: string
           description: The EVM address of this token's contract. Encoded as a lowercase hex string.
@@ -1553,29 +1560,11 @@ components:
           type: string
           description: The staking address for this account.
           example: *staking_address_1
-        address_preimage:
-          $ref: '#/components/schemas/AddressPreimage'
         nonce:
           type: integer
           format: int64
           description: A nonce used to prevent replay.
           example: 0
-        runtime_sdk_balances:
-          description: |
-            The balances of this account in each runtime, as managed by oasis-sdk.
-            NOTE 1: This field is omitted for efficiency when listing multiple accounts.
-            NOTE 2: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
-          type: array
-          items:
-            $ref: '#/components/schemas/RuntimeSdkBalance'
-        runtime_evm_balances:
-          description: |
-            The balances of this account in each runtime, as managed by EVM smart contracts (notably, ERC-20).
-            NOTE 1: This field is omitted for efficiency when listing multiple accounts.
-            NOTE 2: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
-          type: array
-          items:
-            $ref: '#/components/schemas/RuntimeEvmBalance'
         available:
           <<: *BigIntType
           description: The available balance, in base units.
@@ -2008,7 +1997,7 @@ components:
           type: string
           description: |
             A reasonable "amount" associated with this transaction, if
-            applicable. The meaning varies based on the transaction mehtod.
+            applicable. The meaning varies based on the transaction method.
             Usually in native denomination, ParaTime units. As a string.
           example: "100000001666393459"
         success:
@@ -2016,6 +2005,35 @@ components:
           description: Whether this transaction successfully executed.
       description: |
         A runtime transaction.
+
+    RuntimeAccount:
+      type: object
+      required: [address, runtime, balances, evm_balances, stats]
+      properties:
+        address:
+          type: string
+          description: The staking address for this account.
+          example: *staking_address_1
+        address_preimage:
+          $ref: '#/components/schemas/AddressPreimage'
+        balances:
+          description: |
+            The balance(s) of this account in this runtime. Most runtimes use only one denomination, and thus
+            produce only one balance here. These balances do not include "layer (n+1) tokens", i.e. tokens
+            managed by smart contracts deployed in this runtime. For example, in EVM-compatible runtimes,
+            this does not include ERC-20 tokens
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeSdkBalance'
+        evm_balances:
+          description: |
+            The balances of this account in each runtime, as managed by EVM smart contracts (notably, ERC-20).
+            NOTE: This field is limited to 1000 entries. If you need more, please let us know in a GitHub issue.
+          type: array
+          items:
+            $ref: '#/components/schemas/RuntimeEvmBalance'
+        stats:
+          $ref: '#/components/schemas/AccountStats'
 
     EvmTokenType:
       type: string
@@ -2084,6 +2102,22 @@ components:
             The number of addresses that have a nonzero balance of this token,
             as calculated from Transfer events.
           example: 123
+    
+    AccountStats:
+      type: object
+      required: [total_sent, total_received, num_txns]
+      properties:
+        total_sent:
+          description: The total number of tokens sent, in base units.
+          <<: *BigIntType
+        total_received:
+          description: The total number of tokens received, in base units.
+          <<: *BigIntType
+        num_txns:
+          description: The total number of transactions this account was involved with.
+          type: integer
+          format: uint64
+          example: 4184
 
     TxVolumeList:
       type: object

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -288,3 +288,11 @@ func (srv *StrictServerImpl) GetRuntimeEvents(ctx context.Context, request apiTy
 	}
 	return apiTypes.GetRuntimeEvents200JSONResponse(*events), nil
 }
+
+func (srv *StrictServerImpl) GetRuntimeAccountsAddress(ctx context.Context, request apiTypes.GetRuntimeAccountsAddressRequestObject) (apiTypes.GetRuntimeAccountsAddressResponseObject, error) {
+	account, err := srv.dbClient.RuntimeAccount(ctx, request.Address)
+	if err != nil {
+		return nil, err
+	}
+	return apiTypes.GetRuntimeAccountsAddress200JSONResponse(*account), nil
+}

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -46,14 +46,6 @@ type AccountList = api.AccountList
 // Account is the storage response for GetAccount.
 type Account = api.Account
 
-// Types that are a part of the storage response for GetAccount.
-type (
-	AddressPreimage          = api.AddressPreimage
-	AddressDerivationContext = api.AddressDerivationContext
-	RuntimeSdkBalance        = api.RuntimeSdkBalance
-	RuntimeEvmBalance        = api.RuntimeEvmBalance
-)
-
 // DebondingDelegationList is the storage response for ListDebondingDelegations.
 type DebondingDelegationList = api.DebondingDelegationList
 
@@ -135,6 +127,18 @@ type RuntimeEventList = api.RuntimeEventList
 type RuntimeEvent = api.RuntimeEvent
 
 type RuntimeEventType = api.RuntimeEventType
+
+// Types that are a part of the storage response for GetRuntimeAccount.
+type (
+	AddressPreimage          = api.AddressPreimage
+	AddressDerivationContext = api.AddressDerivationContext
+	RuntimeSdkBalance        = api.RuntimeSdkBalance
+	RuntimeEvmBalance        = api.RuntimeEvmBalance
+)
+
+type RuntimeAccount = api.RuntimeAccount
+
+type AccountStats = api.AccountStats
 
 type EvmTokenList = api.EvmTokenList
 

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -108,7 +108,6 @@ func TestIndexer(t *testing.T) {
 	err = tests.GetFrom(fmt.Sprintf("/consensus/accounts/%s", bobAddress), &account)
 	require.Nil(t, err)
 	require.Equal(t, account.Address, bobAddress.String())
-	require.Nil(t, account.AddressPreimage)
 	require.Zero(t, account.Nonce)
 	require.Zero(t, account.Available)
 	require.Zero(t, *account.DelegationsBalance)


### PR DESCRIPTION
Resolves #325 

Open questions:
- We'd like to support querying runtime accounts by the runtime address (eth address) as well as the consensus address. Whether or not to scope that into the MVP/this ticket is up for debate.
- Do we want to support multiple oasis-sdk balances per runtime? Doing so slightly complicates the schema (need a list of `runtimeSdkBalance`). AFAIK we only currently use 'ROSE' as the native denomination and have no plans to add more. I'd prefer to keep it simple if possible.
- Do we want to include `AccountStats` for consensus accounts if we can only show the `numTxs` for them? As Mitja pointed out, we cannot show total sent/received bc we have no consensus transfers table

Edit** 
Impl open questions:
- ~~If there is no matching entry in the `address_preimages` table, we have not seen this address in runtimes before and return 404; is this alright? Before, in the old `/consensus/account/{addr}` endpoint, we'd ignore this and leave default values because we did a full outer join and an account could only have consensus data. On the frontend, we def want to display a zero-valued account; but I'm not as sure what the backend api should display.~~
- Edit*** After thinking more I'm in favor of not doing 404s and instead returning zero-valued account objects. Better to be consistent with the frontend. (and consensus endpoint)
- Do we want a generic `/{runtime}/accounts` endpoint similar to the consensus one?

Note: For both runtime_balances and evm_balances, we now return an empty list instead of making the entire field nullable (and removing the key). I believe this was was originally nullable for the same reasons as the above point (full outer join; the addr might be valid but have no runtime data). I prefer to make this change since it more accurately describes the account state; it's probably more ergonomic for frontend folks, and it mirrors what we do in `consensus/account/{addr}` for `allowances`. But lmk if anyone feels strongly otherwise.

OTOH, if we want to implement `/emerald/accounts` we may want to make `evm_balances` optional for performance reasons. 