### PR TITLE
include codegen files in docker image

### DIFF
--- a/docker/indexer/Dockerfile
+++ b/docker/indexer/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update -q -q && \
 
 COPY --from=oasis-indexer-builder /code/go/oasis-indexer /usr/local/bin/oasis-indexer
 COPY --from=oasis-indexer-builder /code/go/storage/migrations /storage/migrations/
-COPY . /oasis-indexer
+COPY --from=oasis-indexer-builder /code/go/ /oasis-indexer
 COPY --from=openapi-builder /api/spec/v1.html api/spec/v1.html
 
 ENTRYPOINT ["oasis-indexer"]


### PR DESCRIPTION
In support of https://github.com/oasislabs/private-charts/pull/552

We now copy the repo _after_ `make codegen-go` has been run in the build process.

Without the codegen files; the statecheck tests fail. We already copy the repo into the dockerfile, so the added size of the generated files is marginal.