### PR TITLE
api: Add runtime and Consensus transaction failure details

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -418,6 +418,14 @@ func (m *Main) queueTransactionInserts(batch *storage.QueryBatch, data *storage.
 			m.logger.Warn("failed to marshal transaction body", "err", err, "tx_hash", signedTx.Hash().Hex(), "height", data.Height)
 			bodyBytes = []byte{}
 		}
+		var module *string
+		if len(result.Error.Module) > 0 {
+			module = &result.Error.Module
+		}
+		var message *string
+		if len(result.Error.Message) > 0 {
+			message = &result.Error.Message
+		}
 		batch.Queue(queries.ConsensusTransactionInsert,
 			data.BlockHeader.Height,
 			signedTx.Hash().Hex(),
@@ -428,9 +436,9 @@ func (m *Main) queueTransactionInserts(batch *storage.QueryBatch, data *storage.
 			tx.Method,
 			sender,
 			bodyBytes,
-			result.Error.Module,
+			module,
 			result.Error.Code,
-			result.Error.Message,
+			message,
 		)
 		batch.Queue(queries.ConsensusAccountNonceUpdate,
 			sender,

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1240,6 +1240,15 @@ components:
         success:
           type: boolean
           description: Whether this transaction successfully executed.
+        code:
+          type: integer
+          description: The status code of a failed call.
+        module:
+          type: string
+          description: The module of a failed call.
+        message:
+          type: string
+          description: The message of a failed call.
       description: |
         A consensus transaction.
 

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1240,17 +1240,25 @@ components:
         success:
           type: boolean
           description: Whether this transaction successfully executed.
-        code:
-          type: integer
-          description: The status code of a failed call.
-        module:
-          type: string
-          description: The module of a failed call.
-        message:
-          type: string
-          description: The message of a failed call.
+        error:
+          $ref: '#/components/schemas/TxError'
+          description: Error details of a failed transaction.
       description: |
         A consensus transaction.
+
+    TxError:
+      type: object
+      required: [code, module, message]
+      properties:
+        code:
+          type: integer
+          description: The status code of a failed transaction.
+        module:
+          type: string
+          description: The module of a failed transaction.
+        message:
+          type: string
+          description: The message of a failed transaction.
 
     ConsensusEventType:
       type: string
@@ -2072,15 +2080,9 @@ components:
         success:
           type: boolean
           description: Whether this transaction successfully executed.
-        code:
-          type: integer
-          description: The status code of a failed call.
-        module:
-          type: string
-          description: The module of a failed call.
-        message:
-          type: string
-          description: The message of a failed call.
+        error:
+          $ref: '#/components/schemas/TxError'
+          description: Error details of a failed transaction.
       description: |
         A runtime transaction.
 

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2063,6 +2063,15 @@ components:
         success:
           type: boolean
           description: Whether this transaction successfully executed.
+        code:
+          type: integer
+          description: The status code of a failed call.
+        module:
+          type: string
+          description: The module of a failed call.
+        message:
+          type: string
+          description: The message of a failed call.
       description: |
         A runtime transaction.
 

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1248,10 +1248,11 @@ components:
 
     TxError:
       type: object
-      required: [code, module, message]
+      required: [code]
       properties:
         code:
           type: integer
+          format: uint32
           description: The status code of a failed transaction.
         module:
           type: string

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -55,10 +55,14 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 		Success:    cr.IsSuccess(),
 	}
 	if !cr.IsSuccess() {
+		// `module` should be present but message may be null
+		// https://github.com/oasisprotocol/oasis-sdk/blob/fb741678585c04fdb413441f2bfba18aafbf98f3/client-sdk/go/types/transaction.go#L488-L492
 		apiTransaction.Error = &apiTypes.TxError{
-			Code:    int(cr.Failed.Code),
-			Module:  cr.Failed.Module,
-			Message: cr.Failed.Message,
+			Code:   cr.Failed.Code,
+			Module: &cr.Failed.Module,
+		}
+		if len(cr.Failed.Message) > 0 {
+			apiTransaction.Error.Message = &cr.Failed.Message
 		}
 	}
 	if err = uncategorized.VisitCall(&tx.Call, &cr, &uncategorized.CallHandler{

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -55,10 +55,11 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 		Success:    cr.IsSuccess(),
 	}
 	if !cr.IsSuccess() {
-		code := int(cr.Failed.Code)
-		apiTransaction.Code = &code
-		apiTransaction.Module = &cr.Failed.Module
-		apiTransaction.Message = &cr.Failed.Message
+		apiTransaction.Error = &apiTypes.TxError{
+			Code:    int(cr.Failed.Code),
+			Module:  cr.Failed.Module,
+			Message: cr.Failed.Message,
+		}
 	}
 	if err = uncategorized.VisitCall(&tx.Call, &cr, &uncategorized.CallHandler{
 		AccountsTransfer: func(body *accounts.Transfer) error {

--- a/api/v1/logic.go
+++ b/api/v1/logic.go
@@ -54,6 +54,12 @@ func renderRuntimeTransaction(storageTransaction client.RuntimeTransaction) (api
 		Body:       body,
 		Success:    cr.IsSuccess(),
 	}
+	if !cr.IsSuccess() {
+		code := int(cr.Failed.Code)
+		apiTransaction.Code = &code
+		apiTransaction.Module = &cr.Failed.Module
+		apiTransaction.Message = &cr.Failed.Message
+	}
 	if err = uncategorized.VisitCall(&tx.Call, &cr, &uncategorized.CallHandler{
 		AccountsTransfer: func(body *accounts.Transfer) error {
 			toAddr, err2 := uncategorized.StringifySdkAddress(&body.To)

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -285,7 +285,11 @@ func (srv *StrictServerImpl) GetRuntimeTransactionsTxHash(ctx context.Context, r
 	}
 
 	// Perform additional tx body parsing on the fly; DB stores only partially-parsed txs.
-	var apiTransactions apiTypes.RuntimeTransactionList
+	apiTransactions := apiTypes.RuntimeTransactionList{
+		Transactions:        []apiTypes.RuntimeTransaction{},
+		TotalCount:          storageTransactions.TotalCount,
+		IsTotalCountClipped: storageTransactions.IsTotalCountClipped,
+	}
 	for _, storageTransaction := range storageTransactions.Transactions {
 		apiTransaction, err2 := renderRuntimeTransaction(storageTransaction)
 		if err2 != nil {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -279,9 +279,9 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 	}
 	for res.rows.Next() {
 		var t Transaction
-		var code uint64
-		var module string
-		var message string
+		var code uint32
+		var module *string
+		var message *string
 		if err := res.rows.Scan(
 			&t.Block,
 			&t.Index,
@@ -302,7 +302,7 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 			t.Success = true
 		} else {
 			t.Error = &apiTypes.TxError{
-				Code:    int(code),
+				Code:    code,
 				Module:  module,
 				Message: message,
 			}
@@ -323,9 +323,9 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 	}
 
 	var t Transaction
-	var code uint64
-	var module string
-	var message string
+	var code uint32
+	var module *string
+	var message *string
 	if err := c.db.QueryRow(
 		ctx,
 		queries.Transaction,
@@ -350,7 +350,7 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 		t.Success = true
 	} else {
 		t.Error = &apiTypes.TxError{
-			Code:    int(code),
+			Code:    code,
 			Module:  module,
 			Message: message,
 		}

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -279,7 +279,8 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 	}
 	for res.rows.Next() {
 		var t Transaction
-		var code uint64
+		var module string
+		var message string
 		if err := res.rows.Scan(
 			&t.Block,
 			&t.Index,
@@ -289,13 +290,18 @@ func (c *StorageClient) Transactions(ctx context.Context, p apiTypes.GetConsensu
 			&t.Fee,
 			&t.Method,
 			&t.Body,
-			&code,
+			&t.Code,
+			&module,
+			&message,
 			&t.Timestamp,
 		); err != nil {
 			return nil, wrapError(err)
 		}
-		if code == oasisErrors.CodeNoError {
+		if *t.Code == oasisErrors.CodeNoError {
 			t.Success = true
+		} else {
+			t.Module = &module
+			t.Message = &message
 		}
 
 		ts.Transactions = append(ts.Transactions, t)
@@ -313,7 +319,8 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 	}
 
 	var t Transaction
-	var code uint64
+	var module string
+	var message string
 	if err := c.db.QueryRow(
 		ctx,
 		queries.Transaction,
@@ -327,13 +334,18 @@ func (c *StorageClient) Transaction(ctx context.Context, txHash string) (*Transa
 		&t.Fee,
 		&t.Method,
 		&t.Body,
-		&code,
+		&t.Code,
+		&module,
+		&message,
 		&t.Timestamp,
 	); err != nil {
 		return nil, wrapError(err)
 	}
-	if code == oasisErrors.CodeNoError {
+	if *t.Code == oasisErrors.CodeNoError {
 		t.Success = true
+	} else {
+		t.Module = &module
+		t.Message = &message
 	}
 
 	c.cacheTx(&t)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -45,6 +45,8 @@ const (
 				chain.transactions.method as method,
 				chain.transactions.body as body,
 				chain.transactions.code as code,
+				chain.transactions.module as module,
+				chain.transactions.message as message,
 				chain.blocks.time as time
 			FROM chain.transactions
 			JOIN chain.blocks ON chain.transactions.block = chain.blocks.height
@@ -65,7 +67,7 @@ const (
 			OFFSET $9::bigint`
 
 	Transaction = `
-		SELECT block, tx_index, tx_hash, sender, nonce, fee_amount, method, body, code, chain.blocks.time
+		SELECT block, tx_index, tx_hash, sender, nonce, fee_amount, method, body, code, module, message, chain.blocks.time
 			FROM chain.transactions
 			JOIN chain.blocks ON chain.transactions.block = chain.blocks.height
 			WHERE tx_hash = $1::text`

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -51,7 +51,7 @@ CREATE TABLE chain.transactions
   -- Error Fields
   -- This includes an encoding of no error.
   module  TEXT,
-  code    UINT31,  -- From https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/consensus/api/transaction/results/results.go#L20-L20
+  code    UINT31 NOT NULL,  -- From https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/consensus/api/transaction/results/results.go#L20-L20
   message TEXT,
 
   -- We require a composite primary key since duplicate transactions (with identical hashes) can


### PR DESCRIPTION
## What

Add runtime failure details including `code`, `module`, and `message` to API response for runtime transactions.

Add failure details including `code`, `module`, and `message` to API response for Consensus transactions.

## Changes

### Runtime

For `v1/emerald/transactions/af4c53ebbc11570a4b4fc086ea52cea48e50d6a52a0b2e81446bc54ae727baae`, we see:

```
{
  "is_total_count_clipped": false,
  "total_count": 0,
  "transactions": [
    {
      "amount": "400000000000000000",
      "body": {
        "address": "o3KM94hIeiU9oLecNoDuhYlcBPM=",
        "data": "",
        "value": "BY0V4XYoAAA="
      },
      "eth_hash": "3db558dd0d635131ab449c2607f63f6c2d21e222de96945894c6051da9f9e769",
      "fee": "2231400000000000",
      "gas_limit": 22314,
      "gas_used": 22143,
      "hash": "af4c53ebbc11570a4b4fc086ea52cea48e50d6a52a0b2e81446bc54ae727baae",
      "index": 2,
      "method": "evm.Call",
      "nonce_0": 788,
      "round": 1007653,
      "sender_0": "oasis1qrzhdmygev6z8vq4rpfxdscqns0xzfawgye26kp0",
      "sender_0_eth": "0x7DC7B25043983BBF7C30D45ffaf132C0C5F100A8",
      "size": 143,
      "success": true,
      "timestamp": "2022-04-11T15:50:44-05:00",
      "to": "oasis1qpv50jh2t5pmk6gpa3hmugl954ewkahzgqk32gc5",
      "to_eth": "0xa3728cf788487A253DA0B79c3680eE85895c04f3"
    }
  ]
}
```

For a transaction with error such as `v1/emerald/transactions/9f80d9ae209a1f487bf7bc4b548aab11ab5fb1e3d6dab80d30ab7a9d68259356`, we see:

```
{
  "is_total_count_clipped": false,
  "total_count": 0,
  "transactions": [
    {
      "amount": "0",
      "body": {
        "address": "FIZsupZtnOrWpl1PLf5Oyd/Lpec=",
        "data": "duDlAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA+AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAGy5dQqSZDOC4CDqmhcKu4PfBfMLAAAAAAAAAAAAAAAAIccYwi1S0POnibdS1ML9WQiopzMAAAAAAAAAAAAAAAC8AzIDeWzCyMVDparpOppkMyBDPQAAAAAAAAAAAAAAAGy5dQqSZDOC4CDqmhcKu4PfBfMLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMAAAAAAAAAAAAAAAAEpZCzhDhFV5KkuQbJ3GO3qgyjFgAAAAAAAAAAAAAAAB3gYvBp/x8fMv55LEB41t3qsE2ZAAAAAAAAAAAAAAAAmpG8PtfQ1kIsdZnM3YwiAL/UqOoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAABrWYTnmXjpZSVHMAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGvp7hHfsAAAAAAAAAAAAAAAAAAAAAAAAAAAAD7u8gyiY69yV/MAAAAAAAAAAAAAAAAAAAAAAAAAAAAAKANOW2z1Li5RQLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHf9x/3LYAAAAAAAAAAAAAAAAAAAAAAAAAAAASy/21XKW+I3XsDgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD5QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAPoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA9iNQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABdwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAnEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACRhOcqAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfDG/uCGGQj3kAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABOt1ZRTCpWFuAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAH0+e6AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAfTmOg=",
        "value": ""
      },
      "code": 8,
      "eth_hash": "4ce227e0561a43933eb6b4904f6d634c430cff33bec4e659636a16cdd69031b5",
      "fee": "100000000000000000",
      "gas_limit": 1000000,
      "gas_used": 87316,
      "hash": "9f80d9ae209a1f487bf7bc4b548aab11ab5fb1e3d6dab80d30ab7a9d68259356",
      "index": 2,
      "message": "reverted: xky",
      "method": "evm.Call",
      "module": "evm",
      "nonce_0": 11157,
      "round": 1008173,
      "sender_0": "oasis1qq99lg557djn39hlp42jq03jqusxhy7ussve94y9",
      "sender_0_eth": "0x8b262A8204B31066Ee28Da5F2da249171d64Bf5C",
      "size": 1456,
      "success": false,
      "timestamp": "2022-04-11T16:44:04-05:00",
      "to": "oasis1qpmu8k80egszzxs9ruc4zzklsd69u79tvgmt8prt",
      "to_eth": "0x14866Cba966D9cEAd6A65D4f2Dfe4eC9DfCBA5E7"
    }
  ]
}
```

### Consensus

For `v1/consensus/transactions/1224426e4126f79c6486fa5b74f096c07471bfd51e6b25242c131eb5fa7ecc8f`, we see:
```
{
  "block": 8051022,
  "body": "omJpZFggAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA4uqpn8AI+H9nY29tbWl0c4GjY3NpZ1hAuv+eM1Glh/Bc8ajQfSZkUUd01Lx+Hn8YJ3HNHnlWY9n9FbaJz1yUNGF0rTwUErIIKFMqr14AQ7YNSGIfrgD9AGZoZWFkZXKnZXJvdW5kGgAPUjFnaW9fcm9vdFggCijJ6xtpKuQxQri8yv9lr+n6FCcOYI4rhast9pCLHxdncmFrX3NpZ1hAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGpzdGF0ZV9yb290WCCgmvMKVdJb+82yO6J/+yof2oeUahE497Tn/QutU1iskGxpbl9tc2dzX2hhc2hYIMZyuNHvVu0oq4fDYixRFAab3TrXuPlzdJjQwB7O8JZ6bW1lc3NhZ2VzX2hhc2hYIMZyuNHvVu0oq4fDYixRFAab3TrXuPlzdJjQwB7O8JZ6bXByZXZpb3VzX2hhc2hYIJnU+qz97kUkdE0PrZf/z8e/zZq3JHGJHn9vx8MA4DBvZ25vZGVfaWRYIA6Y9YmyDLUxzIf4uaodHmXBhpjlTgxC0h74P2RQSD22",
  "code": 0,
  "fee": "0",
  "hash": "1224426e4126f79c6486fa5b74f096c07471bfd51e6b25242c131eb5fa7ecc8f",
  "index": 0,
  "method": "roothash.ExecutorCommit",
  "nonce": 198436,
  "sender": "oasis1qzfpcry9yj9z4w3rr5f5tmtu4v7xs5pjmufaw097",
  "success": true,
  "timestamp": "2022-04-11T09:29:25-05:00"
}
```

For `v1/consensus/transactions/e7b22c0153c78f66b810f78ab68fbcb5d7a2d70bb5ec617c704817cf57d32903`, we see:

```
{
  "block": 8048958,
  "body": "ompzaWduYXR1cmVzhaJpc2lnbmF0dXJlWEBV9LaBdMo4Y/qdQzacuRVDcGvAsZGluftBfgZ396CwdWYh4YoaVc2beQi3wwKQo7z/rNztw+AraR8pD4chyCUDanB1YmxpY19rZXlYIEQpQ8coIhmBBXjvdI53xwCF5tkKz+UzUORedDe+8ymOomlzaWduYXR1cmVYQIwBMiaxaoyzpI8XX8Bsfyh/oiHGkJG4Ngb74tyMkWHivyLnE0r6v2/ytENJjDFL16kNFsGdw5NnrwsPabGvfgZqcHVibGljX2tleVggwVzDTtgyF/L/biM+/RrHJhie2Ttk+FK5l4z3I8LjOsOiaXNpZ25hdHVyZVhAke/fnGRihjE7XZ604IlUtUk40GY5wLi1UZC4T5w0lE+9nV7dXlk2jeuD8KFRoY33PAn8bhWcgD3QKl2o1m7WB2pwdWJsaWNfa2V5WCCgiTdvmTp3ZuC/TcXzCSvfIfRnv3m5nDj/wskYnMrqwaJpc2lnbmF0dXJlWEC7XlBijgxqdQoERSiVC02CXyYZQwFa048gXkpoZC8CxlBsft5jaApv0LgJzroUAG7sPEIUT70gf7lzTP1gTYcPanB1YmxpY19rZXlYIGAeTvd4c+df5kUJ7v76rnKfKhAgMtIqEgXvBpjtWp+comlzaWduYXR1cmVYQExF3kq8C94rK/T1qWIvmNv5OreZvRiCRXXWAKshe3GgCaId0RrvVW49TT/a8pL5fdS+rGkNpFd6pbJwmvFOoAJqcHVibGljX2tleVggKGqRI7Ryg5srApDU+DMqfjkTcIUp3111fcD9hxYfZSNzdW50cnVzdGVkX3Jhd192YWx1ZVkB3qthdgJiaWRYIEQpQ8coIhmBBXjvdI53xwCF5tkKz+UzUORedDe+8ymOY3AycKJiaWRYIMFcw07YMhfy/24jPv0axyYYntk7ZPhSuZeM9yPC4zrDaWFkZHJlc3Nlc/ZjdGxzo2dwdWJfa2V5WCAoapEjtHKDmysCkNT4Myp+ORNwhSnfXXV9wP2HFh9lI2lhZGRyZXNzZXP2bG5leHRfcHViX2tleVggx1QmTaHUD/NeZ3TP2QdFJs1yncc9pEdA4cb5MW7eci5jdnJmoWJpZFggYB5O93hz51/mRQnu/vqucp8qECAy0ioSBe8GmO1an5xlcm9sZXMIaHJ1bnRpbWVz9mljb25zZW5zdXOiYmlkWCCgiTdvmTp3ZuC/TcXzCSvfIfRnv3m5nDj/wskYnMrqwWlhZGRyZXNzZXOBomJpZFggwVzDTtgyF/L/biM+/RrHJhie2Ttk+FK5l4z3I8LjOsNnYWRkcmVzc6NiSVBQAAAAAAAAAAAAAP//j26GBWRQb3J0GWggZFpvbmVgaWVudGl0eV9pZFggGDWO0+R7qSrWB0bvT+V2Kz6vlHcm6ZnaNQM2/FsFqEBqZXhwaXJhdGlvbgJwc29mdHdhcmVfdmVyc2lvbmYyMi4xLjM=",
  "code": 13,
  "fee": "0",
  "hash": "e7b22c0153c78f66b810f78ab68fbcb5d7a2d70bb5ec617c704817cf57d32903",
  "index": 51,
  "message": "registry: node expired",
  "method": "registry.RegisterNode",
  "module": "registry",
  "nonce": 13419,
  "sender": "oasis1qryxlps075x66qt24kxskjqy2sp75nfuccs46k9a",
  "success": false,
  "timestamp": "2022-04-11T06:00:27-05:00"
}
```

## TODO

- [x] Refactor to `error` substructure