### PR TITLE
sql: reuse queries. update->upsert.

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -440,7 +440,7 @@ func (m *Main) queueTransactionInserts(batch *storage.QueryBatch, data *storage.
 			result.Error.Code,
 			message,
 		)
-		batch.Queue(queries.ConsensusAccountNonceUpdate,
+		batch.Queue(queries.ConsensusAccountNonceUpsert,
 			sender,
 			tx.Nonce+1,
 		)
@@ -684,11 +684,11 @@ func (m *Main) queueTransfers(batch *storage.QueryBatch, data *storage.StakingDa
 			continue
 		}
 
-		batch.Queue(queries.ConsensusSenderUpdate,
+		batch.Queue(queries.ConsensusDecreaseGeneralBalanceUpsert,
 			transfer.From.String(),
 			transfer.Amount.String(),
 		)
-		batch.Queue(queries.ConsensusReceiverUpdate,
+		batch.Queue(queries.ConsensusIncreaseGeneralBalanceUpsert,
 			transfer.To.String(),
 			transfer.Amount.String(),
 		)
@@ -699,7 +699,7 @@ func (m *Main) queueTransfers(batch *storage.QueryBatch, data *storage.StakingDa
 
 func (m *Main) queueBurns(batch *storage.QueryBatch, data *storage.StakingData) error {
 	for _, burn := range data.Burns {
-		batch.Queue(queries.ConsensusBurnUpdate,
+		batch.Queue(queries.ConsensusDecreaseGeneralBalanceUpsert,
 			burn.Owner.String(),
 			burn.Amount.String(),
 		)
@@ -716,7 +716,7 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 			escrower := e.Add.Escrow.String()
 			amount := e.Add.Amount.String()
 			newShares := e.Add.NewShares.String()
-			batch.Queue(queries.ConsensusDecreaseGeneralBalanceForEscrowUpdate,
+			batch.Queue(queries.ConsensusDecreaseGeneralBalanceUpsert,
 				owner,
 				amount,
 			)
@@ -754,7 +754,7 @@ func (m *Main) queueEscrows(batch *storage.QueryBatch, data *storage.StakingData
 				e.DebondingStart.DebondEndTime,
 			)
 		case e.Reclaim != nil:
-			batch.Queue(queries.ConsensusReclaimGeneralBalanceUpdate,
+			batch.Queue(queries.ConsensusIncreaseGeneralBalanceUpsert,
 				e.Reclaim.Owner.String(),
 				e.Reclaim.Amount.String(),
 			)


### PR DESCRIPTION
Some low-priority tweaks to our SQL queries.
- Changes some updates to upserts (`INSERT ... ON CONFLICT DO UPDATE`). I found one of these while debugging https://github.com/oasisprotocol/nexus/issues/853. A block (not directly related to that bug) tried to delegate A's voting power to B. Since this was A's first tx, it had no entries in the `accounts` table, and so the `delegations(delegator, delagatee)` table had its FK violated (`delegator` should reference a known `accounts.address`).
    - I did not change all remaining UPDATEs to upserts; they seem to all affect tables that either are not targets of a FK, or where a matching row clearly has to exist from before
- Removes some queries in favor of query reuse. In particular, we had several queries for updating `accounts.general_balance`; they all did the exact same thing, but were separate consts based on the _reason_ for the update (e.g. decreasing balance because of a burn, or because of putting tokens into escrow). I think that's counterproductive at this layer.

Testing: ./tests/e2e_regression/reindex_and_run.sh, 100 rounds