### PR TITLE
config: archive node configuration

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -68,7 +68,7 @@ func (a *AggregateStatsAnalyzer) Name() string {
 	return AggregateStatsAnalyzerName
 }
 
-func NewAggregateStatsAnalyzer(chainID string, cfg *config.AggregateStatsConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
+func NewAggregateStatsAnalyzer(cfg *config.AggregateStatsConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
 	logger.Info("starting aggregate_stats analyzer")
 	return &AggregateStatsAnalyzer{
 		target:           target,

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -39,12 +39,9 @@ type Analyzer interface {
 // ConsensusConfig specifies configuration parameters for
 // for processing the consensus layer.
 type ConsensusConfig struct {
-	// ChainID is the chain ID for the underlying network.
-	ChainID string
-
-	// ChainContext is the ChainContext (= chain identifier, based on a hash of the
-	// genesis file) for the underlying network.
-	ChainContext string
+	// GenesisChainContext is the chain context that specifies which genesis
+	// file to analyze.
+	GenesisChainContext string
 
 	// Range is the range of blocks to process.
 	// If this is set, the analyzer analyzes blocks in the provided range.

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
@@ -89,37 +88,14 @@ var _ analyzer.Analyzer = (*Main)(nil)
 
 func NewMain(
 	runtime analyzer.Runtime,
-	nodeCfg *config.NodeConfig,
+	sourceConfig *config.SourceConfig,
 	target storage.TargetStorage,
 	logger *log.Logger,
 ) (*Main, error) {
 	ctx := context.Background()
 
 	// Initialize source storage.
-	networkCfg := oasisConfig.Network{
-		ChainContext: nodeCfg.ChainContext,
-		RPC:          nodeCfg.RPC,
-	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
-	if err != nil {
-		logger.Error("error creating client factory",
-			"err", err,
-		)
-		return nil, err
-	}
-
-	network, err := analyzer.FromChainContext(nodeCfg.ChainContext)
-	if err != nil {
-		return nil, err
-	}
-
-	id, err := runtime.ID(network)
-	if err != nil {
-		return nil, err
-	}
-	logger.Info("Runtime ID determined", "runtime", runtime.String(), "runtime_id", id)
-
-	client, err := factory.Runtime(id)
+	client, err := oasis.NewRuntimeClient(ctx, sourceConfig, runtime)
 	if err != nil {
 		logger.Error("error creating runtime client",
 			"err", err,

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
@@ -45,37 +44,14 @@ var _ analyzer.Analyzer = (*Main)(nil)
 
 func NewMain(
 	runtime analyzer.Runtime,
-	nodeCfg *config.NodeConfig,
+	sourceConfig *config.SourceConfig,
 	target storage.TargetStorage,
 	logger *log.Logger,
 ) (*Main, error) {
 	ctx := context.Background()
 
 	// Initialize source storage.
-	networkCfg := oasisConfig.Network{
-		ChainContext: nodeCfg.ChainContext,
-		RPC:          nodeCfg.RPC,
-	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
-	if err != nil {
-		logger.Error("error creating client factory",
-			"err", err,
-		)
-		return nil, err
-	}
-
-	network, err := analyzer.FromChainContext(nodeCfg.ChainContext)
-	if err != nil {
-		return nil, err
-	}
-
-	id, err := runtime.ID(network)
-	if err != nil {
-		return nil, err
-	}
-	logger.Info("Runtime ID determined", "runtime", runtime.String(), "runtime_id", id)
-
-	client, err := factory.Runtime(id)
+	client, err := oasis.NewRuntimeClient(ctx, sourceConfig, runtime)
 	if err != nil {
 		logger.Error("error creating runtime client",
 			"err", err,

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -29,11 +29,7 @@ func (a *MetadataRegistryAnalyzer) Name() string {
 	return MetadataRegistryAnalyzerName
 }
 
-func NewMetadataRegistryAnalyzer(chainID string, cfg *config.MetadataRegistryConfig, target storage.TargetStorage, logger *log.Logger) (*MetadataRegistryAnalyzer, error) {
-	if chainID == "" {
-		return nil, fmt.Errorf("metadata_registry analyzer: `ChainID` must be specified in the config")
-	}
-
+func NewMetadataRegistryAnalyzer(cfg *config.MetadataRegistryConfig, target storage.TargetStorage, logger *log.Logger) (*MetadataRegistryAnalyzer, error) {
 	logger.Info("Starting metadata_registry analyzer")
 	return &MetadataRegistryAnalyzer{
 		interval: cfg.Interval,

--- a/analyzer/runtime/evm_test.go
+++ b/analyzer/runtime/evm_test.go
@@ -11,20 +11,34 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/oasisprotocol/oasis-core/go/runtime/client/api"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/stretchr/testify/require"
 
+	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/evmabi"
 	"github.com/oasisprotocol/oasis-indexer/cmd/common"
+	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis"
 )
 
-func TestEVMDownloadTokenERC20(t *testing.T) {
+var (
+	ChainName          = "mainnet"
+	CurrentArchiveName = config.DefaultChains[ChainName].CurrentRecord().ArchiveName
 	// TODO: Would be nice to have an offline test.
+	PublicSourceConfig = &config.SourceConfig{
+		ChainName: ChainName,
+		Nodes: map[string]*config.NodeConfig{
+			CurrentArchiveName: {
+				RPC: sdkConfig.DefaultNetworks.All[ChainName].RPC,
+			},
+		},
+		FastStartup: false,
+	}
+)
+
+func TestEVMDownloadTokenERC20(t *testing.T) {
 	ctx := context.Background()
-	cf, err := oasis.NewClientFactory(ctx, config.DefaultNetworks.All["mainnet"], true)
-	require.NoError(t, err)
-	source, err := cf.Runtime(config.DefaultNetworks.All["mainnet"].ParaTimes.All["emerald"].ID)
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, analyzer.RuntimeEmerald)
 	require.NoError(t, err)
 	// Wormhole bridged USDT on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")
@@ -35,11 +49,8 @@ func TestEVMDownloadTokenERC20(t *testing.T) {
 }
 
 func TestEVMDownloadTokenBalanceERC20(t *testing.T) {
-	// TODO: Would be nice to have an offline test.
 	ctx := context.Background()
-	cf, err := oasis.NewClientFactory(ctx, config.DefaultNetworks.All["mainnet"], true)
-	require.NoError(t, err)
-	source, err := cf.Runtime(config.DefaultNetworks.All["mainnet"].ParaTimes.All["emerald"].ID)
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, analyzer.RuntimeEmerald)
 	require.NoError(t, err)
 	// Wormhole bridged USDT on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")
@@ -53,11 +64,8 @@ func TestEVMDownloadTokenBalanceERC20(t *testing.T) {
 }
 
 func TestEVMFailDeterministicUnoccupied(t *testing.T) {
-	// TODO: Would be nice to have an offline test.
 	ctx := context.Background()
-	cf, err := oasis.NewClientFactory(ctx, config.DefaultNetworks.All["mainnet"], true)
-	require.NoError(t, err)
-	source, err := cf.Runtime(config.DefaultNetworks.All["mainnet"].ParaTimes.All["emerald"].ID)
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, analyzer.RuntimeEmerald)
 	require.NoError(t, err)
 	// An address at which no smart contract exists.
 	tokenEthAddr, err := hex.DecodeString("5555555555555555555555555555555555555555")
@@ -70,11 +78,8 @@ func TestEVMFailDeterministicUnoccupied(t *testing.T) {
 }
 
 func TestEVMFailDeterministicOutOfGas(t *testing.T) {
-	// TODO: Would be nice to have an offline test.
 	ctx := context.Background()
-	cf, err := oasis.NewClientFactory(ctx, config.DefaultNetworks.All["mainnet"], true)
-	require.NoError(t, err)
-	source, err := cf.Runtime(config.DefaultNetworks.All["mainnet"].ParaTimes.All["emerald"].ID)
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, analyzer.RuntimeEmerald)
 	require.NoError(t, err)
 	// Wormhole bridged USDT on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")
@@ -92,11 +97,8 @@ func TestEVMFailDeterministicOutOfGas(t *testing.T) {
 }
 
 func TestEVMFailDeterministicUnsupportedMethod(t *testing.T) {
-	// TODO: Would be nice to have an offline test.
 	ctx := context.Background()
-	cf, err := oasis.NewClientFactory(ctx, config.DefaultNetworks.All["mainnet"], true)
-	require.NoError(t, err)
-	source, err := cf.Runtime(config.DefaultNetworks.All["mainnet"].ParaTimes.All["emerald"].ID)
+	source, err := oasis.NewRuntimeClient(ctx, PublicSourceConfig, analyzer.RuntimeEmerald)
 	require.NoError(t, err)
 	// Wormhole bridged USDT on Emerald mainnet.
 	tokenEthAddr, err := hex.DecodeString("dC19A122e268128B5eE20366299fc7b5b199C8e3")

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
@@ -40,7 +39,7 @@ var _ analyzer.Analyzer = (*Main)(nil)
 // NewRuntimeAnalyzer returns a new main analyzer for a runtime.
 func NewRuntimeAnalyzer(
 	runtime analyzer.Runtime,
-	nodeCfg config.NodeConfig,
+	sourceConfig *config.SourceConfig,
 	cfg *config.BlockBasedAnalyzerConfig,
 	target storage.TargetStorage,
 	logger *log.Logger,
@@ -48,30 +47,7 @@ func NewRuntimeAnalyzer(
 	ctx := context.Background()
 
 	// Initialize source storage.
-	networkCfg := oasisConfig.Network{
-		ChainContext: nodeCfg.ChainContext,
-		RPC:          nodeCfg.RPC,
-	}
-	factory, err := oasis.NewClientFactory(ctx, &networkCfg, nodeCfg.FastStartup)
-	if err != nil {
-		logger.Error("error creating client factory",
-			"err", err,
-		)
-		return nil, err
-	}
-
-	network, err := analyzer.FromChainContext(nodeCfg.ChainContext)
-	if err != nil {
-		return nil, err
-	}
-
-	id, err := runtime.ID(network)
-	if err != nil {
-		return nil, err
-	}
-	logger.Info("Runtime ID determined", "runtime", runtime.String(), "runtime_id", id)
-
-	client, err := factory.Runtime(id)
+	client, err := oasis.NewRuntimeClient(ctx, sourceConfig, runtime)
 	if err != nil {
 		logger.Error("error creating runtime client",
 			"err", err,

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/iancoleman/strcase"
+	"github.com/rs/cors"
+
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/metrics"
-	"github.com/rs/cors"
 )
 
 var (
@@ -99,23 +99,6 @@ func MetricsMiddleware(m metrics.RequestMetrics, logger log.Logger) func(next ht
 				metricName = "ignored"
 			}
 			m.RequestCounter(metricName, statusTxt).Inc()
-		})
-	}
-}
-
-// ChainMiddleware is a middleware that adds chain-specific information
-// to the request context.
-func ChainMiddleware(chainID string) func(next http.Handler) http.Handler {
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// snake_case the chainID; it's how it's used to name the DB schemas.
-			chainIDSnake := strcase.ToSnake(chainID)
-
-			// TODO: Set chainID based on provided height params.
-
-			next.ServeHTTP(w, r.WithContext(
-				context.WithValue(r.Context(), common.ChainIDContextKey, chainIDSnake),
-			))
 		})
 	}
 }

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -75,8 +75,6 @@ x-query-params:
       86400 (1 day). Requests with other values may be rejected.
 
 x-examples:
-  chain-id:
-    - &chain_id_1 'oasis-3'
   block-height:
     - &block_height_1 8048956
     - &block_height_2 8049555
@@ -1023,11 +1021,6 @@ components:
       type: object
       required: [latest_chain_id, latest_block, latest_update]
       properties:
-        latest_chain_id:
-          x-go-name: LatestChainID  # oapi-codegen generates LatestChainId (with a lowercase d) by default.
-          type: string
-          description: The most recently indexed chain ID.
-          example: *chain_id_1
         latest_block:
           type: integer
           format: int64

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -172,52 +172,52 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	analyzers := map[string]A{}
 	if cfg.Analyzers.Consensus != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return consensus.NewMain(cfg.Node, cfg.Analyzers.Consensus, client, logger)
+			return consensus.NewMain(&cfg.Source, cfg.Analyzers.Consensus, client, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeEmerald, cfg.Node, cfg.Analyzers.Emerald, client, logger)
+			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeEmerald, &cfg.Source, cfg.Analyzers.Emerald, client, logger)
 		})
 	}
 	if cfg.Analyzers.Sapphire != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeSapphire, cfg.Node, cfg.Analyzers.Sapphire, client, logger)
+			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeSapphire, &cfg.Source, cfg.Analyzers.Sapphire, client, logger)
 		})
 	}
 	if cfg.Analyzers.Cipher != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeCipher, cfg.Node, cfg.Analyzers.Cipher, client, logger)
+			return runtime.NewRuntimeAnalyzer(analyzer.RuntimeCipher, &cfg.Source, cfg.Analyzers.Cipher, client, logger)
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokens != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return evmtokens.NewMain(analyzer.RuntimeEmerald, &cfg.Node, client, logger)
+			return evmtokens.NewMain(analyzer.RuntimeEmerald, &cfg.Source, client, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokens != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return evmtokens.NewMain(analyzer.RuntimeSapphire, &cfg.Node, client, logger)
+			return evmtokens.NewMain(analyzer.RuntimeSapphire, &cfg.Source, client, logger)
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokenBalances != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return evmtokenbalances.NewMain(analyzer.RuntimeEmerald, &cfg.Node, client, logger)
+			return evmtokenbalances.NewMain(analyzer.RuntimeEmerald, &cfg.Source, client, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokenBalances != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return evmtokenbalances.NewMain(analyzer.RuntimeSapphire, &cfg.Node, client, logger)
+			return evmtokenbalances.NewMain(analyzer.RuntimeSapphire, &cfg.Source, client, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return analyzer.NewMetadataRegistryAnalyzer(cfg.Node.ChainID, cfg.Analyzers.MetadataRegistry, client, logger)
+			return analyzer.NewMetadataRegistryAnalyzer(cfg.Analyzers.MetadataRegistry, client, logger)
 		})
 	}
 	if cfg.Analyzers.AggregateStats != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			return analyzer.NewAggregateStatsAnalyzer(cfg.Node.ChainID, cfg.Analyzers.AggregateStats, client, logger)
+			return analyzer.NewAggregateStatsAnalyzer(cfg.Analyzers.AggregateStats, client, logger)
 		})
 	}
 	if err != nil {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -86,7 +86,6 @@ func Init(cfg *config.ServerConfig) (*Service, error) {
 // Service is the Oasis Indexer's API service.
 type Service struct {
 	address string
-	chainID string
 	target  *storage.StorageClient
 	logger  *log.Logger
 }
@@ -100,14 +99,13 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := storage.NewStorageClient(cfg.ChainID, cfg.ChainName, backing, logger)
+	client, err := storage.NewStorageClient(cfg.ChainName, backing, logger)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Service{
 		address: cfg.Endpoint,
-		chainID: cfg.ChainID,
 		target:  client,
 		logger:  logger,
 	}, nil
@@ -148,7 +146,6 @@ func (s *Service) Start() {
 		apiTypes.ChiServerOptions{
 			BaseURL: v1BaseURL,
 			Middlewares: []apiTypes.MiddlewareFunc{
-				api.ChainMiddleware(s.chainID),
 				api.RuntimeFromURLMiddleware(v1BaseURL),
 				api.CorsMiddleware,
 			},

--- a/common/types.go
+++ b/common/types.go
@@ -93,9 +93,6 @@ func Ptr[T any](v T) *T {
 type ContextKey string
 
 const (
-	// ChainIDContextKey is used to set the relevant chain ID
-	// in a request context.
-	ChainIDContextKey ContextKey = "chain_id"
 	// RuntimeContextKey is used to set the relevant runtime name
 	// in a request context.
 	RuntimeContextKey ContextKey = "runtime"

--- a/config/config.go
+++ b/config/config.go
@@ -239,9 +239,6 @@ func (cfg *AggregateStatsConfig) Validate() error {
 
 // ServerConfig contains the API server configuration.
 type ServerConfig struct {
-	// ChainID is the chain ID (normally latest) for the server API
-	ChainID string `koanf:"chain_id"`
-
 	// ChainName is the name of the chain (e.g. mainnet/testnet/local).
 	ChainName string `koanf:"chain_name"`
 

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -1,8 +1,9 @@
 analysis:
-  node:
-    chain_id: oasis-3
-    rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
-    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+  source:
+    chain_name: mainnet
+    nodes:
+      damask:
+        rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
   analyzers:
     metadata_registry:
       interval: 1h
@@ -20,7 +21,6 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_id: oasis-3
   chain_name: mainnet
   endpoint: 0.0.0.0:8008
   storage:

--- a/config/history.go
+++ b/config/history.go
@@ -1,0 +1,116 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/consensus/api"
+)
+
+type Record struct {
+	ArchiveName   string `koanf:"archive_name"`
+	GenesisHeight int64  `koanf:"genesis_height"`
+	ChainContext  string `koanf:"chain_context"`
+}
+
+type History struct {
+	Records []*Record `koanf:"records"`
+}
+
+func (h *History) CurrentRecord() *Record {
+	return h.Records[0]
+}
+
+func (h *History) EarliestRecord() *Record {
+	return h.Records[len(h.Records)-1]
+}
+
+func (h *History) RecordForHeight(height int64) (*Record, error) {
+	if height == api.HeightLatest {
+		return h.CurrentRecord(), nil
+	}
+	for _, r := range h.Records {
+		if height >= r.GenesisHeight {
+			return r, nil
+		}
+	}
+	earliestRecord := h.EarliestRecord()
+	return nil, fmt.Errorf(
+		"height %d earlier than earliest history record %s genesis height %d",
+		height,
+		earliestRecord.ArchiveName,
+		earliestRecord.GenesisHeight,
+	)
+}
+
+var DefaultChains = map[string]*History{
+	"mainnet": {
+		Records: []*Record{
+			{
+				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2022-04-11
+				ArchiveName:   "damask",
+				GenesisHeight: 8048956,
+				ChainContext:  "b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535",
+			},
+			{
+				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2021-04-28
+				ArchiveName:   "cobalt",
+				GenesisHeight: 3027601,
+				ChainContext:  "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898",
+			},
+			{
+				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2020-11-18
+				// This archive name coincides with the chain name "mainnet,"
+				// but this "mainnet" refers to the consensus version that was
+				// first used on the mainnet after mainnet beta. The testnet
+				// chain also had a network running this consensus version
+				// nicknamed "mainnet."
+				ArchiveName:   "mainnet",
+				GenesisHeight: 702000,
+				ChainContext:  "a4dc2c4537992d6d2908c9779927ccfee105830250d903fd1abdfaf42cb45631",
+			},
+			{
+				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2020-10-01
+				ArchiveName:   "beta",
+				GenesisHeight: 1,
+				ChainContext:  "a245619497e580dd3bc1aa3256c07f68b8dcc13f92da115eadc3b231b083d3c4",
+			},
+		},
+	},
+	"testnet": {
+		Records: []*Record{
+			// TODO: coalesce compatible records
+			// TODO: rename archives to match compatible API
+			// TODO: fill in chain context
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2022-03-03
+				ArchiveName:   "2022-03-03",
+				GenesisHeight: 8535081,
+			},
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2021-04-13
+				ArchiveName:   "2021-04-13",
+				GenesisHeight: 3398334,
+			},
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2021-03-24
+				ArchiveName:   "2021-03-24",
+				GenesisHeight: 3076800,
+			},
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2021-02-03
+				ArchiveName:   "2021-02-03",
+				GenesisHeight: 2284801,
+			},
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2020-11-04
+				ArchiveName:   "2020-11-04",
+				GenesisHeight: 811055,
+			},
+			{
+				// https://github.com/oasisprotocol/testnet-artifacts/releases/tag/2020-09-15
+				ArchiveName:   "2020-09-15",
+				GenesisHeight: 1,
+			},
+		},
+	},
+}

--- a/config/history.go
+++ b/config/history.go
@@ -42,6 +42,18 @@ func (h *History) RecordForHeight(height int64) (*Record, error) {
 	)
 }
 
+func SingleRecordHistory(chainContext string) *History {
+	return &History{
+		Records: []*Record{
+			{
+				ArchiveName:   "damask",
+				GenesisHeight: 1,
+				ChainContext:  chainContext,
+			},
+		},
+	}
+}
+
 var DefaultChains = map[string]*History{
 	"mainnet": {
 		Records: []*Record{

--- a/config/local-dev.yml
+++ b/config/local-dev.yml
@@ -1,8 +1,9 @@
 analysis:
-  node:
-    chain_id: oasis-3
-    rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
-    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+  source:
+    chain_name: mainnet
+    nodes:
+      damask:
+        rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
   analyzers:
     metadata_registry:
       interval: 1h
@@ -20,7 +21,6 @@ analysis:
     migrations: file://storage/migrations
 
 server:
-  chain_id: oasis-3
   chain_name: mainnet
   endpoint: localhost:8008
   storage:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/golang-migrate/migrate/v4 v4.15.2
 	github.com/google/uuid v1.3.0
-	github.com/iancoleman/strcase v0.2.0
 	github.com/jackc/pgx/v5 v5.3.1
 	github.com/knadh/koanf v1.4.1
 	github.com/oasisprotocol/oasis-core/go v0.2202.5

--- a/go.sum
+++ b/go.sum
@@ -762,7 +762,6 @@ github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKe
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
-github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -322,14 +322,18 @@ const (
 			txs.error_code,
 			txs.error_message
 		FROM chain.runtime_transactions AS txs
-		LEFT JOIN chain.runtime_transaction_signers AS signer0 USING (runtime, round, tx_index)
+		LEFT JOIN chain.runtime_transaction_signers AS signer0 ON
+		    (signer0.runtime = txs.runtime) AND
+		    (signer0.round = txs.round) AND
+		    (signer0.tx_index = txs.tx_index) AND
+		    (signer0.signer_index = 0)
 		LEFT JOIN chain.address_preimages AS signer_eth ON
 			(signer0.signer_address = signer_eth.address) AND
 			(signer_eth.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth') AND (signer_eth.context_version = 0)
 		LEFT JOIN chain.address_preimages AS to_eth ON
 			(txs.to = to_eth.address) AND
 			(to_eth.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth') AND (to_eth.context_version = 0)
-		LEFT JOIN chain.runtime_related_transactions AS rel ON 
+		LEFT JOIN chain.runtime_related_transactions AS rel ON
 			(txs.round = rel.tx_round) AND
 			(txs.tx_index = rel.tx_index) AND
 			(txs.runtime = rel.runtime) AND
@@ -338,7 +342,6 @@ const (
 			($4::text IS NOT NULL)
 		WHERE
 			(txs.runtime = $1) AND
-			(signer0.signer_index = 0) AND
 			($2::bigint IS NULL OR txs.round = $2::bigint) AND
 			($3::text IS NULL OR txs.tx_hash = $3::text OR txs.tx_eth_hash = $3::text) AND
 			($4::text IS NULL OR rel.account_address = $4::text)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -84,18 +84,6 @@ const (
 			LIMIT $6::bigint
 			OFFSET $7::bigint`
 
-	EventsRelAccounts = `
-		SELECT event_block, tx_index, tx_hash, type, body
-			FROM chain.accounts_related_events
-			WHERE (account_address = $1::text) AND
-					($2::bigint IS NULL OR event_block = $1::bigint) AND
-					($3::integer IS NULL OR tx_index = $3::integer) AND
-					($4::text IS NULL OR tx_hash = $4::text) AND
-					($5::text IS NULL OR type = $5::text)
-			ORDER BY event_block DESC, tx_index
-			LIMIT $6::bigint
-			OFFSET $7::bigint`
-
 	Entities = `
 		SELECT id, address
 			FROM chain.entities

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/config"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/connections"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/history"
 )
@@ -32,11 +33,11 @@ func NewConsensusClient(ctx context.Context, sourceConfig *config.SourceConfig) 
 func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, runtime analyzer.Runtime) (*RuntimeClient, error) {
 	currentHistoryRecord := sourceConfig.History().CurrentRecord()
 	currentNode := sourceConfig.Nodes[currentHistoryRecord.ArchiveName]
-	rawConn, err := history.RawConnect(currentNode)
+	rawConn, err := connections.RawConnect(currentNode)
 	if err != nil {
 		return nil, fmt.Errorf("indexer RawConnect: %w", err)
 	}
-	sdkConn, err := history.SDKConnect(ctx, currentHistoryRecord.ChainContext, currentNode, sourceConfig.FastStartup)
+	sdkConn, err := connections.SDKConnect(ctx, currentHistoryRecord.ChainContext, currentNode, sourceConfig.FastStartup)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/oasis/connections/raw_grpc.go
+++ b/storage/oasis/connections/raw_grpc.go
@@ -1,4 +1,4 @@
-package history
+package connections
 
 import (
 	"crypto/tls"

--- a/storage/oasis/connections/sdk.go
+++ b/storage/oasis/connections/sdk.go
@@ -1,4 +1,4 @@
-package history
+package connections
 
 import (
 	"context"

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -7,10 +7,10 @@ import (
 	beaconAPI "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
-	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 
 	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 // ConsensusClient is a client to the consensus methods/data of oasis node. It
@@ -24,7 +24,7 @@ import (
 //     using nodeapi types directly.
 type ConsensusClient struct {
 	nodeApi nodeapi.ConsensusApiLite
-	network *config.Network
+	network *sdkConfig.Network
 }
 
 // GenesisDocument returns the original genesis document.

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -8,6 +8,7 @@ import (
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 	hash "github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	"github.com/oasisprotocol/oasis-core/go/common/errors"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	consensusTransaction "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	consensusResults "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
@@ -16,6 +17,7 @@ import (
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 	sdkClient "github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -62,6 +64,11 @@ type TransactionWithResults struct {
 type TxResult struct {
 	Error  TxError
 	Events []Event
+}
+
+// IsSuccess returns true if transaction execution was successful.
+func (r *TxResult) IsSuccess() bool {
+	return r.Error.Code == errors.CodeNoError
 }
 
 type TxError consensusResults.Error

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -28,11 +28,11 @@ var APIConstructors = map[string]APIConstructor{
 		return damask.NewDamaskConsensusApiLite(sdkConn.Consensus()), nil
 	},
 	"cobalt": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-		rawGRPCConnection, err := ConnectNoVerify(nodeConfig.RPC)
+		rawConn, err := RawConnect(nodeConfig)
 		if err != nil {
-			return nil, fmt.Errorf("indexer ConnectNoVerify: %w", err)
+			return nil, fmt.Errorf("indexer RawConnect: %w", err)
 		}
-		return cobalt.NewCobaltConsensusApiLite(rawGRPCConnection), nil
+		return cobalt.NewCobaltConsensusApiLite(rawConn), nil
 	},
 }
 

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -1,0 +1,175 @@
+package history
+
+import (
+	"context"
+	"fmt"
+
+	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
+	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
+
+	"github.com/oasisprotocol/oasis-indexer/config"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/cobalt"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/damask"
+)
+
+var _ nodeapi.ConsensusApiLite = (*HistoryConsensusApiLite)(nil)
+
+type APIConstructor func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error)
+
+var APIConstructors = map[string]APIConstructor{
+	"damask": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
+		sdkConn, err := SDKConnect(ctx, chainContext, nodeConfig, fastStartup)
+		if err != nil {
+			return nil, err
+		}
+		return damask.NewDamaskConsensusApiLite(sdkConn.Consensus()), nil
+	},
+	"cobalt": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
+		rawGRPCConnection, err := ConnectNoVerify(nodeConfig.RPC)
+		if err != nil {
+			return nil, fmt.Errorf("indexer ConnectNoVerify: %w", err)
+		}
+		return cobalt.NewCobaltConsensusApiLite(rawGRPCConnection), nil
+	},
+}
+
+type HistoryConsensusApiLite struct {
+	History *config.History
+	// APIs. Keys are "archive names," which are named after mainnet releases,
+	// in lowercase e.g. "cobalt" and "damask."
+	APIs map[string]nodeapi.ConsensusApiLite
+}
+
+func NewHistoryConsensusApiLite(ctx context.Context, history *config.History, nodes map[string]*config.NodeConfig, fastStartup bool) (*HistoryConsensusApiLite, error) {
+	APIs := map[string]nodeapi.ConsensusApiLite{}
+	for _, record := range history.Records {
+		if nodeConfig, ok := nodes[record.ArchiveName]; ok {
+			apiConstructor := APIConstructors[record.ArchiveName]
+			if apiConstructor == nil {
+				return nil, fmt.Errorf("historical API for archive %s not implemented", record.ArchiveName)
+			}
+			api, err := apiConstructor(ctx, record.ChainContext, nodeConfig, fastStartup)
+			if err != nil {
+				return nil, fmt.Errorf("connecting to archive %s: %w", record.ArchiveName, err)
+			}
+			APIs[record.ArchiveName] = api
+		}
+	}
+	return &HistoryConsensusApiLite{
+		History: history,
+		APIs:    APIs,
+	}, nil
+}
+
+func (c *HistoryConsensusApiLite) APIForHeight(height int64) (nodeapi.ConsensusApiLite, error) {
+	record, err := c.History.RecordForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("dertermining archive: %w", err)
+	}
+	api, ok := c.APIs[record.ArchiveName]
+	if !ok {
+		return nil, fmt.Errorf("archive %s for has no node configured", record.ArchiveName)
+	}
+	return api, nil
+}
+
+func (c *HistoryConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
+	// Use latest.
+	height := consensus.HeightLatest
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetGenesisDocument(ctx)
+}
+
+func (c *HistoryConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.StateToGenesis(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetBlock(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetTransactionsWithResults(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return 0, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetEpoch(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.RegistryEvents(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.StakingEvents(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GovernanceEvents(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.RoothashEvents(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetValidators(ctx, height)
+}
+
+func (c *HistoryConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetCommittees(ctx, height, runtimeID)
+}
+
+func (c *HistoryConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+	api, err := c.APIForHeight(height)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for height %d: %w", height, err)
+	}
+	return api.GetProposal(ctx, height, proposalID)
+}

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -10,6 +10,7 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 
 	"github.com/oasisprotocol/oasis-indexer/config"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/connections"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/cobalt"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/damask"
@@ -21,14 +22,14 @@ type APIConstructor func(ctx context.Context, chainContext string, nodeConfig *c
 
 var APIConstructors = map[string]APIConstructor{
 	"damask": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-		sdkConn, err := SDKConnect(ctx, chainContext, nodeConfig, fastStartup)
+		sdkConn, err := connections.SDKConnect(ctx, chainContext, nodeConfig, fastStartup)
 		if err != nil {
 			return nil, err
 		}
 		return damask.NewDamaskConsensusApiLite(sdkConn.Consensus()), nil
 	},
 	"cobalt": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-		rawConn, err := RawConnect(nodeConfig)
+		rawConn, err := connections.RawConnect(nodeConfig)
 		if err != nil {
 			return nil, fmt.Errorf("indexer RawConnect: %w", err)
 		}

--- a/storage/oasis/nodeapi/history/raw_grpc.go
+++ b/storage/oasis/nodeapi/history/raw_grpc.go
@@ -8,16 +8,18 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/oasisprotocol/oasis-indexer/config"
 )
 
-// ConnectNoVerify establishes gRPC connection with the target URL,
+// RawConnect establishes gRPC connection with the target URL,
 // omitting the chain context check.
 // This is based on oasis-sdk `ConnectNoVerify()` function,
 // but returns a raw gRPC connection instead of the oasis-sdk `Connection` wrapper.
-func ConnectNoVerify(rpc string) (*grpc.ClientConn, error) {
+func RawConnect(nodeConfig *config.NodeConfig) (*grpc.ClientConn, error) {
 	var dialOpts []grpc.DialOption
 	fakeSDKNet := &sdkConfig.Network{
-		RPC: rpc,
+		RPC: nodeConfig.RPC,
 	}
 	switch fakeSDKNet.IsLocalRPC() {
 	case true:
@@ -29,5 +31,5 @@ func ConnectNoVerify(rpc string) (*grpc.ClientConn, error) {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
 	}
 
-	return cmnGrpc.Dial(rpc, dialOpts...)
+	return cmnGrpc.Dial(nodeConfig.RPC, dialOpts...)
 }

--- a/storage/oasis/nodeapi/history/raw_grpc.go
+++ b/storage/oasis/nodeapi/history/raw_grpc.go
@@ -1,0 +1,33 @@
+package history
+
+import (
+	"crypto/tls"
+
+	cmnGrpc "github.com/oasisprotocol/oasis-core/go/common/grpc"
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// ConnectNoVerify establishes gRPC connection with the target URL,
+// omitting the chain context check.
+// This is based on oasis-sdk `ConnectNoVerify()` function,
+// but returns a raw gRPC connection instead of the oasis-sdk `Connection` wrapper.
+func ConnectNoVerify(rpc string) (*grpc.ClientConn, error) {
+	var dialOpts []grpc.DialOption
+	fakeSDKNet := &sdkConfig.Network{
+		RPC: rpc,
+	}
+	switch fakeSDKNet.IsLocalRPC() {
+	case true:
+		// No TLS needed for local nodes.
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	case false:
+		// Configure TLS for non-local nodes.
+		creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	}
+
+	return cmnGrpc.Dial(rpc, dialOpts...)
+}

--- a/storage/oasis/nodeapi/history/sdk.go
+++ b/storage/oasis/nodeapi/history/sdk.go
@@ -1,0 +1,35 @@
+package history
+
+import (
+	"context"
+	"fmt"
+
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
+
+	"github.com/oasisprotocol/oasis-indexer/config"
+)
+
+// SDKConnect creates an Oasis SDK Connection to a node running the current
+// version of oasis-node.
+func SDKConnect(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (connection.Connection, error) {
+	fakeNet := &sdkConfig.Network{
+		RPC:          nodeConfig.RPC,
+		ChainContext: chainContext,
+	}
+	var sdkConn connection.Connection
+	if fastStartup {
+		var err error
+		sdkConn, err = connection.ConnectNoVerify(ctx, fakeNet)
+		if err != nil {
+			return nil, fmt.Errorf("SDK ConnectNoVerify: %w", err)
+		}
+	} else {
+		var err error
+		sdkConn, err = connection.Connect(ctx, fakeNet)
+		if err != nil {
+			return nil, fmt.Errorf("SDK Connect: %w", err)
+		}
+	}
+	return sdkConn, nil
+}

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -3,11 +3,11 @@ package oasis
 import (
 	"context"
 
-	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
-	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 // RuntimeClient is a client to a runtime. Unlike RuntimeApiLite implementations,
@@ -49,7 +49,7 @@ func (rc *RuntimeClient) EVMSimulateCall(ctx context.Context, round uint64, gasP
 }
 
 func (rc *RuntimeClient) nativeTokenSymbol() string {
-	for _, network := range config.DefaultNetworks.All {
+	for _, network := range sdkConfig.DefaultNetworks.All {
 		// Iterate over all networks and find the one that contains the runtime.
 		// Any network will do; we assume that paratime IDs are unique across networks.
 		// TODO: Remove this assumption; paratime IDs are chosen by the entity that registers them,
@@ -57,7 +57,7 @@ func (rc *RuntimeClient) nativeTokenSymbol() string {
 		// https://github.com/oasisprotocol/oasis-indexer/pull/362#discussion_r1153606360
 		for _, paratime := range network.ParaTimes.All {
 			if paratime.ID == rc.info.ID.Hex() {
-				return paratime.Denominations[config.NativeDenominationKey].Symbol
+				return paratime.Denominations[sdkConfig.NativeDenominationKey].Symbol
 			}
 		}
 	}

--- a/tests/config.go
+++ b/tests/config.go
@@ -2,7 +2,6 @@ package tests
 
 const (
 	GenesisHeight = int64(8_048_956) // TODO: Get from config.
-	ChainID       = "oasis-test"     // TODO: Get from config.
 )
 
 var baseEndpoint string

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -20,7 +20,7 @@ analysis:
     migrations: file:///storage/migrations
 
 server:
-  chain_name: localnet  # a fake mainnet, based on oasis-net-runner
+  chain_name: localnet  # unused
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -1,8 +1,15 @@
 analysis:
-  node:
-      chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner
-      rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
-      chaincontext: 59e65fd10f3057cb8009998c5e6288db40b32a3a37f3c3a7c769fd84ed4c63c9
+  source:
+    custom_chain:
+      history:
+        records:
+          - archive_name: damask
+            genesis_height: 1
+            chain_context: 59e65fd10f3057cb8009998c5e6288db40b32a3a37f3c3a7c769fd84ed4c63c9
+      sdk_network: {}
+    nodes:
+      damask:
+        rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
   analyzers:
     consensus:
       from: 1
@@ -13,8 +20,7 @@ analysis:
     migrations: file:///storage/migrations
 
 server:
-  chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner
-  chain_name: localnet
+  chain_name: localnet  # a fake mainnet, based on oasis-net-runner
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/e2e_config.yaml
+++ b/tests/e2e_regression/e2e_config.yaml
@@ -1,10 +1,11 @@
 # Indexer configuration for non-synthetic e2e regression tests implemented in this directory.
 
 analysis:
-  node:
-    chain_id: oasis-3
-    rpc: unix:/tmp/node.sock
-    chaincontext: b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535
+  source:
+    chain_name: mainnet
+    nodes:
+      damask:
+        rpc: unix:/tmp/node.sock
     fast_startup: true
   analyzers:
     consensus:

--- a/tests/http/v1/status_test.go
+++ b/tests/http/v1/status_test.go
@@ -20,6 +20,5 @@ func TestGetStatus(t *testing.T) {
 	err := tests.GetFrom("/", &status)
 	require.Nil(t, err)
 
-	require.Equal(t, tests.ChainID, status.LatestChainID)
 	require.LessOrEqual(t, tests.GenesisHeight, status.LatestBlock)
 }


### PR DESCRIPTION
new config format to allow setting multiple nodes, for archive access. see the sample configs for how to migrate your config files.

indexer devs: no more client factory system. just create a consensus client or runtime client directly. see existing analyzers for how to do this.

indexer devs: the analyzer no longer runs with a set chain context. in general, don't verify signatures. our node(s) will do that.