### PR TITLE
`{runtime}/status`: Endpoint for current number of compute nodes

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -578,8 +578,17 @@ func (m *Main) queueNodeEvents(batch *storage.QueryBatch, data *storage.Registry
 				nodeEvent.Node.SoftwareVersion,
 				0,
 			)
+
+			// Update the node's runtime associations by deleting
+			// previous node records and inserting new ones.
+			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.Node.ID.String())
+			for _, runtime := range nodeEvent.Node.Runtimes {
+				// XXX: Include other fields here if needed in the future.
+				batch.Queue(queries.ConsensusRuntimeNodesUpsert, runtime.ID.String(), nodeEvent.Node.ID.String())
+			}
 		} else {
 			// An existing node is expired.
+			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.Node.ID.String())
 			batch.Queue(queries.ConsensusNodeDelete,
 				nodeEvent.Node.ID.String(),
 			)

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -105,6 +105,13 @@ const (
       software_version = excluded.software_version,
       voting_power = excluded.voting_power`
 
+	ConsensusRuntimeNodesUpsert = `
+    INSERT INTO chain.runtime_nodes (runtime_id, node_id) VALUES ($1, $2)
+      ON CONFLICT (runtime_id, node_id) DO NOTHING`
+
+	ConsensusRuntimeNodesDelete = `
+    DELETE FROM chain.runtime_nodes WHERE node_id = $1`
+
 	ConsensusNodeDelete = `
     DELETE FROM chain.nodes WHERE id = $1`
 

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -927,6 +927,20 @@ paths:
                 $ref: '#/components/schemas/RuntimeAccount'
         <<: *common_error_responses
 
+  /{runtime}/status:
+    get:
+      summary: Returns the runtime status.
+      parameters:
+        - *runtime
+      responses:
+        '200':
+          description: A JSON object containing latest runtime status.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RuntimeStatus'
+        <<: *common_error_responses
+
   /{layer}/stats/tx_volume:
     get:
       summary: |
@@ -2081,6 +2095,25 @@ components:
         stats:
           $ref: '#/components/schemas/AccountStats'
 
+    RuntimeStatus:
+      type: object
+      required: [active_nodes, latest_block, latest_update]
+      properties:
+        active_nodes:
+          type: integer
+          description: The number of compute nodes that are registered and can run the runtime.
+          example: 42
+        latest_block:
+          type: integer
+          format: int64
+          description: The height of the most recent indexed block (also sometimes referred to as "round") for this runtime. Query a synced Oasis node for the latest block produced.
+          example: *block_height_1
+        latest_update:
+          type: string
+          format: date-time
+          description: The RFC 3339 formatted time when the Indexer processed the latest block for this runtime. Compare with current time for approximate indexing progress with the Oasis Network.
+          example: *iso_timestamp_1
+
     EvmTokenType:
       type: string
       enum:
@@ -2148,7 +2181,7 @@ components:
             The number of addresses that have a nonzero balance of this token,
             as calculated from Transfer events.
           example: 123
-    
+
     AccountStats:
       type: object
       required: [total_sent, total_received, num_txns]

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -312,3 +312,15 @@ func (srv *StrictServerImpl) GetRuntimeAccountsAddress(ctx context.Context, requ
 	}
 	return apiTypes.GetRuntimeAccountsAddress200JSONResponse(*account), nil
 }
+
+func (srv *StrictServerImpl) GetRuntimeStatus(ctx context.Context, request apiTypes.GetRuntimeStatusRequestObject) (apiTypes.GetRuntimeStatusResponseObject, error) {
+	if !request.Runtime.IsValid() {
+		return nil, &apiTypes.InvalidParamFormatError{ParamName: "runtime", Err: fmt.Errorf("not a valid enum value: %s", request.Runtime)}
+	}
+
+	status, err := srv.dbClient.RuntimeStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return apiTypes.GetRuntimeStatus200JSONResponse(*status), nil
+}

--- a/api/v1/types/util.go
+++ b/api/v1/types/util.go
@@ -44,6 +44,15 @@ func (c Layer) IsValid() bool {
 	}
 }
 
+func (c Runtime) IsValid() bool {
+	switch c {
+	case RuntimeCipher, RuntimeEmerald, RuntimeSapphire:
+		return true
+	default:
+		return false
+	}
+}
+
 // Validate validates the parameters.
 func (p *GetLayerStatsActiveAccountsParams) Validate() error {
 	if p.WindowStepSeconds == nil {

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -100,7 +100,7 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	client, err := storage.NewStorageClient(cfg.ChainID, backing, logger)
+	client, err := storage.NewStorageClient(cfg.ChainID, cfg.ChainName, backing, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -189,6 +189,9 @@ type ServerConfig struct {
 	// ChainID is the chain ID (normally latest) for the server API
 	ChainID string `koanf:"chain_id"`
 
+	// ChainName is the name of the chain (e.g. mainnet/testnet/local).
+	ChainName string `koanf:"chain_name"`
+
 	// Endpoint is the service endpoint from which to serve the API.
 	Endpoint string `koanf:"endpoint"`
 
@@ -203,6 +206,10 @@ func (cfg *ServerConfig) Validate() error {
 	if cfg.Storage == nil {
 		return fmt.Errorf("no storage config provided")
 	}
+	if cfg.ChainName == "" {
+		return fmt.Errorf("no chain name provided")
+	}
+
 	return cfg.Storage.Validate(false /* requireMigrations */)
 }
 

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -19,6 +19,7 @@ analysis:
 
 server:
   chain_id: oasis-3
+  chain_name: mainnet
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://rwuser:password@indexer-postgres:5432/indexer?sslmode=disable

--- a/config/local-dev.yml
+++ b/config/local-dev.yml
@@ -19,6 +19,7 @@ analysis:
 
 server:
   chain_id: oasis-3
+  chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -14,6 +14,7 @@ const (
 	Status = `
 		SELECT height, processed_time
 			FROM chain.processed_blocks
+			WHERE analyzer=$1
 		ORDER BY processed_time DESC
 		LIMIT 1`
 
@@ -416,6 +417,12 @@ const (
 			balance != 0
 		ORDER BY balance DESC
 		LIMIT 1000  -- To prevent huge responses. Hardcoded because API exposes this as a subfield that does not lend itself to pagination.
+	`
+
+	RuntimeActiveNodes = `
+		SELECT COUNT(*) AS active_nodes
+		FROM chain.runtime_nodes
+		WHERE runtime_id = $1::text
 	`
 
 	FineTxVolumes = `

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -130,6 +130,9 @@ type RuntimeEvent = api.RuntimeEvent
 
 type RuntimeEventType = api.RuntimeEventType
 
+// RuntimeStatus is the storage response for RuntimeStatus.
+type RuntimeStatus = api.RuntimeStatus
+
 // Types that are a part of the storage response for GetRuntimeAccount.
 type (
 	AddressPreimage          = api.AddressPreimage

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -155,6 +155,14 @@ CREATE TABLE chain.runtimes
   key_manager  HEX64
 );
 
+CREATE TABLE chain.runtime_nodes
+(
+  runtime_id HEX64 NOT NULL REFERENCES chain.runtimes(id) DEFERRABLE INITIALLY DEFERRED,
+  node_id    base64_ed25519_pubkey NOT NULL REFERENCES chain.nodes(id) DEFERRABLE INITIALLY DEFERRED,
+
+  PRIMARY KEY (runtime_id, node_id)
+);
+
 -- Staking Backend Data
 
 CREATE TABLE chain.accounts

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -14,6 +14,7 @@ analysis:
 
 server:
   chain_id: oasis-3  # a fake mainnet, based on oasis-net-runner
+  chain_name: localnet
   endpoint: 0.0.0.0:8008
   storage:
     endpoint: postgresql://indexer:password@indexer-postgres:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/reindex_and_run.sh
+++ b/tests/e2e_regression/reindex_and_run.sh
@@ -32,6 +32,7 @@ analysis:
 
 server:
   chain_id: oasis-3
+  chain_name: mainnet
   endpoint: localhost:8008
   storage:
     endpoint: postgresql://api:password@localhost:5432/indexer?sslmode=disable

--- a/tests/e2e_regression/run.sh
+++ b/tests/e2e_regression/run.sh
@@ -64,6 +64,7 @@ testCases=(
   'emerald_txs              /v1/emerald/transactions'
   'emerald_events           /v1/consensus/events'
   'emerald_events_by_type   /v1/consensus/events?type=sdf'
+  'emerald_status           /v1/emerald/status'
 )
 nCases=${#testCases[@]}
 


### PR DESCRIPTION
Testing (on some early damask mainnet blocks):
```
curl "http://localhost:8008/v1/emerald/status"
{"active_nodes":57,"latest_block":8053413,"latest_update":"2023-03-10T16:21:45Z"}

curl "http://localhost:8008/v1/cipher/status"
{"active_nodes":9,"latest_block":8053698,"latest_update":"2023-03-10T16:22:32Z"}

curl "http://localhost:8008/v1/wrong/status"
{"msg":"Invalid format for parameter runtime: not a valid enum value: wrong"}
```


## Deployment
This PR adds a new required parameter that needs to be included in the deployment config:
```
server:
  chain_name: mainnet # (or testnet on the testnet indexer)
```