### PR TITLE
refactor: Remove QueryFactory

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgx/v4"
 
 	"github.com/oasisprotocol/oasis-indexer/config"
@@ -54,7 +53,6 @@ var dailyActiveAccountsLayers = []string{
 }
 
 type AggregateStatsAnalyzer struct {
-	qf     QueryFactory
 	target storage.TargetStorage
 
 	txVolumeInterval time.Duration
@@ -72,7 +70,6 @@ func (a *AggregateStatsAnalyzer) Name() string {
 func NewAggregateStatsAnalyzer(chainID string, cfg *config.AggregateStatsConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
 	logger.Info("starting aggregate_stats analyzer")
 	return &AggregateStatsAnalyzer{
-		qf:               NewQueryFactory(strcase.ToSnake(chainID), "" /*runtime*/),
 		target:           target,
 		txVolumeInterval: cfg.TxVolumeInterval,
 		logger:           logger.With("analyzer", AggregateStatsAnalyzerName),

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/iancoleman/strcase"
 	"github.com/jackc/pgx/v4"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -49,7 +48,6 @@ type parsedEvent struct {
 // Main is the main Analyzer for the consensus layer.
 type Main struct {
 	cfg     analyzer.ConsensusConfig
-	qf      analyzer.QueryFactory
 	target  storage.TargetStorage
 	logger  *log.Logger
 	metrics metrics.DatabaseMetrics
@@ -96,7 +94,6 @@ func NewMain(nodeCfg config.NodeConfig, cfg *config.BlockBasedAnalyzerConfig, ta
 	logger.Info("Starting consensus analyzer", "config", ac)
 	return &Main{
 		cfg:     ac,
-		qf:      analyzer.NewQueryFactory(strcase.ToSnake(nodeCfg.ChainID), "" /* no runtime identifier for the consensus layer */),
 		target:  target,
 		logger:  logger.With("analyzer", ConsensusAnalyzerName),
 		metrics: metrics.NewDefaultDatabaseMetrics(ConsensusAnalyzerName),

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -110,7 +110,7 @@ type StaleToken struct {
 
 func (m Main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, error) {
 	var staleTokens []*StaleToken
-	rows, err := m.target.Query(ctx, m.qf.RuntimeEVMTokensAnalysisStaleQuery(), limit)
+	rows, err := m.target.Query(ctx, m.qf.RuntimeEVMTokensAnalysisStaleQuery(), m.runtime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying discovered tokens: %w", err)
 	}
@@ -170,6 +170,7 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 				}
 				if tokenData != nil {
 					batch.Queue(m.qf.RuntimeEVMTokenInsertQuery(),
+						m.runtime,
 						staleToken.Addr,
 						tokenData.Type,
 						tokenData.Name,
@@ -191,11 +192,12 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 					return fmt.Errorf("downloading mutated token %s: %w", staleToken.Addr, err)
 				}
 				batch.Queue(m.qf.RuntimeEVMTokenUpdateQuery(),
+					m.runtime,
 					staleToken.Addr,
 					mutable.TotalSupply.String(),
 				)
 			}
-			batch.Queue(m.qf.RuntimeEVMTokenAnalysisUpdateQuery(), staleToken.Addr, staleToken.LastMutateRound)
+			batch.Queue(m.qf.RuntimeEVMTokenAnalysisUpdateQuery(), m.runtime, staleToken.Addr, staleToken.LastMutateRound)
 			return nil
 		})
 	}

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/modules"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -105,7 +106,7 @@ type StaleToken struct {
 
 func (m Main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, error) {
 	var staleTokens []*StaleToken
-	rows, err := m.target.Query(ctx, m.qf.RuntimeEVMTokensAnalysisStaleQuery(), m.runtime, limit)
+	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokensAnalysisStale, m.runtime, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying discovered tokens: %w", err)
 	}
@@ -164,7 +165,7 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 					return fmt.Errorf("downloading new token %s: %w", staleToken.Addr, err)
 				}
 				if tokenData != nil {
-					batch.Queue(m.qf.RuntimeEVMTokenInsertQuery(),
+					batch.Queue(queries.RuntimeEVMTokenInsert,
 						m.runtime,
 						staleToken.Addr,
 						tokenData.Type,
@@ -186,13 +187,13 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 				if err != nil {
 					return fmt.Errorf("downloading mutated token %s: %w", staleToken.Addr, err)
 				}
-				batch.Queue(m.qf.RuntimeEVMTokenUpdateQuery(),
+				batch.Queue(queries.RuntimeEVMTokenUpdate,
 					m.runtime,
 					staleToken.Addr,
 					mutable.TotalSupply.String(),
 				)
 			}
-			batch.Queue(m.qf.RuntimeEVMTokenAnalysisUpdateQuery(), m.runtime, staleToken.Addr, staleToken.LastMutateRound)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisUpdate, m.runtime, staleToken.Addr, staleToken.LastMutateRound)
 			return nil
 		})
 	}

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iancoleman/strcase"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"golang.org/x/sync/errgroup"
 
@@ -37,7 +36,6 @@ const (
 type Main struct {
 	runtime analyzer.Runtime
 	cfg     analyzer.RuntimeConfig
-	qf      analyzer.QueryFactory
 	target  storage.TargetStorage
 	logger  *log.Logger
 }
@@ -87,12 +85,9 @@ func NewMain(
 		Source: client,
 	}
 
-	qf := analyzer.NewQueryFactory(strcase.ToSnake(nodeCfg.ChainID), runtime.String())
-
 	return &Main{
 		runtime: runtime,
 		cfg:     ac,
-		qf:      qf,
 		target:  target,
 		logger:  logger.With("analyzer", EvmTokensAnalyzerPrefix+runtime.String()),
 	}, nil

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/iancoleman/strcase"
 	registry "github.com/oasisprotocol/metadata-registry-tools"
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -16,7 +15,6 @@ import (
 const MetadataRegistryAnalyzerName = "metadata_registry"
 
 type MetadataRegistryAnalyzer struct {
-	qf       QueryFactory
 	target   storage.TargetStorage
 	logger   *log.Logger
 	metrics  metrics.DatabaseMetrics
@@ -37,7 +35,6 @@ func NewMetadataRegistryAnalyzer(chainID string, cfg *config.MetadataRegistryCon
 	logger.Info("Starting metadata_registry analyzer")
 	return &MetadataRegistryAnalyzer{
 		interval: cfg.Interval,
-		qf:       NewQueryFactory(strcase.ToSnake(chainID), "" /*runtime*/),
 		target:   target,
 		logger:   logger.With("analyzer", MetadataRegistryAnalyzerName),
 		metrics:  metrics.NewDefaultDatabaseMetrics(MetadataRegistryAnalyzerName),

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	registry "github.com/oasisprotocol/metadata-registry-tools"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/metrics"
@@ -76,7 +77,7 @@ func (a *MetadataRegistryAnalyzer) queueUpdates(ctx context.Context, batch *stor
 
 	for id, meta := range entities {
 		batch.Queue(
-			a.qf.ConsensusEntityMetaUpsertQuery(),
+			queries.ConsensusEntityMetaUpsert,
 			id.String(),
 			meta,
 		)

--- a/analyzer/modules/accounts.go
+++ b/analyzer/modules/accounts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -56,7 +57,7 @@ func (h *AccountsHandler) queueMints(batch *storage.QueryBatch, data *storage.Ac
 	for _, mint := range data.Mints {
 		// Record the event.
 		batch.Queue(
-			h.qf.RuntimeMintInsertQuery(),
+			queries.RuntimeMintInsert,
 			h.runtimeName,
 			data.Round,
 			mint.Owner.String(),
@@ -65,7 +66,7 @@ func (h *AccountsHandler) queueMints(batch *storage.QueryBatch, data *storage.Ac
 		)
 		// Increase minter's balance.
 		batch.Queue(
-			h.qf.RuntimeNativeBalanceUpdateQuery(),
+			queries.RuntimeNativeBalanceUpdate,
 			h.runtimeName,
 			mint.Owner.String(),
 			h.source.StringifyDenomination(mint.Amount.Denomination),
@@ -80,7 +81,7 @@ func (h *AccountsHandler) queueBurns(batch *storage.QueryBatch, data *storage.Ac
 	for _, burn := range data.Burns {
 		// Record the event.
 		batch.Queue(
-			h.qf.RuntimeBurnInsertQuery(),
+			queries.RuntimeBurnInsert,
 			h.runtimeName,
 			data.Round,
 			burn.Owner.String(),
@@ -89,7 +90,7 @@ func (h *AccountsHandler) queueBurns(batch *storage.QueryBatch, data *storage.Ac
 		)
 		// Decrease burner's balance.
 		batch.Queue(
-			h.qf.RuntimeNativeBalanceUpdateQuery(),
+			queries.RuntimeNativeBalanceUpdate,
 			h.runtimeName,
 			burn.Owner.String(),
 			h.source.StringifyDenomination(burn.Amount.Denomination),
@@ -104,7 +105,7 @@ func (h *AccountsHandler) queueTransfers(batch *storage.QueryBatch, data *storag
 	for _, transfer := range data.Transfers {
 		// Record the event.
 		batch.Queue(
-			h.qf.RuntimeTransferInsertQuery(),
+			queries.RuntimeTransferInsert,
 			h.runtimeName,
 			data.Round,
 			transfer.From.String(),
@@ -114,7 +115,7 @@ func (h *AccountsHandler) queueTransfers(batch *storage.QueryBatch, data *storag
 		)
 		// Increase receiver's balance.
 		batch.Queue(
-			h.qf.RuntimeNativeBalanceUpdateQuery(),
+			queries.RuntimeNativeBalanceUpdate,
 			h.runtimeName,
 			transfer.To.String(),
 			h.source.StringifyDenomination(transfer.Amount.Denomination),
@@ -122,7 +123,7 @@ func (h *AccountsHandler) queueTransfers(batch *storage.QueryBatch, data *storag
 		)
 		// Decrease sender's balance.
 		batch.Queue(
-			h.qf.RuntimeNativeBalanceUpdateQuery(),
+			queries.RuntimeNativeBalanceUpdate,
 			h.runtimeName,
 			transfer.From.String(),
 			h.source.StringifyDenomination(transfer.Amount.Denomination),

--- a/analyzer/modules/accounts.go
+++ b/analyzer/modules/accounts.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -19,13 +18,12 @@ const (
 type AccountsHandler struct {
 	source      storage.RuntimeSourceStorage
 	runtimeName string
-	qf          *analyzer.QueryFactory
 	logger      *log.Logger
 }
 
 // NewAccountsHandler creates a new handler for `accounts` module data.
-func NewAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, qf *analyzer.QueryFactory, logger *log.Logger) *AccountsHandler {
-	return &AccountsHandler{source, runtimeName, qf, logger}
+func NewAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, logger *log.Logger) *AccountsHandler {
+	return &AccountsHandler{source, runtimeName, logger}
 }
 
 // PrepareAccountsData prepares raw data from the `accounts` module for insertion.

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -17,14 +17,15 @@ const (
 // ConsensusAccountsHandler implements support for transforming and inserting data from the
 // `consensus_accounts` module for a runtime into target storage.
 type ConsensusAccountsHandler struct {
-	source storage.RuntimeSourceStorage
-	qf     *analyzer.QueryFactory
-	logger *log.Logger
+	source      storage.RuntimeSourceStorage
+	runtimeName string
+	qf          *analyzer.QueryFactory
+	logger      *log.Logger
 }
 
 // NewConsensusAccountsHandler creates a new handler for `consensus_accounts` module data.
-func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, qf *analyzer.QueryFactory, logger *log.Logger) *ConsensusAccountsHandler {
-	return &ConsensusAccountsHandler{source, qf, logger}
+func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, qf *analyzer.QueryFactory, logger *log.Logger) *ConsensusAccountsHandler {
+	return &ConsensusAccountsHandler{source, runtimeName, qf, logger}
 }
 
 // PrepareConsensusAccountsData prepares raw data from the `consensus_accounts` module for insertion.
@@ -65,6 +66,7 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 		errorModule, errorCode := decomposeError(deposit.Error)
 		batch.Queue(
 			h.qf.RuntimeDepositInsertQuery(),
+			h.runtimeName,
 			data.Round,
 			deposit.From.String(),
 			deposit.To.String(),
@@ -93,6 +95,7 @@ func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, dat
 		errorModule, errorCode := decomposeError(withdraw.Error)
 		batch.Queue(
 			h.qf.RuntimeWithdrawInsertQuery(),
+			h.runtimeName,
 			data.Round,
 			withdraw.From.String(),
 			withdraw.To.String(),

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
@@ -19,13 +18,12 @@ const (
 type ConsensusAccountsHandler struct {
 	source      storage.RuntimeSourceStorage
 	runtimeName string
-	qf          *analyzer.QueryFactory
 	logger      *log.Logger
 }
 
 // NewConsensusAccountsHandler creates a new handler for `consensus_accounts` module data.
-func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, qf *analyzer.QueryFactory, logger *log.Logger) *ConsensusAccountsHandler {
-	return &ConsensusAccountsHandler{source, runtimeName, qf, logger}
+func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, logger *log.Logger) *ConsensusAccountsHandler {
+	return &ConsensusAccountsHandler{source, runtimeName, logger}
 }
 
 // PrepareConsensusAccountsData prepares raw data from the `consensus_accounts` module for insertion.

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
@@ -63,7 +64,7 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 		}
 		errorModule, errorCode := decomposeError(deposit.Error)
 		batch.Queue(
-			h.qf.RuntimeDepositInsertQuery(),
+			queries.RuntimeDepositInsert,
 			h.runtimeName,
 			data.Round,
 			deposit.From.String(),
@@ -92,7 +93,7 @@ func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, dat
 		}
 		errorModule, errorCode := decomposeError(withdraw.Error)
 		batch.Queue(
-			h.qf.RuntimeWithdrawInsertQuery(),
+			queries.RuntimeWithdrawInsert,
 			h.runtimeName,
 			data.Round,
 			withdraw.From.String(),

--- a/analyzer/modules/consensusaccounts.go
+++ b/analyzer/modules/consensusaccounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
@@ -17,14 +18,14 @@ const (
 // ConsensusAccountsHandler implements support for transforming and inserting data from the
 // `consensus_accounts` module for a runtime into target storage.
 type ConsensusAccountsHandler struct {
-	source      storage.RuntimeSourceStorage
-	runtimeName string
-	logger      *log.Logger
+	source  storage.RuntimeSourceStorage
+	runtime analyzer.Runtime
+	logger  *log.Logger
 }
 
 // NewConsensusAccountsHandler creates a new handler for `consensus_accounts` module data.
-func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtimeName string, logger *log.Logger) *ConsensusAccountsHandler {
-	return &ConsensusAccountsHandler{source, runtimeName, logger}
+func NewConsensusAccountsHandler(source storage.RuntimeSourceStorage, runtime analyzer.Runtime, logger *log.Logger) *ConsensusAccountsHandler {
+	return &ConsensusAccountsHandler{source, runtime, logger}
 }
 
 // PrepareConsensusAccountsData prepares raw data from the `consensus_accounts` module for insertion.
@@ -65,7 +66,7 @@ func (h *ConsensusAccountsHandler) queueDeposits(batch *storage.QueryBatch, data
 		errorModule, errorCode := decomposeError(deposit.Error)
 		batch.Queue(
 			queries.RuntimeDepositInsert,
-			h.runtimeName,
+			h.runtime,
 			data.Round,
 			deposit.From.String(),
 			deposit.To.String(),
@@ -94,7 +95,7 @@ func (h *ConsensusAccountsHandler) queueWithdraws(batch *storage.QueryBatch, dat
 		errorModule, errorCode := decomposeError(withdraw.Error)
 		batch.Queue(
 			queries.RuntimeWithdrawInsert,
-			h.runtimeName,
+			h.runtime,
 			data.Round,
 			withdraw.From.String(),
 			withdraw.To.String(),

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -16,14 +16,15 @@ const (
 // CoreHandler implements support for transforming and inserting data from the
 // `core` module for a runtime into target storage.
 type CoreHandler struct {
-	source storage.RuntimeSourceStorage
-	qf     *analyzer.QueryFactory
-	logger *log.Logger
+	source      storage.RuntimeSourceStorage
+	runtimeName string
+	qf          *analyzer.QueryFactory
+	logger      *log.Logger
 }
 
 // NewCoreHandler creates a new handler for `core` module data.
-func NewCoreHandler(source storage.RuntimeSourceStorage, qf *analyzer.QueryFactory, logger *log.Logger) *CoreHandler {
-	return &CoreHandler{source, qf, logger}
+func NewCoreHandler(source storage.RuntimeSourceStorage, runtimeName string, qf *analyzer.QueryFactory, logger *log.Logger) *CoreHandler {
+	return &CoreHandler{source, runtimeName, qf, logger}
 }
 
 // PrepareCoreData prepares raw data from the `core` module for insertion.
@@ -54,6 +55,7 @@ func (h *CoreHandler) queueGasUsed(batch *storage.QueryBatch, data *storage.Core
 	for _, gasUsed := range data.GasUsed {
 		batch.Queue(
 			h.qf.RuntimeGasUsedInsertQuery(),
+			h.runtimeName,
 			data.Round,
 			nil, // TODO: Get sender address from transaction data
 			gasUsed.Amount,

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -18,13 +17,12 @@ const (
 type CoreHandler struct {
 	source      storage.RuntimeSourceStorage
 	runtimeName string
-	qf          *analyzer.QueryFactory
 	logger      *log.Logger
 }
 
 // NewCoreHandler creates a new handler for `core` module data.
-func NewCoreHandler(source storage.RuntimeSourceStorage, runtimeName string, qf *analyzer.QueryFactory, logger *log.Logger) *CoreHandler {
-	return &CoreHandler{source, runtimeName, qf, logger}
+func NewCoreHandler(source storage.RuntimeSourceStorage, runtimeName string, logger *log.Logger) *CoreHandler {
+	return &CoreHandler{source, runtimeName, logger}
 }
 
 // PrepareCoreData prepares raw data from the `core` module for insertion.

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
@@ -16,14 +17,14 @@ const (
 // CoreHandler implements support for transforming and inserting data from the
 // `core` module for a runtime into target storage.
 type CoreHandler struct {
-	source      storage.RuntimeSourceStorage
-	runtimeName string
-	logger      *log.Logger
+	source  storage.RuntimeSourceStorage
+	runtime analyzer.Runtime
+	logger  *log.Logger
 }
 
 // NewCoreHandler creates a new handler for `core` module data.
-func NewCoreHandler(source storage.RuntimeSourceStorage, runtimeName string, logger *log.Logger) *CoreHandler {
-	return &CoreHandler{source, runtimeName, logger}
+func NewCoreHandler(source storage.RuntimeSourceStorage, runtime analyzer.Runtime, logger *log.Logger) *CoreHandler {
+	return &CoreHandler{source, runtime, logger}
 }
 
 // PrepareCoreData prepares raw data from the `core` module for insertion.
@@ -54,7 +55,7 @@ func (h *CoreHandler) queueGasUsed(batch *storage.QueryBatch, data *storage.Core
 	for _, gasUsed := range data.GasUsed {
 		batch.Queue(
 			queries.RuntimeGasUsedInsert,
-			h.runtimeName,
+			h.runtime,
 			data.Round,
 			nil, // TODO: Get sender address from transaction data
 			gasUsed.Amount,

--- a/analyzer/modules/core.go
+++ b/analyzer/modules/core.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -52,7 +53,7 @@ func (h *CoreHandler) Name() string {
 func (h *CoreHandler) queueGasUsed(batch *storage.QueryBatch, data *storage.CoreData) error {
 	for _, gasUsed := range data.GasUsed {
 		batch.Queue(
-			h.qf.RuntimeGasUsedInsertQuery(),
+			queries.RuntimeGasUsedInsert,
 			h.runtimeName,
 			data.Round,
 			nil, // TODO: Get sender address from transaction data

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -1,609 +1,448 @@
 package analyzer
 
-// QueryFactory is a convenience type for creating database queries.
-type QueryFactory struct {
-	chainID string
-	runtime string
-}
-
-func NewQueryFactory(_ string, runtime string) QueryFactory {
-	return QueryFactory{"chain", runtime}
-}
-
-// NewWithRuntime returns a new QueryFactory with the runtime set.
-func (qf QueryFactory) NewWithRuntime(runtime string) QueryFactory {
-	return QueryFactory{qf.chainID, runtime}
-}
-
-func (qf QueryFactory) LatestBlockQuery() string {
-	return `
-		SELECT height FROM chain.processed_blocks
-			WHERE analyzer = $1
-		ORDER BY height DESC
-		LIMIT 1`
-}
-
-func (qf QueryFactory) IsGenesisProcessedQuery() string {
-	return `
-		SELECT EXISTS (
-			SELECT 1 FROM chain.processed_geneses
-			WHERE chain_context = $1
-		)`
-}
-
-func (qf QueryFactory) IndexingProgressQuery() string {
-	return `
-		INSERT INTO chain.processed_blocks (height, analyzer, processed_time)
-			VALUES
-				($1, $2, CURRENT_TIMESTAMP)`
-}
-
-func (qf QueryFactory) GenesisIndexingProgressQuery() string {
-	return `
-		INSERT INTO chain.processed_geneses (chain_context, processed_time)
-			VALUES
-				($1, CURRENT_TIMESTAMP)`
-}
-
-func (qf QueryFactory) ConsensusBlockInsertQuery() string {
-	return `
-		INSERT INTO chain.blocks (height, block_hash, time, num_txs, namespace, version, type, root_hash)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
-}
-
-func (qf QueryFactory) ConsensusEpochInsertQuery() string {
-	return `
-		INSERT INTO chain.epochs (id, start_height)
-			VALUES ($1, $2)
-		ON CONFLICT (id) DO NOTHING`
-}
-
-func (qf QueryFactory) ConsensusEpochUpdateQuery() string {
-	return `
-		UPDATE chain.epochs
-		SET end_height = $2
-			WHERE id = $1 AND end_height IS NULL`
-}
-
-func (qf QueryFactory) ConsensusTransactionInsertQuery() string {
-	return `
-		INSERT INTO chain.transactions (block, tx_hash, tx_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
-}
-
-func (qf QueryFactory) ConsensusAccountNonceUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-		SET
-			nonce = $2
-		WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusCommissionsUpsertQuery() string {
-	return `
-		INSERT INTO chain.commissions (address, schedule)
-			VALUES ($1, $2)
-		ON CONFLICT (address) DO
-			UPDATE SET
-				schedule = excluded.schedule`
-}
-
-func (qf QueryFactory) ConsensusEventInsertQuery() string {
-	return `
-		INSERT INTO chain.events (type, body, tx_block, tx_hash, tx_index, related_accounts)
-			VALUES ($1, $2, $3, $4, $5, $6)`
-}
-
-func (qf QueryFactory) ConsensusAccountRelatedTransactionInsertQuery() string {
-	return `
-		INSERT INTO chain.accounts_related_transactions (account_address, tx_block, tx_index)
-			VALUES ($1, $2, $3)`
-}
-
-func (qf QueryFactory) ConsensusAccountRelatedEventInsertQuery() string {
-	return `
-		INSERT INTO chain.accounts_related_events (account_address, event_block, tx_index, tx_hash, type, body)
-			VALUES ($1, $2, $3, $4, $5, $6)`
-}
-
-func (qf QueryFactory) ConsensusRuntimeUpsertQuery() string {
-	return `
-		INSERT INTO chain.runtimes (id, suspended, kind, tee_hardware, key_manager)
-			VALUES ($1, $2, $3, $4, $5)
-			ON CONFLICT (id) DO
-			UPDATE SET
-				suspended = excluded.suspended,
-				kind = excluded.kind,
-				tee_hardware = excluded.tee_hardware,
-				key_manager = excluded.key_manager`
-}
-
-func (qf QueryFactory) ConsensusClaimedNodeInsertQuery() string {
-	return `
-		INSERT INTO chain.claimed_nodes (entity_id, node_id) VALUES ($1, $2)
-			ON CONFLICT (entity_id, node_id) DO NOTHING`
-}
-
-func (qf QueryFactory) ConsensusEntityUpsertQuery() string {
-	return `
-		INSERT INTO chain.entities (id, address) VALUES ($1, $2)
-			ON CONFLICT (id) DO
-			UPDATE SET
-				address = excluded.address`
-}
-
-func (qf QueryFactory) ConsensusNodeUpsertQuery() string {
-	return `
-		INSERT INTO chain.nodes (id, entity_id, expiration, tls_pubkey, tls_next_pubkey, tls_addresses, p2p_pubkey, p2p_addresses, consensus_pubkey, consensus_address, vrf_pubkey, roles, software_version, voting_power)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
-		ON CONFLICT (id) DO UPDATE
-		SET
-			entity_id = excluded.entity_id,
-			expiration = excluded.expiration,
-			tls_pubkey = excluded.tls_pubkey,
-			tls_next_pubkey = excluded.tls_next_pubkey,
-			tls_addresses = excluded.tls_addresses,
-			p2p_pubkey = excluded.p2p_pubkey,
-			p2p_addresses = excluded.p2p_addresses,
-			consensus_pubkey = excluded.consensus_pubkey,
-			consensus_address = excluded.consensus_address,
-			vrf_pubkey = excluded.vrf_pubkey,
-			roles = excluded.roles,
-			software_version = excluded.software_version,
-			voting_power = excluded.voting_power`
-}
-
-func (qf QueryFactory) ConsensusNodeDeleteQuery() string {
-	return `
-		DELETE FROM chain.nodes WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusEntityMetaUpsertQuery() string {
-	return `
-		UPDATE chain.entities
-		SET meta = $2
-			WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusSenderUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-		SET
-			general_balance = general_balance - $2
-		WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusReceiverUpdateQuery() string {
-	return `
-		INSERT INTO chain.accounts (address, general_balance)
-			VALUES ($1, $2)
-		ON CONFLICT (address) DO
-			UPDATE SET general_balance = chain.accounts.general_balance + $2`
-}
-
-func (qf QueryFactory) ConsensusBurnUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-		SET
-			general_balance = general_balance - $2
-		WHERE address = $1`
-}
-
-// Decreases the general balance because the given amount is being moved to escrow.
-func (qf QueryFactory) ConsensusDecreaseGeneralBalanceForEscrowUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-		SET
-			general_balance = general_balance - $2
-		WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusAddEscrowBalanceUpsertQuery() string {
-	return `
-		INSERT INTO chain.accounts (address, escrow_balance_active, escrow_total_shares_active)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (address) DO
-			UPDATE SET
-				escrow_balance_active = chain.accounts.escrow_balance_active + $2,
-				escrow_total_shares_active = chain.accounts.escrow_total_shares_active + $3`
-}
-
-func (qf QueryFactory) ConsensusAddDelegationsUpsertQuery() string {
-	return `
-		INSERT INTO chain.delegations (delegatee, delegator, shares)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (delegatee, delegator) DO
-			UPDATE SET shares = chain.delegations.shares + $3`
-}
-
-func (qf QueryFactory) ConsensusTakeEscrowUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-			SET
-				escrow_balance_active = escrow_balance_active - FLOOR($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
-				escrow_balance_debonding = escrow_balance_debonding - FLOOR($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
-			WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusDebondingStartEscrowBalanceUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-			SET
-				escrow_balance_active = escrow_balance_active - $2,
-				escrow_total_shares_active = escrow_total_shares_active - $3,
-				escrow_balance_debonding = escrow_balance_debonding + $2,
-				escrow_total_shares_debonding = escrow_total_shares_debonding + $4
-			WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusDebondingStartDelegationsUpdateQuery() string {
-	return `
-		UPDATE chain.delegations
-			SET shares = shares - $3
-				WHERE delegatee = $1 AND delegator = $2`
-}
-
-func (qf QueryFactory) ConsensusDebondingStartDebondingDelegationsInsertQuery() string {
-	return `
-		INSERT INTO chain.debonding_delegations (delegatee, delegator, shares, debond_end)
-			VALUES ($1, $2, $3, $4)`
-}
-
-func (qf QueryFactory) ConsensusReclaimGeneralBalanceUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-			SET
-				general_balance = general_balance + $2
-			WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusReclaimEscrowBalanceUpdateQuery() string {
-	return `
-		UPDATE chain.accounts
-			SET
-				escrow_balance_debonding = escrow_balance_debonding - $2,
-				escrow_total_shares_debonding = escrow_total_shares_debonding - $3
-			WHERE address = $1`
-}
-
-func (qf QueryFactory) ConsensusDeleteDebondingDelegationsQuery() string {
-	// Network upgrades delays debonding by 1 epoch
-	return `
-		DELETE FROM chain.debonding_delegations
-			WHERE id = (
-				SELECT id
-				FROM chain.debonding_delegations
-				WHERE
-					delegator = $1 AND delegatee = $2 AND shares = $3 AND debond_end IN ($4::bigint, $4::bigint - 1)
-				LIMIT 1
-			)`
-}
-
-func (qf QueryFactory) ConsensusAllowanceChangeDeleteQuery() string {
-	return `
-		DELETE FROM chain.allowances
-			WHERE owner = $1 AND beneficiary = $2`
-}
-
-func (qf QueryFactory) ConsensusAllowanceOwnerUpsertQuery() string {
-	return `
-		INSERT INTO chain.accounts (address)
-			VALUES ($1)
-		ON CONFLICT (address) DO NOTHING`
-}
-
-func (qf QueryFactory) ConsensusAllowanceChangeUpdateQuery() string {
-	return `
-		INSERT INTO chain.allowances (owner, beneficiary, allowance)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (owner, beneficiary) DO
-			UPDATE SET allowance = excluded.allowance`
-}
-
-func (qf QueryFactory) ConsensusValidatorNodeUpdateQuery() string {
-	return `
-		UPDATE chain.nodes SET voting_power = $2
-			WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusCommitteeMemberInsertQuery() string {
-	return `
-		INSERT INTO chain.committee_members (node, valid_for, runtime, kind, role)
-			VALUES ($1, $2, $3, $4, $5)`
-}
-
-func (qf QueryFactory) ConsensusCommitteeMembersTruncateQuery() string {
-	return `
-		TRUNCATE chain.committee_members`
-}
-
-func (qf QueryFactory) ConsensusProposalSubmissionInsertQuery() string {
-	return `
-		INSERT INTO chain.proposals (id, submitter, state, deposit, handler, cp_target_version, rhp_target_version, rcp_target_version, upgrade_epoch, created_at, closes_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
-}
-
-func (qf QueryFactory) ConsensusProposalSubmissionCancelInsertQuery() string {
-	return `
-		INSERT INTO chain.proposals (id, submitter, state, deposit, cancels, created_at, closes_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`
-}
-
-func (qf QueryFactory) ConsensusProposalExecutionsUpdateQuery() string {
-	return `
-		UPDATE chain.proposals
-		SET executed = true
-			WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusProposalUpdateQuery() string {
-	return `
-		UPDATE chain.proposals
-		SET state = $2
-			WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusProposalInvalidVotesUpdateQuery() string {
-	return `
-		UPDATE chain.proposals
-		SET invalid_votes = $2
-			WHERE id = $1`
-}
-
-func (qf QueryFactory) ConsensusVoteInsertQuery() string {
-	return `
-		INSERT INTO chain.votes (proposal, voter, vote)
-			VALUES ($1, $2, $3)`
-}
-
-func (qf QueryFactory) RuntimeBlockInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
-}
-
-func (qf QueryFactory) RuntimeTransactionSignerInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_transaction_signers (runtime, round, tx_index, signer_index, signer_address, nonce)
-			VALUES ($1, $2, $3, $4, $5, $6)`
-}
-
-func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
-			VALUES ($1, $2, $3, $4)`
-}
-
-func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, gas_used, size, timestamp, raw, result_raw)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
-}
-
-func (qf QueryFactory) RuntimeEventInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
-}
-
-func (qf QueryFactory) RuntimeMintInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ($1, $2, NULL, $3, $4, $5)`
-}
-
-func (qf QueryFactory) RuntimeBurnInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ($1, $2, $3, NULL, $4, $5)`
-}
-
-func (qf QueryFactory) RuntimeTransferInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ($1, $2, $3, $4, $5, $6)`
-}
-
-func (qf QueryFactory) RuntimeDepositInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_deposits (runtime, round, sender, receiver, amount, nonce, module, code)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
-}
-
-func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_withdraws (runtime, round, sender, receiver, amount, nonce, module, code)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
-}
-
-func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {
-	return `
-		INSERT INTO chain.runtime_sdk_balances (runtime, account_address, symbol, balance)
-		  VALUES ($1, $2, $3, $4)
-		ON CONFLICT (runtime, account_address, symbol) DO
-		UPDATE SET balance = chain.runtime_sdk_balances.balance + $4`
-}
-
-func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {
-	return `
-		INSERT INTO chain.runtime_gas_used (runtime, round, sender, amount)
-			VALUES ($1, $2, $3, $4)`
-}
-
-func (qf QueryFactory) AddressPreimageInsertQuery() string {
-	return `
-		INSERT INTO chain.address_preimages (address, context_identifier, context_version, address_data)
-			VALUES ($1, $2, $3, $4)
-		ON CONFLICT DO NOTHING`
-}
-
-func (qf QueryFactory) RuntimeEvmBalanceUpdateQuery() string {
-	return `
-		INSERT INTO chain.evm_token_balances (runtime, token_address, account_address, balance)
-			VALUES ($1, $2, $3, $4)
-		ON CONFLICT (runtime, token_address, account_address) DO
-			UPDATE SET balance = chain.evm_token_balances.balance + $4`
-}
-
-func (qf QueryFactory) RuntimeEVMTokensAnalysisStaleQuery() string {
-	return `
-		SELECT
-			evm_token_analysis.token_address,
-			evm_token_analysis.last_mutate_round,
-			evm_token_analysis.last_download_round,
-			evm_tokens.token_type,
-			address_preimages.context_identifier,
-			address_preimages.context_version,
-			address_preimages.address_data
-		FROM chain.evm_token_analysis
-		LEFT JOIN chain.evm_tokens USING (runtime, token_address)
-		LEFT JOIN chain.address_preimages ON
-			address_preimages.address = evm_token_analysis.token_address
-		WHERE
-			evm_token_analysis.runtime = $1 AND
-			(
-				evm_token_analysis.last_download_round IS NULL OR
-				evm_token_analysis.last_mutate_round > evm_token_analysis.last_download_round
-			)
-		LIMIT $2`
-}
-
-func (qf QueryFactory) RuntimeEVMTokenAnalysisInsertQuery() string {
-	return `
-		INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (runtime, token_address) DO NOTHING`
-}
-
-func (qf QueryFactory) RuntimeEVMTokenAnalysisMutateInsertQuery() string {
-	return `
-		INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
-			VALUES ($1, $2, $3)
-		ON CONFLICT (runtime, token_address) DO UPDATE
-			SET last_mutate_round = excluded.last_mutate_round`
-}
-
-func (qf QueryFactory) RuntimeEVMTokenAnalysisUpdateQuery() string {
-	return `
-		UPDATE chain.evm_token_analysis
-		SET
-			last_download_round = $3
-		WHERE
-			runtime = $1 AND
-			token_address = $2`
-}
-
-func (qf QueryFactory) RuntimeEVMTokenInsertQuery() string {
-	return `
-		INSERT INTO chain.evm_tokens (runtime, token_address, token_type, token_name, symbol, decimals, total_supply)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`
-}
-
-func (qf QueryFactory) RuntimeEVMTokenUpdateQuery() string {
-	return `
-		UPDATE chain.evm_tokens
-		SET
-			total_supply = $3
-		WHERE
-			runtime = $1 AND
-			token_address = $2`
-}
-
-func (qf QueryFactory) RefreshDailyTxVolumeQuery() string {
-	return `
-		REFRESH MATERIALIZED VIEW stats.daily_tx_volume
-	`
-}
-
-func (qf QueryFactory) RefreshMin5TxVolumeQuery() string {
-	return `
-		REFRESH MATERIALIZED VIEW stats.min5_tx_volume
-	`
-}
-
-// LatestDailyAccountStatsQuery returns the query to get the timestamp of the latest daily active accounts stat.
-func (qf QueryFactory) LatestDailyAccountStatsQuery() string {
-	return `
-		SELECT window_end
-		FROM stats.daily_active_accounts
-		WHERE layer = $1
-		ORDER BY window_end DESC
-		LIMIT 1
-	`
-}
-
-// InsertDailyAccountStatsQuery returns the query to insert the daily active accounts stat.
-func (qf QueryFactory) InsertDailyAccountStatsQuery() string {
-	return `
-		INSERT INTO stats.daily_active_accounts (layer, window_end, active_accounts)
-		VALUES ($1, $2, $3)
-	`
-}
-
-// EarliestConsensusBlockTimeQuery returns the query to get the timestamp of the earliest
-// indexed consensus block.
-func (qf QueryFactory) EarliestConsensusBlockTimeQuery() string {
-	return `
-		SELECT time
-		FROM chain.blocks
-		ORDER BY height
-		LIMIT 1
-	`
-}
-
-// LatestConsensusBlockTimeQuery returns the query to get the timestamp of the latest
-// indexed consensus block.
-func (qf QueryFactory) LatestConsensusBlockTimeQuery() string {
-	return `
-		SELECT time
-		FROM chain.blocks
-		ORDER BY height DESC
-		LIMIT 1
-	`
-}
-
-// EarliestRuntimeBlockTimeQuery returns the query to get the timestamp of the earliest
-// indexed runtime block.
-func (qf QueryFactory) EarliestRuntimeBlockTimeQuery() string {
-	return `
-		SELECT timestamp
-		FROM chain.runtime_blocks
-		WHERE (runtime = $1)
-		ORDER BY round
-		LIMIT 1
-	`
-}
-
-// LatestRuntimeBlockTimeQuery returns the query to get the timestamp of the latest
-// indexed runtime block.
-func (qf QueryFactory) LatestRuntimeBlockTimeQuery() string {
-	return `
-		SELECT timestamp
-		FROM chain.runtime_blocks
-		WHERE (runtime = $1)
-		ORDER BY round DESC
-		LIMIT 1
-	`
-}
-
-// ConsensusActiveAccountsQuery returns the query to get the number of
-// active accounts in the consensus layer within the given time range.
-func (qf QueryFactory) ConsensusActiveAccountsQuery() string {
-	return `
-		SELECT COUNT(DISTINCT account_address)
-		FROM chain.accounts_related_transactions AS art
-		JOIN chain.blocks AS b ON art.tx_block = b.height
-		WHERE (b.time >= $1::timestamptz AND b.time < $2::timestamptz)
-		`
-}
-
-// RuntimeActiveAccountsQuery returns the query to get the number of
-// active accounts in the runtime layer within the given time range.
-func (qf QueryFactory) RuntimeActiveAccountsQuery() string {
-	return `
-		SELECT COUNT(DISTINCT account_address)
-		FROM chain.runtime_related_transactions AS rt
-		JOIN chain.runtime_blocks AS b ON (rt.runtime = b.runtime AND rt.tx_round = b.round)
-		WHERE (rt.runtime = $1 AND b.timestamp >= $2::timestamptz AND b.timestamp < $3::timestamptz)
-	`
-}
+const (
+	LatestBlock = `
+    SELECT height FROM chain.processed_blocks
+      WHERE analyzer = $1
+    ORDER BY height DESC
+    LIMIT 1`
+
+	IsGenesisProcessed = `
+    SELECT EXISTS (
+      SELECT 1 FROM chain.processed_geneses
+      WHERE chain_context = $1
+    )`
+
+	IndexingProgress = `
+    INSERT INTO chain.processed_blocks (height, analyzer, processed_time)
+      VALUES
+        ($1, $2, CURRENT_TIMESTAMP)`
+
+	GenesisIndexingProgress = `
+    INSERT INTO chain.processed_geneses (chain_context, processed_time)
+      VALUES
+        ($1, CURRENT_TIMESTAMP)`
+
+	ConsensusBlockInsert = `
+    INSERT INTO chain.blocks (height, block_hash, time, num_txs, namespace, version, type, root_hash)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+	ConsensusEpochInsert = `
+    INSERT INTO chain.epochs (id, start_height)
+      VALUES ($1, $2)
+    ON CONFLICT (id) DO NOTHING`
+
+	ConsensusEpochUpdate = `
+    UPDATE chain.epochs
+    SET end_height = $2
+      WHERE id = $1 AND end_height IS NULL`
+
+	ConsensusTransactionInsert = `
+    INSERT INTO chain.transactions (block, tx_hash, tx_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
+
+	ConsensusAccountNonceUpdate = `
+    UPDATE chain.accounts
+    SET
+      nonce = $2
+    WHERE address = $1`
+
+	ConsensusCommissionsUpsert = `
+    INSERT INTO chain.commissions (address, schedule)
+      VALUES ($1, $2)
+    ON CONFLICT (address) DO
+      UPDATE SET
+        schedule = excluded.schedule`
+
+	ConsensusEventInsert = `
+    INSERT INTO chain.events (type, body, tx_block, tx_hash, tx_index, related_accounts)
+      VALUES ($1, $2, $3, $4, $5, $6)`
+
+	ConsensusAccountRelatedTransactionInsert = `
+    INSERT INTO chain.accounts_related_transactions (account_address, tx_block, tx_index)
+      VALUES ($1, $2, $3)`
+
+	ConsensusAccountRelatedEventInsert = `
+    INSERT INTO chain.accounts_related_events (account_address, event_block, tx_index, tx_hash, type, body)
+      VALUES ($1, $2, $3, $4, $5, $6)`
+
+	ConsensusRuntimeUpsert = `
+    INSERT INTO chain.runtimes (id, suspended, kind, tee_hardware, key_manager)
+      VALUES ($1, $2, $3, $4, $5)
+      ON CONFLICT (id) DO
+      UPDATE SET
+        suspended = excluded.suspended,
+        kind = excluded.kind,
+        tee_hardware = excluded.tee_hardware,
+        key_manager = excluded.key_manager`
+
+	ConsensusClaimedNodeInsert = `
+    INSERT INTO chain.claimed_nodes (entity_id, node_id) VALUES ($1, $2)
+      ON CONFLICT (entity_id, node_id) DO NOTHING`
+
+	ConsensusEntityUpsert = `
+    INSERT INTO chain.entities (id, address) VALUES ($1, $2)
+      ON CONFLICT (id) DO
+      UPDATE SET
+        address = excluded.address`
+
+	ConsensusNodeUpsert = `
+    INSERT INTO chain.nodes (id, entity_id, expiration, tls_pubkey, tls_next_pubkey, tls_addresses, p2p_pubkey, p2p_addresses, consensus_pubkey, consensus_address, vrf_pubkey, roles, software_version, voting_power)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+    ON CONFLICT (id) DO UPDATE
+    SET
+      entity_id = excluded.entity_id,
+      expiration = excluded.expiration,
+      tls_pubkey = excluded.tls_pubkey,
+      tls_next_pubkey = excluded.tls_next_pubkey,
+      tls_addresses = excluded.tls_addresses,
+      p2p_pubkey = excluded.p2p_pubkey,
+      p2p_addresses = excluded.p2p_addresses,
+      consensus_pubkey = excluded.consensus_pubkey,
+      consensus_address = excluded.consensus_address,
+      vrf_pubkey = excluded.vrf_pubkey,
+      roles = excluded.roles,
+      software_version = excluded.software_version,
+      voting_power = excluded.voting_power`
+
+	ConsensusNodeDelete = `
+    DELETE FROM chain.nodes WHERE id = $1`
+
+	ConsensusEntityMetaUpsert = `
+    UPDATE chain.entities
+    SET meta = $2
+      WHERE id = $1`
+
+	ConsensusSenderUpdate = `
+    UPDATE chain.accounts
+    SET
+      general_balance = general_balance - $2
+    WHERE address = $1`
+
+	ConsensusReceiverUpdate = `
+    INSERT INTO chain.accounts (address, general_balance)
+      VALUES ($1, $2)
+    ON CONFLICT (address) DO
+      UPDATE SET general_balance = chain.accounts.general_balance + $2`
+
+	ConsensusBurnUpdate = `
+    UPDATE chain.accounts
+    SET
+      general_balance = general_balance - $2
+    WHERE address = $1`
+
+	// Decreases the general balance because the given amount is being moved to escrow.
+	ConsensusDecreaseGeneralBalanceForEscrowUpdate = `
+    UPDATE chain.accounts
+    SET
+      general_balance = general_balance - $2
+    WHERE address = $1`
+
+	ConsensusAddEscrowBalanceUpsert = `
+    INSERT INTO chain.accounts (address, escrow_balance_active, escrow_total_shares_active)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (address) DO
+      UPDATE SET
+        escrow_balance_active = chain.accounts.escrow_balance_active + $2,
+        escrow_total_shares_active = chain.accounts.escrow_total_shares_active + $3`
+
+	ConsensusAddDelegationsUpsert = `
+    INSERT INTO chain.delegations (delegatee, delegator, shares)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (delegatee, delegator) DO
+      UPDATE SET shares = chain.delegations.shares + $3`
+
+	ConsensusTakeEscrowUpdate = `
+    UPDATE chain.accounts
+      SET
+        escrow_balance_active = escrow_balance_active - FLOOR($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
+        escrow_balance_debonding = escrow_balance_debonding - FLOOR($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
+      WHERE address = $1`
+
+	ConsensusDebondingStartEscrowBalanceUpdate = `
+    UPDATE chain.accounts
+      SET
+        escrow_balance_active = escrow_balance_active - $2,
+        escrow_total_shares_active = escrow_total_shares_active - $3,
+        escrow_balance_debonding = escrow_balance_debonding + $2,
+        escrow_total_shares_debonding = escrow_total_shares_debonding + $4
+      WHERE address = $1`
+
+	ConsensusDebondingStartDelegationsUpdate = `
+    UPDATE chain.delegations
+      SET shares = shares - $3
+        WHERE delegatee = $1 AND delegator = $2`
+
+	ConsensusDebondingStartDebondingDelegationsInsert = `
+    INSERT INTO chain.debonding_delegations (delegatee, delegator, shares, debond_end)
+      VALUES ($1, $2, $3, $4)`
+
+	ConsensusReclaimGeneralBalanceUpdate = `
+    UPDATE chain.accounts
+      SET
+        general_balance = general_balance + $2
+      WHERE address = $1`
+
+	ConsensusReclaimEscrowBalanceUpdate = `
+    UPDATE chain.accounts
+      SET
+        escrow_balance_debonding = escrow_balance_debonding - $2,
+        escrow_total_shares_debonding = escrow_total_shares_debonding - $3
+      WHERE address = $1`
+
+	// Network upgrades delays debonding by 1 epoch.
+	ConsensusDeleteDebondingDelegations = `
+    DELETE FROM chain.debonding_delegations
+      WHERE id = (
+        SELECT id
+        FROM chain.debonding_delegations
+        WHERE
+          delegator = $1 AND delegatee = $2 AND shares = $3 AND debond_end IN ($4::bigint, $4::bigint - 1)
+        LIMIT 1
+      )`
+
+	ConsensusAllowanceChangeDelete = `
+    DELETE FROM chain.allowances
+      WHERE owner = $1 AND beneficiary = $2`
+
+	ConsensusAllowanceOwnerUpsert = `
+    INSERT INTO chain.accounts (address)
+      VALUES ($1)
+    ON CONFLICT (address) DO NOTHING`
+
+	ConsensusAllowanceChangeUpdate = `
+    INSERT INTO chain.allowances (owner, beneficiary, allowance)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (owner, beneficiary) DO
+      UPDATE SET allowance = excluded.allowance`
+
+	ConsensusValidatorNodeUpdate = `
+    UPDATE chain.nodes SET voting_power = $2
+      WHERE id = $1`
+
+	ConsensusCommitteeMemberInsert = `
+    INSERT INTO chain.committee_members (node, valid_for, runtime, kind, role)
+      VALUES ($1, $2, $3, $4, $5)`
+
+	ConsensusCommitteeMembersTruncate = `
+    TRUNCATE chain.committee_members`
+
+	ConsensusProposalSubmissionInsert = `
+    INSERT INTO chain.proposals (id, submitter, state, deposit, handler, cp_target_version, rhp_target_version, rcp_target_version, upgrade_epoch, created_at, closes_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
+
+	ConsensusProposalSubmissionCancelInsert = `
+    INSERT INTO chain.proposals (id, submitter, state, deposit, cancels, created_at, closes_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)`
+
+	ConsensusProposalExecutionsUpdate = `
+    UPDATE chain.proposals
+    SET executed = true
+      WHERE id = $1`
+
+	ConsensusProposalUpdate = `
+    UPDATE chain.proposals
+    SET state = $2
+      WHERE id = $1`
+
+	ConsensusProposalInvalidVotesUpdate = `
+    UPDATE chain.proposals
+    SET invalid_votes = $2
+      WHERE id = $1`
+
+	ConsensusVoteInsert = `
+    INSERT INTO chain.votes (proposal, voter, vote)
+      VALUES ($1, $2, $3)`
+
+	RuntimeBlockInsert = `
+    INSERT INTO chain.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
+
+	RuntimeTransactionSignerInsert = `
+    INSERT INTO chain.runtime_transaction_signers (runtime, round, tx_index, signer_index, signer_address, nonce)
+      VALUES ($1, $2, $3, $4, $5, $6)`
+
+	RuntimeRelatedTransactionInsert = `
+    INSERT INTO chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
+      VALUES ($1, $2, $3, $4)`
+
+	RuntimeTransactionInsert = `
+    INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, gas_used, size, timestamp, raw, result_raw)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+
+	RuntimeEventInsert = `
+    INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+
+	RuntimeMintInsert = `
+    INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+      VALUES ($1, $2, NULL, $3, $4, $5)`
+
+	RuntimeBurnInsert = `
+    INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+      VALUES ($1, $2, $3, NULL, $4, $5)`
+
+	RuntimeTransferInsert = `
+    INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+      VALUES ($1, $2, $3, $4, $5, $6)`
+
+	RuntimeDepositInsert = `
+    INSERT INTO chain.runtime_deposits (runtime, round, sender, receiver, amount, nonce, module, code)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+	RuntimeWithdrawInsert = `
+    INSERT INTO chain.runtime_withdraws (runtime, round, sender, receiver, amount, nonce, module, code)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
+
+	RuntimeNativeBalanceUpdate = `
+    INSERT INTO chain.runtime_sdk_balances (runtime, account_address, symbol, balance)
+      VALUES ($1, $2, $3, $4)
+    ON CONFLICT (runtime, account_address, symbol) DO
+    UPDATE SET balance = chain.runtime_sdk_balances.balance + $4`
+
+	RuntimeGasUsedInsert = `
+    INSERT INTO chain.runtime_gas_used (runtime, round, sender, amount)
+      VALUES ($1, $2, $3, $4)`
+
+	AddressPreimageInsert = `
+    INSERT INTO chain.address_preimages (address, context_identifier, context_version, address_data)
+      VALUES ($1, $2, $3, $4)
+    ON CONFLICT DO NOTHING`
+
+	RuntimeEvmBalanceUpdate = `
+    INSERT INTO chain.evm_token_balances (runtime, token_address, account_address, balance)
+      VALUES ($1, $2, $3, $4)
+    ON CONFLICT (runtime, token_address, account_address) DO
+      UPDATE SET balance = chain.evm_token_balances.balance + $4`
+
+	RuntimeEVMTokensAnalysisStale = `
+    SELECT
+      evm_token_analysis.token_address,
+      evm_token_analysis.last_mutate_round,
+      evm_token_analysis.last_download_round,
+      evm_tokens.token_type,
+      address_preimages.context_identifier,
+      address_preimages.context_version,
+      address_preimages.address_data
+    FROM chain.evm_token_analysis
+    LEFT JOIN chain.evm_tokens USING (runtime, token_address)
+    LEFT JOIN chain.address_preimages ON
+      address_preimages.address = evm_token_analysis.token_address
+    WHERE
+      evm_token_analysis.runtime = $1 AND
+      (
+        evm_token_analysis.last_download_round IS NULL OR
+        evm_token_analysis.last_mutate_round > evm_token_analysis.last_download_round
+      )
+    LIMIT $2`
+
+	RuntimeEVMTokenAnalysisInsert = `
+    INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (runtime, token_address) DO NOTHING`
+
+	RuntimeEVMTokenAnalysisMutateInsert = `
+    INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (runtime, token_address) DO UPDATE
+      SET last_mutate_round = excluded.last_mutate_round`
+
+	RuntimeEVMTokenAnalysisUpdate = `
+    UPDATE chain.evm_token_analysis
+    SET
+      last_download_round = $3
+    WHERE
+      runtime = $1 AND
+      token_address = $2`
+
+	RuntimeEVMTokenInsert = `
+    INSERT INTO chain.evm_tokens (runtime, token_address, token_type, token_name, symbol, decimals, total_supply)
+      VALUES ($1, $2, $3, $4, $5, $6, $7)`
+
+	RuntimeEVMTokenUpdate = `
+    UPDATE chain.evm_tokens
+    SET
+      total_supply = $3
+    WHERE
+      runtime = $1 AND
+      token_address = $2`
+
+	RefreshDailyTxVolume = `
+    REFRESH MATERIALIZED VIEW stats.daily_tx_volume
+  `
+
+	RefreshMin5TxVolume = `
+    REFRESH MATERIALIZED VIEW stats.min5_tx_volume
+  `
+
+	// LatestDailyAccountStatsQuery returns the query to get the timestamp of the latest daily active accounts stat.
+	LatestDailyAccountStats = `
+    SELECT window_end
+    FROM stats.daily_active_accounts
+    WHERE layer = $1
+    ORDER BY window_end DESC
+    LIMIT 1
+  `
+
+	// InsertDailyAccountStatsQuery returns the query to insert the daily active accounts stat.
+	InsertDailyAccountStats = `
+    INSERT INTO stats.daily_active_accounts (layer, window_end, active_accounts)
+    VALUES ($1, $2, $3)
+  `
+
+	// EarliestConsensusBlockTimeQuery returns the query to get the timestamp of the earliest
+	// indexed consensus block.
+	EarliestConsensusBlockTime = `
+    SELECT time
+    FROM chain.blocks
+    ORDER BY height
+    LIMIT 1
+  `
+
+	// LatestConsensusBlockTimeQuery returns the query to get the timestamp of the latest
+	// indexed consensus block.
+	LatestConsensusBlockTime = `
+    SELECT time
+    FROM chain.blocks
+    ORDER BY height DESC
+    LIMIT 1
+  `
+
+	// EarliestRuntimeBlockTimeQuery returns the query to get the timestamp of the earliest
+	// indexed runtime block.
+	EarliestRuntimeBlockTime = `
+    SELECT timestamp
+    FROM chain.runtime_blocks
+    WHERE (runtime = $1)
+    ORDER BY round
+    LIMIT 1
+  `
+
+	// LatestRuntimeBlockTimeQuery returns the query to get the timestamp of the latest
+	// indexed runtime block.
+	LatestRuntimeBlockTime = `
+    SELECT timestamp
+    FROM chain.runtime_blocks
+    WHERE (runtime = $1)
+    ORDER BY round DESC
+    LIMIT 1
+  `
+
+	// ConsensusActiveAccountsQuery returns the query to get the number of
+	// active accounts in the consensus layer within the given time range.
+	ConsensusActiveAccounts = `
+    SELECT COUNT(DISTINCT account_address)
+    FROM chain.accounts_related_transactions AS art
+    JOIN chain.blocks AS b ON art.tx_block = b.height
+    WHERE (b.time >= $1::timestamptz AND b.time < $2::timestamptz)
+    `
+
+	// RuntimeActiveAccountsQuery returns the query to get the number of
+	// active accounts in the runtime layer within the given time range.
+	RuntimeActiveAccounts = `
+    SELECT COUNT(DISTINCT account_address)
+    FROM chain.runtime_related_transactions AS rt
+    JOIN chain.runtime_blocks AS b ON (rt.runtime = b.runtime AND rt.tx_round = b.round)
+    WHERE (rt.runtime = $1 AND b.timestamp >= $2::timestamptz AND b.timestamp < $3::timestamptz)
+  `
+)

--- a/analyzer/queries.go
+++ b/analyzer/queries.go
@@ -1,9 +1,5 @@
 package analyzer
 
-import (
-	"fmt"
-)
-
 // QueryFactory is a convenience type for creating database queries.
 type QueryFactory struct {
 	chainID string
@@ -20,11 +16,11 @@ func (qf QueryFactory) NewWithRuntime(runtime string) QueryFactory {
 }
 
 func (qf QueryFactory) LatestBlockQuery() string {
-	return fmt.Sprintf(`
-		SELECT height FROM %s.processed_blocks
+	return `
+		SELECT height FROM chain.processed_blocks
 			WHERE analyzer = $1
 		ORDER BY height DESC
-		LIMIT 1`, qf.chainID)
+		LIMIT 1`
 }
 
 func (qf QueryFactory) IsGenesisProcessedQuery() string {
@@ -36,10 +32,10 @@ func (qf QueryFactory) IsGenesisProcessedQuery() string {
 }
 
 func (qf QueryFactory) IndexingProgressQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.processed_blocks (height, analyzer, processed_time)
+	return `
+		INSERT INTO chain.processed_blocks (height, analyzer, processed_time)
 			VALUES
-				($1, $2, CURRENT_TIMESTAMP)`, qf.chainID)
+				($1, $2, CURRENT_TIMESTAMP)`
 }
 
 func (qf QueryFactory) GenesisIndexingProgressQuery() string {
@@ -50,95 +46,95 @@ func (qf QueryFactory) GenesisIndexingProgressQuery() string {
 }
 
 func (qf QueryFactory) ConsensusBlockInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.blocks (height, block_hash, time, num_txs, namespace, version, type, root_hash)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`, qf.chainID)
+	return `
+		INSERT INTO chain.blocks (height, block_hash, time, num_txs, namespace, version, type, root_hash)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 }
 
 func (qf QueryFactory) ConsensusEpochInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.epochs (id, start_height)
+	return `
+		INSERT INTO chain.epochs (id, start_height)
 			VALUES ($1, $2)
-		ON CONFLICT (id) DO NOTHING`, qf.chainID)
+		ON CONFLICT (id) DO NOTHING`
 }
 
 func (qf QueryFactory) ConsensusEpochUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.epochs
+	return `
+		UPDATE chain.epochs
 		SET end_height = $2
-			WHERE id = $1 AND end_height IS NULL`, qf.chainID)
+			WHERE id = $1 AND end_height IS NULL`
 }
 
 func (qf QueryFactory) ConsensusTransactionInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.transactions (block, tx_hash, tx_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID)
+	return `
+		INSERT INTO chain.transactions (block, tx_hash, tx_index, nonce, fee_amount, max_gas, method, sender, body, module, code, message)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`
 }
 
 func (qf QueryFactory) ConsensusAccountNonceUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 		SET
 			nonce = $2
-		WHERE address = $1`, qf.chainID)
+		WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusCommissionsUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.commissions (address, schedule)
+	return `
+		INSERT INTO chain.commissions (address, schedule)
 			VALUES ($1, $2)
 		ON CONFLICT (address) DO
 			UPDATE SET
-				schedule = excluded.schedule`, qf.chainID)
+				schedule = excluded.schedule`
 }
 
 func (qf QueryFactory) ConsensusEventInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.events (type, body, tx_block, tx_hash, tx_index, related_accounts)
-			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID)
+	return `
+		INSERT INTO chain.events (type, body, tx_block, tx_hash, tx_index, related_accounts)
+			VALUES ($1, $2, $3, $4, $5, $6)`
 }
 
 func (qf QueryFactory) ConsensusAccountRelatedTransactionInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.accounts_related_transactions (account_address, tx_block, tx_index)
-			VALUES ($1, $2, $3)`, qf.chainID)
+	return `
+		INSERT INTO chain.accounts_related_transactions (account_address, tx_block, tx_index)
+			VALUES ($1, $2, $3)`
 }
 
 func (qf QueryFactory) ConsensusAccountRelatedEventInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.accounts_related_events (account_address, event_block, tx_index, tx_hash, type, body)
-			VALUES ($1, $2, $3, $4, $5, $6)`, qf.chainID)
+	return `
+		INSERT INTO chain.accounts_related_events (account_address, event_block, tx_index, tx_hash, type, body)
+			VALUES ($1, $2, $3, $4, $5, $6)`
 }
 
 func (qf QueryFactory) ConsensusRuntimeUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.runtimes (id, suspended, kind, tee_hardware, key_manager)
+	return `
+		INSERT INTO chain.runtimes (id, suspended, kind, tee_hardware, key_manager)
 			VALUES ($1, $2, $3, $4, $5)
 			ON CONFLICT (id) DO
 			UPDATE SET
 				suspended = excluded.suspended,
 				kind = excluded.kind,
 				tee_hardware = excluded.tee_hardware,
-				key_manager = excluded.key_manager`, qf.chainID)
+				key_manager = excluded.key_manager`
 }
 
 func (qf QueryFactory) ConsensusClaimedNodeInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.claimed_nodes (entity_id, node_id) VALUES ($1, $2)
-			ON CONFLICT (entity_id, node_id) DO NOTHING`, qf.chainID)
+	return `
+		INSERT INTO chain.claimed_nodes (entity_id, node_id) VALUES ($1, $2)
+			ON CONFLICT (entity_id, node_id) DO NOTHING`
 }
 
 func (qf QueryFactory) ConsensusEntityUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.entities (id, address) VALUES ($1, $2)
+	return `
+		INSERT INTO chain.entities (id, address) VALUES ($1, $2)
 			ON CONFLICT (id) DO
 			UPDATE SET
-				address = excluded.address`, qf.chainID)
+				address = excluded.address`
 }
 
 func (qf QueryFactory) ConsensusNodeUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.nodes (id, entity_id, expiration, tls_pubkey, tls_next_pubkey, tls_addresses, p2p_pubkey, p2p_addresses, consensus_pubkey, consensus_address, vrf_pubkey, roles, software_version, voting_power)
+	return `
+		INSERT INTO chain.nodes (id, entity_id, expiration, tls_pubkey, tls_next_pubkey, tls_addresses, p2p_pubkey, p2p_addresses, consensus_pubkey, consensus_address, vrf_pubkey, roles, software_version, voting_power)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		ON CONFLICT (id) DO UPDATE
 		SET
@@ -154,303 +150,303 @@ func (qf QueryFactory) ConsensusNodeUpsertQuery() string {
 			vrf_pubkey = excluded.vrf_pubkey,
 			roles = excluded.roles,
 			software_version = excluded.software_version,
-			voting_power = excluded.voting_power`, qf.chainID)
+			voting_power = excluded.voting_power`
 }
 
 func (qf QueryFactory) ConsensusNodeDeleteQuery() string {
-	return fmt.Sprintf(`
-		DELETE FROM %s.nodes WHERE id = $1`, qf.chainID)
+	return `
+		DELETE FROM chain.nodes WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusEntityMetaUpsertQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.entities
+	return `
+		UPDATE chain.entities
 		SET meta = $2
-			WHERE id = $1`, qf.chainID)
+			WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusSenderUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 		SET
 			general_balance = general_balance - $2
-		WHERE address = $1`, qf.chainID)
+		WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusReceiverUpdateQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.accounts (address, general_balance)
+	return `
+		INSERT INTO chain.accounts (address, general_balance)
 			VALUES ($1, $2)
 		ON CONFLICT (address) DO
-			UPDATE SET general_balance = %[1]s.accounts.general_balance + $2`, qf.chainID)
+			UPDATE SET general_balance = chain.accounts.general_balance + $2`
 }
 
 func (qf QueryFactory) ConsensusBurnUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 		SET
 			general_balance = general_balance - $2
-		WHERE address = $1`, qf.chainID)
+		WHERE address = $1`
 }
 
 // Decreases the general balance because the given amount is being moved to escrow.
 func (qf QueryFactory) ConsensusDecreaseGeneralBalanceForEscrowUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 		SET
 			general_balance = general_balance - $2
-		WHERE address = $1`, qf.chainID)
+		WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusAddEscrowBalanceUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.accounts (address, escrow_balance_active, escrow_total_shares_active)
+	return `
+		INSERT INTO chain.accounts (address, escrow_balance_active, escrow_total_shares_active)
 			VALUES ($1, $2, $3)
 		ON CONFLICT (address) DO
 			UPDATE SET
-				escrow_balance_active = %[1]s.accounts.escrow_balance_active + $2,
-				escrow_total_shares_active = %[1]s.accounts.escrow_total_shares_active + $3`, qf.chainID)
+				escrow_balance_active = chain.accounts.escrow_balance_active + $2,
+				escrow_total_shares_active = chain.accounts.escrow_total_shares_active + $3`
 }
 
 func (qf QueryFactory) ConsensusAddDelegationsUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.delegations (delegatee, delegator, shares)
+	return `
+		INSERT INTO chain.delegations (delegatee, delegator, shares)
 			VALUES ($1, $2, $3)
 		ON CONFLICT (delegatee, delegator) DO
-			UPDATE SET shares = %[1]s.delegations.shares + $3`, qf.chainID)
+			UPDATE SET shares = chain.delegations.shares + $3`
 }
 
 func (qf QueryFactory) ConsensusTakeEscrowUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 			SET
 				escrow_balance_active = escrow_balance_active - FLOOR($2 * escrow_balance_active / (escrow_balance_active + escrow_balance_debonding)),
 				escrow_balance_debonding = escrow_balance_debonding - FLOOR($2 * escrow_balance_debonding / (escrow_balance_active + escrow_balance_debonding))
-			WHERE address = $1`, qf.chainID)
+			WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusDebondingStartEscrowBalanceUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 			SET
 				escrow_balance_active = escrow_balance_active - $2,
 				escrow_total_shares_active = escrow_total_shares_active - $3,
 				escrow_balance_debonding = escrow_balance_debonding + $2,
 				escrow_total_shares_debonding = escrow_total_shares_debonding + $4
-			WHERE address = $1`, qf.chainID)
+			WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusDebondingStartDelegationsUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.delegations
+	return `
+		UPDATE chain.delegations
 			SET shares = shares - $3
-				WHERE delegatee = $1 AND delegator = $2`, qf.chainID)
+				WHERE delegatee = $1 AND delegator = $2`
 }
 
 func (qf QueryFactory) ConsensusDebondingStartDebondingDelegationsInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.debonding_delegations (delegatee, delegator, shares, debond_end)
-			VALUES ($1, $2, $3, $4)`, qf.chainID)
+	return `
+		INSERT INTO chain.debonding_delegations (delegatee, delegator, shares, debond_end)
+			VALUES ($1, $2, $3, $4)`
 }
 
 func (qf QueryFactory) ConsensusReclaimGeneralBalanceUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 			SET
 				general_balance = general_balance + $2
-			WHERE address = $1`, qf.chainID)
+			WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusReclaimEscrowBalanceUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.accounts
+	return `
+		UPDATE chain.accounts
 			SET
 				escrow_balance_debonding = escrow_balance_debonding - $2,
 				escrow_total_shares_debonding = escrow_total_shares_debonding - $3
-			WHERE address = $1`, qf.chainID)
+			WHERE address = $1`
 }
 
 func (qf QueryFactory) ConsensusDeleteDebondingDelegationsQuery() string {
 	// Network upgrades delays debonding by 1 epoch
-	return fmt.Sprintf(`
-		DELETE FROM %[1]s.debonding_delegations
+	return `
+		DELETE FROM chain.debonding_delegations
 			WHERE id = (
 				SELECT id
-				FROM %[1]s.debonding_delegations
+				FROM chain.debonding_delegations
 				WHERE
 					delegator = $1 AND delegatee = $2 AND shares = $3 AND debond_end IN ($4::bigint, $4::bigint - 1)
 				LIMIT 1
-			)`, qf.chainID)
+			)`
 }
 
 func (qf QueryFactory) ConsensusAllowanceChangeDeleteQuery() string {
-	return fmt.Sprintf(`
-		DELETE FROM %s.allowances
-			WHERE owner = $1 AND beneficiary = $2`, qf.chainID)
+	return `
+		DELETE FROM chain.allowances
+			WHERE owner = $1 AND beneficiary = $2`
 }
 
 func (qf QueryFactory) ConsensusAllowanceOwnerUpsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.accounts (address)
+	return `
+		INSERT INTO chain.accounts (address)
 			VALUES ($1)
-		ON CONFLICT (address) DO NOTHING`, qf.chainID)
+		ON CONFLICT (address) DO NOTHING`
 }
 
 func (qf QueryFactory) ConsensusAllowanceChangeUpdateQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.allowances (owner, beneficiary, allowance)
+	return `
+		INSERT INTO chain.allowances (owner, beneficiary, allowance)
 			VALUES ($1, $2, $3)
 		ON CONFLICT (owner, beneficiary) DO
-			UPDATE SET allowance = excluded.allowance`, qf.chainID)
+			UPDATE SET allowance = excluded.allowance`
 }
 
 func (qf QueryFactory) ConsensusValidatorNodeUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.nodes SET voting_power = $2
-			WHERE id = $1`, qf.chainID)
+	return `
+		UPDATE chain.nodes SET voting_power = $2
+			WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusCommitteeMemberInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.committee_members (node, valid_for, runtime, kind, role)
-			VALUES ($1, $2, $3, $4, $5)`, qf.chainID)
+	return `
+		INSERT INTO chain.committee_members (node, valid_for, runtime, kind, role)
+			VALUES ($1, $2, $3, $4, $5)`
 }
 
 func (qf QueryFactory) ConsensusCommitteeMembersTruncateQuery() string {
-	return fmt.Sprintf(`
-		TRUNCATE %s.committee_members`, qf.chainID)
+	return `
+		TRUNCATE chain.committee_members`
 }
 
 func (qf QueryFactory) ConsensusProposalSubmissionInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.proposals (id, submitter, state, deposit, handler, cp_target_version, rhp_target_version, rcp_target_version, upgrade_epoch, created_at, closes_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`, qf.chainID)
+	return `
+		INSERT INTO chain.proposals (id, submitter, state, deposit, handler, cp_target_version, rhp_target_version, rcp_target_version, upgrade_epoch, created_at, closes_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
 }
 
 func (qf QueryFactory) ConsensusProposalSubmissionCancelInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.proposals (id, submitter, state, deposit, cancels, created_at, closes_at)
-			VALUES ($1, $2, $3, $4, $5, $6, $7)`, qf.chainID)
+	return `
+		INSERT INTO chain.proposals (id, submitter, state, deposit, cancels, created_at, closes_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)`
 }
 
 func (qf QueryFactory) ConsensusProposalExecutionsUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.proposals
+	return `
+		UPDATE chain.proposals
 		SET executed = true
-			WHERE id = $1`, qf.chainID)
+			WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusProposalUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.proposals
+	return `
+		UPDATE chain.proposals
 		SET state = $2
-			WHERE id = $1`, qf.chainID)
+			WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusProposalInvalidVotesUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %s.proposals
+	return `
+		UPDATE chain.proposals
 		SET invalid_votes = $2
-			WHERE id = $1`, qf.chainID)
+			WHERE id = $1`
 }
 
 func (qf QueryFactory) ConsensusVoteInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.votes (proposal, voter, vote)
-			VALUES ($1, $2, $3)`, qf.chainID)
+	return `
+		INSERT INTO chain.votes (proposal, voter, vote)
+			VALUES ($1, $2, $3)`
 }
 
 func (qf QueryFactory) RuntimeBlockInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
-			VALUES ('%s', $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_blocks (runtime, round, version, timestamp, block_hash, prev_block_hash, io_root, state_root, messages_hash, in_messages_hash, num_transactions, gas_used, size)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
 }
 
 func (qf QueryFactory) RuntimeTransactionSignerInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transaction_signers (runtime, round, tx_index, signer_index, signer_address, nonce)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_transaction_signers (runtime, round, tx_index, signer_index, signer_address, nonce)
+			VALUES ($1, $2, $3, $4, $5, $6)`
 }
 
 func (qf QueryFactory) RuntimeRelatedTransactionInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
-			VALUES ('%[2]s', $1, $2, $3)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index)
+			VALUES ($1, $2, $3, $4)`
 }
 
 func (qf QueryFactory) RuntimeTransactionInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, gas_used, size, timestamp, raw, result_raw)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7, $8, $9)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, gas_used, size, timestamp, raw, result_raw)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
 }
 
 func (qf QueryFactory) RuntimeEventInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7, $8)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
 }
 
 func (qf QueryFactory) RuntimeMintInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ('%[2]s', $1, NULL, $2, $3, $4)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ($1, $2, NULL, $3, $4, $5)`
 }
 
 func (qf QueryFactory) RuntimeBurnInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ('%[2]s', $1, $2, NULL, $3, $4)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ($1, $2, $3, NULL, $4, $5)`
 }
 
 func (qf QueryFactory) RuntimeTransferInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
+			VALUES ($1, $2, $3, $4, $5, $6)`
 }
 
 func (qf QueryFactory) RuntimeDepositInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_deposits (runtime, round, sender, receiver, amount, nonce, module, code)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_deposits (runtime, round, sender, receiver, amount, nonce, module, code)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 }
 
 func (qf QueryFactory) RuntimeWithdrawInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_withdraws (runtime, round, sender, receiver, amount, nonce, module, code)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6, $7)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_withdraws (runtime, round, sender, receiver, amount, nonce, module, code)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`
 }
 
 func (qf QueryFactory) RuntimeNativeBalanceUpdateQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_sdk_balances (runtime, account_address, symbol, balance)
-		  VALUES ('%[2]s', $1, $2, $3)
+	return `
+		INSERT INTO chain.runtime_sdk_balances (runtime, account_address, symbol, balance)
+		  VALUES ($1, $2, $3, $4)
 		ON CONFLICT (runtime, account_address, symbol) DO
-		UPDATE SET balance = %[1]s.runtime_sdk_balances.balance + $3`, qf.chainID, qf.runtime)
+		UPDATE SET balance = chain.runtime_sdk_balances.balance + $4`
 }
 
 func (qf QueryFactory) RuntimeGasUsedInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.runtime_gas_used (runtime, round, sender, amount)
-			VALUES ('%[2]s', $1, $2, $3)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.runtime_gas_used (runtime, round, sender, amount)
+			VALUES ($1, $2, $3, $4)`
 }
 
 func (qf QueryFactory) AddressPreimageInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %s.address_preimages (address, context_identifier, context_version, address_data)
+	return `
+		INSERT INTO chain.address_preimages (address, context_identifier, context_version, address_data)
 			VALUES ($1, $2, $3, $4)
-		ON CONFLICT DO NOTHING`, qf.chainID)
+		ON CONFLICT DO NOTHING`
 }
 
 func (qf QueryFactory) RuntimeEvmBalanceUpdateQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.evm_token_balances (runtime, token_address, account_address, balance)
-			VALUES ('%[2]s', $1, $2, $3)
+	return `
+		INSERT INTO chain.evm_token_balances (runtime, token_address, account_address, balance)
+			VALUES ($1, $2, $3, $4)
 		ON CONFLICT (runtime, token_address, account_address) DO
-			UPDATE SET balance = %[1]s.evm_token_balances.balance + $3`, qf.chainID, qf.runtime)
+			UPDATE SET balance = chain.evm_token_balances.balance + $4`
 }
 
 func (qf QueryFactory) RuntimeEVMTokensAnalysisStaleQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT
 			evm_token_analysis.token_address,
 			evm_token_analysis.last_mutate_round,
@@ -459,58 +455,58 @@ func (qf QueryFactory) RuntimeEVMTokensAnalysisStaleQuery() string {
 			address_preimages.context_identifier,
 			address_preimages.context_version,
 			address_preimages.address_data
-		FROM %[1]s.evm_token_analysis
-		LEFT JOIN %[1]s.evm_tokens USING (runtime, token_address)
-		LEFT JOIN %[1]s.address_preimages ON
+		FROM chain.evm_token_analysis
+		LEFT JOIN chain.evm_tokens USING (runtime, token_address)
+		LEFT JOIN chain.address_preimages ON
 			address_preimages.address = evm_token_analysis.token_address
 		WHERE
-			evm_token_analysis.runtime = '%[2]s' AND
+			evm_token_analysis.runtime = $1 AND
 			(
 				evm_token_analysis.last_download_round IS NULL OR
 				evm_token_analysis.last_mutate_round > evm_token_analysis.last_download_round
 			)
-		LIMIT $1`, qf.chainID, qf.runtime)
+		LIMIT $2`
 }
 
 func (qf QueryFactory) RuntimeEVMTokenAnalysisInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.evm_token_analysis (runtime, token_address, last_mutate_round)
-			VALUES ('%[2]s', $1, $2)
-		ON CONFLICT (runtime, token_address) DO NOTHING`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
+			VALUES ($1, $2, $3)
+		ON CONFLICT (runtime, token_address) DO NOTHING`
 }
 
 func (qf QueryFactory) RuntimeEVMTokenAnalysisMutateInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.evm_token_analysis (runtime, token_address, last_mutate_round)
-			VALUES ('%[2]s', $1, $2)
+	return `
+		INSERT INTO chain.evm_token_analysis (runtime, token_address, last_mutate_round)
+			VALUES ($1, $2, $3)
 		ON CONFLICT (runtime, token_address) DO UPDATE
-			SET last_mutate_round = excluded.last_mutate_round`, qf.chainID, qf.runtime)
+			SET last_mutate_round = excluded.last_mutate_round`
 }
 
 func (qf QueryFactory) RuntimeEVMTokenAnalysisUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %[1]s.evm_token_analysis
+	return `
+		UPDATE chain.evm_token_analysis
 		SET
-			last_download_round = $2
+			last_download_round = $3
 		WHERE
-			runtime = '%[2]s' AND
-			token_address = $1`, qf.chainID, qf.runtime)
+			runtime = $1 AND
+			token_address = $2`
 }
 
 func (qf QueryFactory) RuntimeEVMTokenInsertQuery() string {
-	return fmt.Sprintf(`
-		INSERT INTO %[1]s.evm_tokens (runtime, token_address, token_type, token_name, symbol, decimals, total_supply)
-			VALUES ('%[2]s', $1, $2, $3, $4, $5, $6)`, qf.chainID, qf.runtime)
+	return `
+		INSERT INTO chain.evm_tokens (runtime, token_address, token_type, token_name, symbol, decimals, total_supply)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)`
 }
 
 func (qf QueryFactory) RuntimeEVMTokenUpdateQuery() string {
-	return fmt.Sprintf(`
-		UPDATE %[1]s.evm_tokens
+	return `
+		UPDATE chain.evm_tokens
 		SET
-			total_supply = $2
+			total_supply = $3
 		WHERE
-			runtime = '%[2]s' AND
-			token_address = $1`, qf.chainID, qf.runtime)
+			runtime = $1 AND
+			token_address = $2`
 }
 
 func (qf QueryFactory) RefreshDailyTxVolumeQuery() string {
@@ -547,67 +543,67 @@ func (qf QueryFactory) InsertDailyAccountStatsQuery() string {
 // EarliestConsensusBlockTimeQuery returns the query to get the timestamp of the earliest
 // indexed consensus block.
 func (qf QueryFactory) EarliestConsensusBlockTimeQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT time
-		FROM %[1]s.blocks
+		FROM chain.blocks
 		ORDER BY height
 		LIMIT 1
-	`, qf.chainID)
+	`
 }
 
 // LatestConsensusBlockTimeQuery returns the query to get the timestamp of the latest
 // indexed consensus block.
 func (qf QueryFactory) LatestConsensusBlockTimeQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT time
-		FROM %[1]s.blocks
+		FROM chain.blocks
 		ORDER BY height DESC
 		LIMIT 1
-	`, qf.chainID)
+	`
 }
 
 // EarliestRuntimeBlockTimeQuery returns the query to get the timestamp of the earliest
 // indexed runtime block.
 func (qf QueryFactory) EarliestRuntimeBlockTimeQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT timestamp
-		FROM %[1]s.runtime_blocks
-		WHERE (runtime = '%[2]s')
+		FROM chain.runtime_blocks
+		WHERE (runtime = $1)
 		ORDER BY round
 		LIMIT 1
-	`, qf.chainID, qf.runtime)
+	`
 }
 
 // LatestRuntimeBlockTimeQuery returns the query to get the timestamp of the latest
 // indexed runtime block.
 func (qf QueryFactory) LatestRuntimeBlockTimeQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT timestamp
-		FROM %[1]s.runtime_blocks
-		WHERE (runtime = '%[2]s')
+		FROM chain.runtime_blocks
+		WHERE (runtime = $1)
 		ORDER BY round DESC
 		LIMIT 1
-	`, qf.chainID, qf.runtime)
+	`
 }
 
 // ConsensusActiveAccountsQuery returns the query to get the number of
 // active accounts in the consensus layer within the given time range.
 func (qf QueryFactory) ConsensusActiveAccountsQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT COUNT(DISTINCT account_address)
-		FROM %[1]s.accounts_related_transactions AS art
-		JOIN %[1]s.blocks AS b ON art.tx_block = b.height
+		FROM chain.accounts_related_transactions AS art
+		JOIN chain.blocks AS b ON art.tx_block = b.height
 		WHERE (b.time >= $1::timestamptz AND b.time < $2::timestamptz)
-		`, qf.chainID)
+		`
 }
 
 // RuntimeActiveAccountsQuery returns the query to get the number of
 // active accounts in the runtime layer within the given time range.
 func (qf QueryFactory) RuntimeActiveAccountsQuery() string {
-	return fmt.Sprintf(`
+	return `
 		SELECT COUNT(DISTINCT account_address)
-		FROM %[1]s.runtime_related_transactions AS rt
-		JOIN %[1]s.runtime_blocks AS b ON (rt.runtime = b.runtime AND rt.tx_round = b.round)
-		WHERE (rt.runtime = '%[2]s' AND b.timestamp >= $1::timestamptz AND b.timestamp < $2::timestamptz)
-		`, qf.chainID, qf.runtime)
+		FROM chain.runtime_related_transactions AS rt
+		JOIN chain.runtime_blocks AS b ON (rt.runtime = b.runtime AND rt.tx_round = b.round)
+		WHERE (rt.runtime = $1 AND b.timestamp >= $2::timestamptz AND b.timestamp < $3::timestamptz)
+	`
 }

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -375,7 +375,7 @@ const (
     REFRESH MATERIALIZED VIEW stats.min5_tx_volume
   `
 
-	// LatestDailyAccountStatsQuery returns the query to get the timestamp of the latest daily active accounts stat.
+	// LatestDailyAccountStats returns the query to get the timestamp of the latest daily active accounts stat.
 	LatestDailyAccountStats = `
     SELECT window_end
     FROM stats.daily_active_accounts
@@ -384,13 +384,13 @@ const (
     LIMIT 1
   `
 
-	// InsertDailyAccountStatsQuery returns the query to insert the daily active accounts stat.
+	// InsertDailyAccountStats returns the query to insert the daily active accounts stat.
 	InsertDailyAccountStats = `
     INSERT INTO stats.daily_active_accounts (layer, window_end, active_accounts)
     VALUES ($1, $2, $3)
   `
 
-	// EarliestConsensusBlockTimeQuery returns the query to get the timestamp of the earliest
+	// EarliestConsensusBlockTime returns the query to get the timestamp of the earliest
 	// indexed consensus block.
 	EarliestConsensusBlockTime = `
     SELECT time
@@ -399,7 +399,7 @@ const (
     LIMIT 1
   `
 
-	// LatestConsensusBlockTimeQuery returns the query to get the timestamp of the latest
+	// LatestConsensusBlockTime returns the query to get the timestamp of the latest
 	// indexed consensus block.
 	LatestConsensusBlockTime = `
     SELECT time
@@ -408,7 +408,7 @@ const (
     LIMIT 1
   `
 
-	// EarliestRuntimeBlockTimeQuery returns the query to get the timestamp of the earliest
+	// EarliestRuntimeBlockTime returns the query to get the timestamp of the earliest
 	// indexed runtime block.
 	EarliestRuntimeBlockTime = `
     SELECT timestamp
@@ -418,7 +418,7 @@ const (
     LIMIT 1
   `
 
-	// LatestRuntimeBlockTimeQuery returns the query to get the timestamp of the latest
+	// LatestRuntimeBlockTime returns the query to get the timestamp of the latest
 	// indexed runtime block.
 	LatestRuntimeBlockTime = `
     SELECT timestamp
@@ -428,7 +428,7 @@ const (
     LIMIT 1
   `
 
-	// ConsensusActiveAccountsQuery returns the query to get the number of
+	// ConsensusActiveAccounts returns the query to get the number of
 	// active accounts in the consensus layer within the given time range.
 	ConsensusActiveAccounts = `
     SELECT COUNT(DISTINCT account_address)
@@ -437,7 +437,7 @@ const (
     WHERE (b.time >= $1::timestamptz AND b.time < $2::timestamptz)
     `
 
-	// RuntimeActiveAccountsQuery returns the query to get the number of
+	// RuntimeActiveAccounts returns the query to get the number of
 	// active accounts in the runtime layer within the given time range.
 	RuntimeActiveAccounts = `
     SELECT COUNT(DISTINCT account_address)

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -1,4 +1,4 @@
-package analyzer
+package queries
 
 const (
 	LatestBlock = `

--- a/analyzer/runtime/incoming.go
+++ b/analyzer/runtime/incoming.go
@@ -18,7 +18,6 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
-	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/modules"
 	common "github.com/oasisprotocol/oasis-indexer/analyzer/uncategorized"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -567,7 +566,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 	}, nil
 }
 
-func (m *Main) emitRoundBatch(batch *storage.QueryBatch, qf *analyzer.QueryFactory, round uint64, blockData *BlockData) {
+func (m *Main) emitRoundBatch(batch *storage.QueryBatch, round uint64, blockData *BlockData) {
 	for _, transactionData := range blockData.TransactionData {
 		for _, signerData := range transactionData.SignerData {
 			batch.Queue(

--- a/analyzer/runtime/incoming.go
+++ b/analyzer/runtime/incoming.go
@@ -19,6 +19,7 @@ import (
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer/modules"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	common "github.com/oasisprotocol/oasis-indexer/analyzer/uncategorized"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -570,7 +571,7 @@ func (m *Main) emitRoundBatch(batch *storage.QueryBatch, round uint64, blockData
 	for _, transactionData := range blockData.TransactionData {
 		for _, signerData := range transactionData.SignerData {
 			batch.Queue(
-				qf.RuntimeTransactionSignerInsertQuery(),
+				queries.RuntimeTransactionSignerInsert,
 				m.runtime,
 				round,
 				transactionData.Index,
@@ -580,10 +581,10 @@ func (m *Main) emitRoundBatch(batch *storage.QueryBatch, round uint64, blockData
 			)
 		}
 		for addr := range transactionData.RelatedAccountAddresses {
-			batch.Queue(qf.RuntimeRelatedTransactionInsertQuery(), m.runtime, addr, round, transactionData.Index)
+			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.runtime, addr, round, transactionData.Index)
 		}
 		batch.Queue(
-			qf.RuntimeTransactionInsertQuery(),
+			queries.RuntimeTransactionInsert,
 			m.runtime,
 			round,
 			transactionData.Index,
@@ -599,7 +600,7 @@ func (m *Main) emitRoundBatch(batch *storage.QueryBatch, round uint64, blockData
 	for _, eventData := range blockData.EventData {
 		eventRelatedAddresses := common.ExtractAddresses(eventData.RelatedAddresses)
 		batch.Queue(
-			qf.RuntimeEventInsertQuery(),
+			queries.RuntimeEventInsert,
 			m.runtime,
 			round,
 			eventData.TxIndex,
@@ -612,16 +613,16 @@ func (m *Main) emitRoundBatch(batch *storage.QueryBatch, round uint64, blockData
 		)
 	}
 	for addr, preimageData := range blockData.AddressPreimages {
-		batch.Queue(qf.AddressPreimageInsertQuery(), addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
+		batch.Queue(queries.AddressPreimageInsert, addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
 	}
 	for key, change := range blockData.TokenBalanceChanges {
-		batch.Queue(qf.RuntimeEvmBalanceUpdateQuery(), m.runtime, key.TokenAddress, key.AccountAddress, change.String())
+		batch.Queue(queries.RuntimeEvmBalanceUpdate, m.runtime, key.TokenAddress, key.AccountAddress, change.String())
 	}
 	for addr, possibleToken := range blockData.PossibleTokens {
 		if possibleToken.Mutated {
-			batch.Queue(qf.RuntimeEVMTokenAnalysisMutateInsertQuery(), m.runtime, addr, round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateInsert, m.runtime, addr, round)
 		} else {
-			batch.Queue(qf.RuntimeEVMTokenAnalysisInsertQuery(), m.runtime, addr, round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.runtime, addr, round)
 		}
 	}
 }

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -105,9 +105,9 @@ func NewRuntimeAnalyzer(
 
 		// module handlers
 		moduleHandlers: []modules.ModuleHandler{
-			modules.NewCoreHandler(client, &qf, logger),
-			modules.NewAccountsHandler(client, &qf, logger),
-			modules.NewConsensusAccountsHandler(client, &qf, logger),
+			modules.NewCoreHandler(client, runtime.String(), &qf, logger),
+			modules.NewAccountsHandler(client, runtime.String(), &qf, logger),
+			modules.NewConsensusAccountsHandler(client, runtime.String(), &qf, logger),
 		},
 	}, nil
 }
@@ -326,6 +326,7 @@ func (m *Main) prepareEventData(ctx context.Context, round uint64, batch *storag
 		eventRelatedAddresses := common.ExtractAddresses(eventData.RelatedAddresses)
 		batch.Queue(
 			m.qf.RuntimeEventInsertQuery(),
+			m.runtime,
 			round,
 			nil, // non-tx event has no tx index
 			nil, // non-tx event has no tx hash
@@ -353,6 +354,7 @@ func (m *Main) queueBlockAndTransactionInserts(ctx context.Context, batch *stora
 
 	batch.Queue(
 		m.qf.RuntimeBlockInsertQuery(),
+		m.runtime,
 		data.Round,
 		data.BlockHeader.Header.Version,
 		time.Unix(int64(data.BlockHeader.Header.Timestamp), 0 /* nanos */),
@@ -367,7 +369,7 @@ func (m *Main) queueBlockAndTransactionInserts(ctx context.Context, batch *stora
 		blockData.Size,
 	)
 
-	emitRoundBatch(batch, &m.qf, data.Round, blockData)
+	m.emitRoundBatch(batch, &m.qf, data.Round, blockData)
 
 	return nil
 }

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/modules"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	common "github.com/oasisprotocol/oasis-indexer/analyzer/uncategorized"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -186,7 +187,7 @@ func (m *Main) latestRound(ctx context.Context) (uint64, error) {
 	var latest uint64
 	if err := m.target.QueryRow(
 		ctx,
-		m.qf.LatestBlockQuery(),
+		queries.LatestBlock,
 		// ^analyzers should only analyze for a single chain ID, and we anchor this
 		// at the starting round.
 		m.runtime.String(),
@@ -203,7 +204,7 @@ func (m *Main) prework() error {
 
 	// Register special addresses.
 	batch.Queue(
-		m.qf.AddressPreimageInsertQuery(),
+		queries.AddressPreimageInsert,
 		rewards.RewardPoolAddress.String(),          // oasis1qp7x0q9qahahhjas0xde8w0v04ctp4pqzu5mhjav on mainnet oasis-3
 		types.AddressV0ModuleContext.Identifier,     // context_identifier
 		int32(types.AddressV0ModuleContext.Version), // context_version
@@ -251,7 +252,7 @@ func (m *Main) processRound(ctx context.Context, round uint64) error {
 	// Update indexing progress.
 	group.Go(func() error {
 		batch.Queue(
-			m.qf.IndexingProgressQuery(),
+			queries.IndexingProgress,
 			round,
 			m.runtime.String(),
 		)
@@ -320,7 +321,7 @@ func (m *Main) prepareEventData(ctx context.Context, round uint64, batch *storag
 	for _, eventData := range res.ExtractedEvents {
 		eventRelatedAddresses := common.ExtractAddresses(eventData.RelatedAddresses)
 		batch.Queue(
-			m.qf.RuntimeEventInsertQuery(),
+			queries.RuntimeEventInsert,
 			m.runtime,
 			round,
 			nil, // non-tx event has no tx index
@@ -335,7 +336,7 @@ func (m *Main) prepareEventData(ctx context.Context, round uint64, batch *storag
 
 	// Insert any eth address preimages found in non-tx events.
 	for addr, preimageData := range blockData.AddressPreimages {
-		batch.Queue(m.qf.AddressPreimageInsertQuery(), addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
+		batch.Queue(queries.AddressPreimageInsert, addr, preimageData.ContextIdentifier, preimageData.ContextVersion, preimageData.Data)
 	}
 
 	return nil
@@ -348,7 +349,7 @@ func (m *Main) queueBlockAndTransactionInserts(ctx context.Context, batch *stora
 	}
 
 	batch.Queue(
-		m.qf.RuntimeBlockInsertQuery(),
+		queries.RuntimeBlockInsert,
 		m.runtime,
 		data.Round,
 		data.BlockHeader.Header.Version,

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -101,9 +101,9 @@ func NewRuntimeAnalyzer(
 
 		// module handlers
 		moduleHandlers: []modules.ModuleHandler{
-			modules.NewCoreHandler(client, runtime.String(), logger),
-			modules.NewAccountsHandler(client, runtime.String(), logger),
-			modules.NewConsensusAccountsHandler(client, runtime.String(), logger),
+			modules.NewCoreHandler(client, runtime, logger),
+			modules.NewAccountsHandler(client, runtime, logger),
+			modules.NewConsensusAccountsHandler(client, runtime, logger),
 		},
 	}, nil
 }

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -55,6 +55,17 @@ func toString(b *BigInt) *string {
 	return &s
 }
 
+func runtimeFromCtx(ctx context.Context) string {
+	// Extract the runtime name. It's populated by a middleware based on the URL.
+	runtime, ok := ctx.Value(common.RuntimeContextKey).(string)
+	if !ok {
+		// We're being called from a non-runtime-specific endpoint.
+		// This shouldn't happen. Return a dummy value, let the caller deal with it.
+		return "__NO_RUNTIME__"
+	}
+	return runtime
+}
+
 // NewStorageClient creates a new storage client.
 func NewStorageClient(chainID string, db storage.TargetStorage, l *log.Logger) (*StorageClient, error) {
 	blockCache, err := ristretto.NewCache(&ristretto.Config{
@@ -941,7 +952,7 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeBlocksQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		p.From,
 		p.To,
 		p.After,
@@ -977,7 +988,7 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeTransactionsQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		p.Block,
 		txHash, // tx_hash; used only by GetRuntimeTransactionsTxHash
 		p.Rel,
@@ -1022,7 +1033,7 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeEventsQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		p.Block,
 		p.TxIndex,
 		p.TxHash,
@@ -1095,7 +1106,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	runtimeSdkRows, queryErr := c.db.Query(
 		ctx,
 		QueryFactoryFromCtx(ctx).AccountRuntimeSdkBalancesQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -1122,7 +1133,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	runtimeEvmRows, queryErr := c.db.Query(
 		ctx,
 		QueryFactoryFromCtx(ctx).AccountRuntimeEvmBalancesQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -1174,7 +1185,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).EvmTokensQuery(),
-		RuntimeFromCtx(ctx),
+		runtimeFromCtx(ctx),
 		p.Limit,
 		p.Offset,
 	)

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -941,6 +941,7 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeBlocksQuery(),
+		RuntimeFromCtx(ctx),
 		p.From,
 		p.To,
 		p.After,
@@ -976,6 +977,7 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeTransactionsQuery(),
+		RuntimeFromCtx(ctx),
 		p.Block,
 		txHash, // tx_hash; used only by GetRuntimeTransactionsTxHash
 		p.Rel,
@@ -1020,6 +1022,7 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).RuntimeEventsQuery(),
+		RuntimeFromCtx(ctx),
 		p.Block,
 		p.TxIndex,
 		p.TxHash,
@@ -1092,6 +1095,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	runtimeSdkRows, queryErr := c.db.Query(
 		ctx,
 		QueryFactoryFromCtx(ctx).AccountRuntimeSdkBalancesQuery(),
+		RuntimeFromCtx(ctx),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -1118,6 +1122,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	runtimeEvmRows, queryErr := c.db.Query(
 		ctx,
 		QueryFactoryFromCtx(ctx).AccountRuntimeEvmBalancesQuery(),
+		RuntimeFromCtx(ctx),
 		address.String(),
 	)
 	if queryErr != nil {
@@ -1169,6 +1174,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 	res, err := c.withTotalCount(
 		ctx,
 		QueryFactoryFromCtx(ctx).EvmTokensQuery(),
+		RuntimeFromCtx(ctx),
 		p.Limit,
 		p.Offset,
 	)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -438,7 +438,7 @@ const (
 		OFFSET $3::bigint
 	`
 
-	// FineDailyActiveAccountsQuery returns the fine-grained query for daily active account windows.
+	// FineDailyActiveAccounts returns the fine-grained query for daily active account windows.
 	FineDailyActiveAccounts = `
 		SELECT window_end, active_accounts
 		FROM stats.daily_active_accounts
@@ -449,7 +449,7 @@ const (
 		OFFSET $3::bigint
 	`
 
-	// DailyActiveAccountsQuery returns the query for daily sampled daily active account windows.
+	// DailyActiveAccounts returns the query for daily sampled daily active account windows.
 	DailyActiveAccounts = `
 		SELECT date_trunc('day', window_end) as window_end, active_accounts
 		FROM stats.daily_active_accounts

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -1,4 +1,4 @@
-package client
+package queries
 
 import (
 	"fmt"


### PR DESCRIPTION
Follow-up to #341 now that it is no longer required to know the ChainID to query the DB.

This PR removes the QueryFactory (QF) abstraction. It was hardly needed any more after its main parameter (chainID) was rendered obsolete. The remaining uses of QueryFactory's `runtime` field were converted so that the runtime is passed into each query as an explicit parameter.

Benefits of killing QF:
- reduces global-ish state (in QF)
- reduces number of ways in which we pass parameters into queries
- removes a layer of templated strings so SQL is easier to reason about and easier to copy-paste (for debugging etc)

A similar-to-QF lightweight templating approach remains in genesis.go. I didn't touch it because we'll majorly clean up its SQL generation (from manually stringifying args to using SQL templates) in an upcoming PR.

For reviewers: Code at most commits does not compile; I still left them there because they each represent a logical step, so it's easier to follow along (IMO).

**Testing**
I ran e2e_regressions; consensus and emerald ran for 100 blocks. None of the tested URLs found any differences.
