### PR TITLE
api: add gas_used and size to runtime transactions

### DIFF
--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -375,8 +375,8 @@ func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
 	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, timestamp, raw, result_raw)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, gas_used, size, timestamp, raw, result_raw)
+			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7, $8, $9)`, qf.chainID, qf.runtime)
 }
 
 func (qf QueryFactory) RuntimeEventInsertQuery() string {

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1909,7 +1909,7 @@ components:
     RuntimeTransaction:
       type: object
       # NOTE: Not guaranteed to be present: eth_hash, to, amount.
-      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, gas_limit, method, body, success]
+      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, gas_limit, gas_used, size, method, body, success]
       properties:
         round:
           type: integer
@@ -1969,6 +1969,14 @@ components:
             The maximum gas that this transaction's sender committed to use to
             execute it.
           example: 30000
+        gas_used:
+          type: integer
+          format: uint64
+          description: The total gas used by the transaction.
+        size:
+          type: integer
+          format: int32
+          description: The total byte size of the transaction.
         method:
           type: string
           description: The method that was called.

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -42,6 +42,8 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 		Index:      storageTransaction.Index,
 		Hash:       storageTransaction.Hash,
 		EthHash:    storageTransaction.EthHash,
+		GasUsed:    storageTransaction.GasUsed,
+		Size:       storageTransaction.Size,
 		Timestamp:  storageTransaction.Timestamp,
 		Sender0:    sender0,
 		Sender0Eth: sender0Eth,

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -999,6 +999,8 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 			&t.Index,
 			&t.Hash,
 			&t.EthHash,
+			&t.GasUsed,
+			&t.Size,
 			&t.Timestamp,
 			&t.Raw,
 			&t.ResultRaw,

--- a/storage/client/queries.go
+++ b/storage/client/queries.go
@@ -397,6 +397,8 @@ func (qf QueryFactory) RuntimeTransactionsQuery() string {
 			txs.tx_index,
 			txs.tx_hash,
 			txs.tx_eth_hash,
+			txs.gas_used,
+			txs.size,
 			txs.timestamp,
 			txs.raw,
 			txs.result_raw,

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -113,6 +113,8 @@ type RuntimeTransaction struct {
 	Index           int64
 	Hash            string
 	EthHash         *string
+	GasUsed         uint64
+	Size            int32
 	Sender0         *string
 	Sender0Eth      *string
 	Timestamp       time.Time

--- a/storage/migrations/02_oasis_3_runtimes.up.sql
+++ b/storage/migrations/02_oasis_3_runtimes.up.sql
@@ -35,6 +35,8 @@ CREATE TABLE oasis_3.runtime_transactions
   tx_index    UINT31 NOT NULL,
   tx_hash     HEX64 NOT NULL,
   tx_eth_hash HEX64,
+  gas_used UINT63 NOT NULL,
+  size UINT31 NOT NULL,
   timestamp TIMESTAMP WITH TIME ZONE NOT NULL,
   -- raw is cbor(UnverifiedTransaction). If you're unable to get a copy of the
   -- transaction from the node itself, parse from here. Remove this if we


### PR DESCRIPTION
Resolves #336 

Testing:
Manually tested locally against a production node and checked that the `gas_used` matched the value reported by the current emerald explorer. `size` is a bit more tricky to verify since the emerald explorer doesn't show it. Warren and I also briefly discussed this and it seems like the way we re-serialize transactions could possibly differ from the way the original transaction was cbor-encoded if the original transaction was serialized in a non-standard manner (which the runtime accepts). Our calculated `size` may be inaccurate in these cases, but to our knowledge this is rare.