### PR TITLE
db: runtime_events table: add indexes

### DIFF
--- a/storage/migrations/02_oasis_3_runtimes.up.sql
+++ b/storage/migrations/02_oasis_3_runtimes.up.sql
@@ -98,6 +98,8 @@ CREATE TABLE oasis_3.runtime_events
   evm_log_params JSONB,
   related_accounts TEXT[]
 );
+CREATE INDEX ix_runtime_events_round ON oasis_3.runtime_events(runtime, round);  -- for sorting by round, when there are no filters applied
+CREATE INDEX ix_runtime_events_tx_hash ON oasis_3.runtime_events(tx_hash);
 CREATE INDEX ix_runtime_events_related_accounts ON oasis_3.runtime_events USING gin(related_accounts);
 CREATE INDEX ix_runtime_events_evm_log_signature ON oasis_3.runtime_events(evm_log_signature);
 CREATE INDEX ix_runtime_events_evm_log_params ON oasis_3.runtime_events USING gin(evm_log_params);


### PR DESCRIPTION
Based on a report from @lukaw3d where the following two queries timed out:
 - https://index-staging.oasislabs.com/v1/emerald/events?tx_hash=1ada4eb14e50d7c5426f707b6d636e2222280308f09356c1cb2c14503fe927e3
 - https://index-staging.oasislabs.com/v1/emerald/events?limit=1

This PR adds an index for each of those two queries.

Already applied in staging and prod DBs. Queries are fast now.