### PR TITLE
analyzer: remove concurrency in runtime analyzer

### DIFF
--- a/analyzer/modules/accounts.go
+++ b/analyzer/modules/accounts.go
@@ -1,8 +1,6 @@
 package modules
 
 import (
-	"context"
-	"fmt"
 	"math/big"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
@@ -30,18 +28,13 @@ func NewAccountsHandler(source storage.RuntimeSourceStorage, runtime analyzer.Ru
 
 // PrepareAccountsData prepares raw data from the `accounts` module for insertion.
 // into target storage.
-func (h *AccountsHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
-	data, err := h.source.AccountsData(ctx, round)
-	if err != nil {
-		return fmt.Errorf("error retrieving accounts data: %w", err)
-	}
-
+func (h *AccountsHandler) PrepareData(batch *storage.QueryBatch, data *storage.RuntimeAllData) error {
 	for _, f := range []func(*storage.QueryBatch, *storage.AccountsData) error{
 		h.queueMints,
 		h.queueBurns,
 		h.queueTransfers,
 	} {
-		if err := f(batch, data); err != nil {
+		if err := f(batch, data.AccountsData); err != nil {
 			return err
 		}
 	}

--- a/analyzer/modules/api.go
+++ b/analyzer/modules/api.go
@@ -1,16 +1,14 @@
 package modules
 
 import (
-	"context"
-
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
 
 // ModuleHandler handles parsing rounds for a runtime module.
 type ModuleHandler interface {
-	// PrepareData prepares data at the specified from the module this ModuleHandler is for
-	// insertion into a relational database via the provided QueryBatch.
-	PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error
+	// PrepareData prepares data from the specified module for insertion
+	// into a relational database via the provided QueryBatch.
+	PrepareData(batch *storage.QueryBatch, data *storage.RuntimeAllData) error
 
 	// Name returns the name of this ModuleHandler.
 	Name() string

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -1,9 +1,6 @@
 package modules
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -30,17 +27,12 @@ func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtime an
 
 // PrepareConsensusAccountsData prepares raw data from the `consensus_accounts` module for insertion.
 // into target storage.
-func (h *ConsensusAccountsHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
-	data, err := h.source.ConsensusAccountsData(ctx, round)
-	if err != nil {
-		return fmt.Errorf("error retrieving consensus_accounts data: %w", err)
-	}
-
+func (h *ConsensusAccountsHandler) PrepareData(batch *storage.QueryBatch, data *storage.RuntimeAllData) error {
 	for _, f := range []func(*storage.QueryBatch, *storage.ConsensusAccountsData) error{
 		h.queueDeposits,
 		h.queueWithdraws,
 	} {
-		if err := f(batch, data); err != nil {
+		if err := f(batch, data.ConsensusAccountsData); err != nil {
 			return err
 		}
 	}

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -1,9 +1,6 @@
 package modules
 
 import (
-	"context"
-	"fmt"
-
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -29,16 +26,11 @@ func NewCoreHandler(source storage.RuntimeSourceStorage, runtime analyzer.Runtim
 
 // PrepareCoreData prepares raw data from the `core` module for insertion.
 // into target storage.
-func (h *CoreHandler) PrepareData(ctx context.Context, round uint64, batch *storage.QueryBatch) error {
-	data, err := h.source.CoreData(ctx, round)
-	if err != nil {
-		return fmt.Errorf("error retrieving core data: %w", err)
-	}
-
+func (h *CoreHandler) PrepareData(batch *storage.QueryBatch, data *storage.RuntimeAllData) error {
 	for _, f := range []func(*storage.QueryBatch, *storage.CoreData) error{
 		h.queueGasUsed,
 	} {
-		if err := f(batch, data); err != nil {
+		if err := f(batch, data.CoreData); err != nil {
 			return err
 		}
 	}

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -25,6 +25,40 @@ type RuntimeClient struct {
 	rtCtx runtimeSignature.Context
 }
 
+// AllData returns all relevant data to the given round.
+func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.RuntimeAllData, error) {
+	blockData, err := rc.BlockData(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+	coreData, err := rc.CoreData(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+	accountsData, err := rc.AccountsData(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+	consensusAccountsData, err := rc.ConsensusAccountsData(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+	rawEvents, err := rc.GetEventsRaw(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+
+	data := storage.RuntimeAllData{
+		Round:                 round,
+		BlockData:             blockData,
+		CoreData:              coreData,
+		AccountsData:          accountsData,
+		ConsensusAccountsData: consensusAccountsData,
+		RawEvents:             rawEvents,
+	}
+	return &data, nil
+}
+
 // BlockData gets block data in the specified round.
 func (rc *RuntimeClient) BlockData(ctx context.Context, round uint64) (*storage.RuntimeBlockData, error) {
 	block, err := rc.client.GetBlock(ctx, round)


### PR DESCRIPTION
One way to resolve #339 

This PR removes concurrency from the runtime analyzer. It also refactors the runtime analyzer to fetch all the data initially and then process it sequentially, similar to the consensus analyzer. 

Open Question:
- Should we keep the added mutex in `storage.QueryBatch`? (see the second commit) During local testing, the additional lock/unlock did not degrade the analyzer speed since the bottleneck is the network requests to the node. Although this mutex is now unnecessary, having a thread-safe `QueryBatch` would prevent this type of bug from sneaking in (again) though. 