### PR TITLE
Minor fixes: improve db ergonomics, e2e testing

### DIFF
--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -143,31 +143,18 @@ func (n Network) String() string {
 }
 
 // Runtime is an identifier for a runtime on the Oasis Network.
-type Runtime uint16
+type Runtime string
 
 const (
-	// RuntimeEmerald is the identifier for the Emerald Runtime.
-	RuntimeEmerald Runtime = iota
-	// RuntimeCipher is the identifier for the Cipher Runtime.
-	RuntimeCipher
-	// RuntimeSapphire is the identifier for the Sapphire Runtime.
-	RuntimeSapphire
-	// RuntimeUnknown is the identifier for an unknown Runtime.
-	RuntimeUnknown = 1000
+	RuntimeEmerald  Runtime = "emerald"
+	RuntimeCipher   Runtime = "cipher"
+	RuntimeSapphire Runtime = "sapphire"
+	RuntimeUnknown  Runtime = "unknown"
 )
 
 // String returns the string representation of a runtime.
 func (r Runtime) String() string {
-	switch r {
-	case RuntimeEmerald:
-		return "emerald"
-	case RuntimeCipher:
-		return "cipher"
-	case RuntimeSapphire:
-		return "sapphire"
-	default:
-		return "unknown"
-	}
+	return string(r)
 }
 
 // ID returns the ID for a Runtime on the provided network.

--- a/storage/api.go
+++ b/storage/api.go
@@ -25,14 +25,14 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-type batchItem struct {
-	cmd  string
-	args []interface{}
+type BatchItem struct {
+	Cmd  string
+	Args []interface{}
 }
 
 // QueryBatch represents a batch of queries to be executed atomically.
 // We use a custom type that mirrors pgx.Batch but also allows introspection for debugging.
-type QueryBatch struct{ items []*batchItem }
+type QueryBatch struct{ items []*BatchItem }
 
 // QueryResults represents the results from a read query.
 type QueryResults = pgx.Rows
@@ -45,9 +45,9 @@ type TxOptions = pgx.TxOptions
 
 // Queue adds query to a batch.
 func (b *QueryBatch) Queue(cmd string, args ...interface{}) {
-	b.items = append(b.items, &batchItem{
-		cmd:  cmd,
-		args: args,
+	b.items = append(b.items, &BatchItem{
+		Cmd:  cmd,
+		Args: args,
 	})
 }
 
@@ -65,20 +65,14 @@ func (b *QueryBatch) Len() int {
 func (b *QueryBatch) AsPgxBatch() pgx.Batch {
 	pgxBatch := pgx.Batch{}
 	for _, item := range b.items {
-		pgxBatch.Queue(item.cmd, item.args...)
+		pgxBatch.Queue(item.Cmd, item.Args...)
 	}
 	return pgxBatch
 }
 
-// Queries returns the queries in the batch. Each item of the returned slice
-// is composed of the SQL command and its arguments.
-func (b *QueryBatch) Queries() [][]interface{} {
-	queries := make([][]interface{}, len(b.items))
-	for idx, item := range b.items {
-		queries[idx] = []interface{}{item.cmd}
-		queries[idx] = append(queries[idx], item.args...)
-	}
-	return queries
+// Queries returns the queries in the batch.
+func (b *QueryBatch) Queries() []*BatchItem {
+	return b.items
 }
 
 // ConsensusSourceStorage defines an interface for retrieving raw block data

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -5,6 +5,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -93,13 +94,28 @@ func (c *Client) SendBatch(ctx context.Context, batch *storage.QueryBatch) error
 }
 
 func (c *Client) SendBatchWithOptions(ctx context.Context, batch *storage.QueryBatch, opts pgx.TxOptions) error {
-	pgxBatch := batch.AsPgxBatch()
 	if err := c.pool.BeginTxFunc(ctx, opts, func(tx pgx.Tx) error {
-		batchResults := tx.SendBatch(ctx, &pgxBatch)
-		defer common.CloseOrLog(batchResults, c.logger)
-		for i := 0; i < pgxBatch.Len(); i++ {
-			if _, err := batchResults.Exec(); err != nil {
-				return fmt.Errorf("query %d %v: %w", i, batch.Queries()[i], err)
+		// NOTE: Sending txs with tx.SendBatch(batch.AsPgxBatch()) is possibly more
+		// efficient. However, it reports errors poorly: If _any_ query is syntactically
+		// malformed, called with the wrong number of args, or has a type conversion problem,
+		// pgx will report the _first_ query as failing.
+		if os.Getenv("PGX_FAST_BATCH") == "1" {
+			// TODO: Remove this branch if we verify that the performance gain is negligible.
+			pgxBatch := batch.AsPgxBatch()
+			batchResults := tx.SendBatch(ctx, &pgxBatch)
+			defer common.CloseOrLog(batchResults, c.logger)
+			for i := 0; i < pgxBatch.Len(); i++ {
+				if _, err := batchResults.Exec(); err != nil {
+					return fmt.Errorf("query %d %v: %w", i, batch.Queries()[i], err)
+				}
+			}
+		} else {
+			for i, q := range batch.Queries() {
+				sql := q[0].(string)
+				args := q[1:]
+				if _, err := tx.Exec(ctx, sql, args...); err != nil {
+					return fmt.Errorf("query %d %v: %w", i, q, err)
+				}
 			}
 		}
 

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -111,9 +111,7 @@ func (c *Client) SendBatchWithOptions(ctx context.Context, batch *storage.QueryB
 			}
 		} else {
 			for i, q := range batch.Queries() {
-				sql := q[0].(string)
-				args := q[1:]
-				if _, err := tx.Exec(ctx, sql, args...); err != nil {
+				if _, err := tx.Exec(ctx, q.Cmd, q.Args...); err != nil {
 					return fmt.Errorf("query %d %v: %w", i, q, err)
 				}
 			}

--- a/tests/e2e_regression/run.sh
+++ b/tests/e2e_regression/run.sh
@@ -105,7 +105,7 @@ diff --recursive "$SCRIPT_DIR/expected" "$outDir" >/dev/null || {
   echo "  git diff --no-index $SCRIPT_DIR/{expected,actual}"
   echo
   echo "If the new results are expected, re-run this script after copying the new results into .../expected:"
-  echo "  cp $SCRIPT_DIR/{actual/*,expected}"
+  echo "  rm -rf $SCRIPT_DIR/expected; cp -r $SCRIPT_DIR/{actual,expected}"
   exit 1
 }
 


### PR DESCRIPTION
Various minor fixes in preparation for https://github.com/oasisprotocol/oasis-indexer/pull/341:
- Expands e2e_regression script so it works smoothly when running&testing multiple block analyzers (e.g. consensus and emerald)
- Tweaks the mechanism via which we submit query batches to the DB; the new approach is possibly (unconfirmed) a little slower but produces more helpful error messages
- Changes the analyzer-internal Runtime enum so its underlying type is `string` rather than `int`; this way, it can be passed directly into SQL queries and pgx knows how to interpret it.
- Makes the internal `QueryBatch.Queries()` method return a more structured type (cmd and args separately), for cleaner usage and easier-to-read logs (in which queries appear when there's an error).