### PR TITLE
analyzer/consensus: Full Cobalt support. Internal types for node responses.

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -562,14 +562,14 @@ func (m *Main) queueNodeEvents(batch *storage.QueryBatch, data *storage.Registry
 
 			// Update the node's runtime associations by deleting
 			// previous node records and inserting new ones.
-			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.Node.ID.String())
-			for _, runtime := range nodeEvent.Node.Runtimes {
+			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.NodeID.String())
+			for _, runtimeID := range nodeEvent.RuntimeIDs {
 				// XXX: Include other fields here if needed in the future.
-				batch.Queue(queries.ConsensusRuntimeNodesUpsert, runtime.ID.String(), nodeEvent.Node.ID.String())
+				batch.Queue(queries.ConsensusRuntimeNodesUpsert, runtimeID.String(), nodeEvent.NodeID.String())
 			}
 		} else {
 			// An existing node is expired.
-			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.Node.ID.String())
+			batch.Queue(queries.ConsensusRuntimeNodesDelete, nodeEvent.NodeID.String())
 			batch.Queue(queries.ConsensusNodeDelete,
 				nodeEvent.NodeID.String(),
 			)

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"os"
 
+	coreLogging "github.com/oasisprotocol/oasis-core/go/common/logging"
+
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/metrics"
@@ -20,6 +22,10 @@ func Init(cfg *config.Config) error {
 	var w io.Writer = os.Stdout
 	format := log.FmtJSON
 	level := log.LevelDebug
+	coreFormat := coreLogging.FmtJSON   // For oasis-core.
+	coreLevel := coreLogging.LevelDebug // For oasis-core.
+
+	// Initialize oasis-indexer logging.
 	if cfg.Log != nil {
 		var err error
 		if w, err = getLoggingStream(cfg.Log); err != nil {
@@ -37,6 +43,12 @@ func Init(cfg *config.Config) error {
 		return err
 	}
 	rootLogger = logger
+
+	// Initialize oasis-core logging. Useful for low-level gRPC issues.
+	if err := coreLogging.Initialize(w, coreFormat, coreLevel, nil); err != nil {
+		logger.Error("failed to initialize oasis-core logging", "err", err)
+		return err
+	}
 
 	// Initialize Prometheus service.
 	if cfg.Metrics != nil {

--- a/common/types.go
+++ b/common/types.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
 
 // Arbitrary-precision integer. Wrapper around big.Int to allow for
@@ -33,6 +35,10 @@ func (b BigInt) MarshalJSON() ([]byte, error) {
 func (b *BigInt) UnmarshalJSON(text []byte) error {
 	v := strings.Trim(string(text), "\"")
 	return b.Int.UnmarshalJSON([]byte(v))
+}
+
+func BigIntFromQuantity(q quantity.Quantity) BigInt {
+	return BigInt{*q.ToBigInt()}
 }
 
 // Implement NumericValuer interface for BigInt.

--- a/storage/api.go
+++ b/storage/api.go
@@ -11,12 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
-	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
-	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -150,7 +145,7 @@ type ConsensusBlockData struct {
 
 	BlockHeader             *consensus.Block
 	Epoch                   beacon.EpochTime
-	TransactionsWithResults []*nodeapi.TransactionWithResults
+	TransactionsWithResults []nodeapi.TransactionWithResults
 }
 
 // BeaconData represents data for the random beacon at a given height.
@@ -168,11 +163,11 @@ type BeaconData struct {
 type RegistryData struct {
 	Height int64
 
-	Events             []*registry.Event
-	RuntimeEvents      []*registry.RuntimeEvent
-	EntityEvents       []*registry.EntityEvent
-	NodeEvents         []*registry.NodeEvent
-	NodeUnfrozenEvents []*registry.NodeUnfrozenEvent
+	Events             []nodeapi.Event
+	RuntimeEvents      []nodeapi.RuntimeEvent
+	EntityEvents       []nodeapi.EntityEvent
+	NodeEvents         []nodeapi.NodeEvent
+	NodeUnfrozenEvents []nodeapi.NodeUnfrozenEvent
 }
 
 // StakingData represents data for accounts at a given height.
@@ -183,26 +178,29 @@ type StakingData struct {
 	Height int64
 	Epoch  beacon.EpochTime
 
-	Events           []*staking.Event
-	Transfers        []*staking.TransferEvent
-	Burns            []*staking.BurnEvent
-	Escrows          []*staking.EscrowEvent
-	AllowanceChanges []*staking.AllowanceChangeEvent
+	Events                []nodeapi.Event
+	Transfers             []nodeapi.TransferEvent
+	Burns                 []nodeapi.BurnEvent
+	AddEscrows            []nodeapi.AddEscrowEvent
+	TakeEscrows           []nodeapi.TakeEscrowEvent
+	ReclaimEscrows        []nodeapi.ReclaimEscrowEvent
+	DebondingStartEscrows []nodeapi.DebondingStartEscrowEvent
+	AllowanceChanges      []nodeapi.AllowanceChangeEvent
 }
 
 // RootHashData represents data for runtime processing at a given height.
 type RootHashData struct {
 	Height int64
 
-	Events []*roothash.Event
+	Events []nodeapi.Event
 }
 
 // SchedulerData represents data for elected committees and validators at a given height.
 type SchedulerData struct {
 	Height int64
 
-	Validators []*scheduler.Validator
-	Committees map[common.Namespace][]*scheduler.Committee
+	Validators []nodeapi.Validator
+	Committees map[common.Namespace][]nodeapi.Committee
 }
 
 // GovernanceData represents governance data for proposals at a given height.
@@ -212,11 +210,11 @@ type SchedulerData struct {
 type GovernanceData struct {
 	Height int64
 
-	Events                []*governance.Event
-	ProposalSubmissions   []*governance.Proposal
-	ProposalExecutions    []*governance.ProposalExecutedEvent
-	ProposalFinalizations []*governance.Proposal
-	Votes                 []*governance.VoteEvent
+	Events                []nodeapi.Event
+	ProposalSubmissions   []nodeapi.Proposal
+	ProposalExecutions    []nodeapi.ProposalExecutedEvent
+	ProposalFinalizations []nodeapi.Proposal
+	Votes                 []nodeapi.VoteEvent
 }
 
 // RuntimeSourceStorage defines an interface for retrieving raw block data

--- a/storage/api.go
+++ b/storage/api.go
@@ -10,8 +10,6 @@ import (
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
-	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
-	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -19,6 +17,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
@@ -149,10 +148,9 @@ type ConsensusAllData struct {
 type ConsensusBlockData struct {
 	Height int64
 
-	BlockHeader  *consensus.Block
-	Epoch        beacon.EpochTime
-	Transactions []*transaction.SignedTransaction
-	Results      []*results.Result
+	BlockHeader             *consensus.Block
+	Epoch                   beacon.EpochTime
+	TransactionsWithResults []*nodeapi.TransactionWithResults
 }
 
 // BeaconData represents data for the random beacon at a given height.

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -66,7 +66,7 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodeApi = cobalt.NewCobaltConsensusApiLite(grpcConn, (*cf.connection).Consensus())
+		nodeApi = cobalt.NewCobaltConsensusApiLite(grpcConn)
 	} else {
 		// Assume Damask.
 		client := (*cf.connection).Consensus()

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -66,7 +66,7 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 		if err != nil {
 			return nil, err
 		}
-		nodeApi = cobalt.NewCobaltConsensusApiLite(grpcConn)
+		nodeApi = cobalt.NewCobaltConsensusApiLite(grpcConn, (*cf.connection).Consensus())
 	} else {
 		// Assume Damask.
 		client := (*cf.connection).Consensus()

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -6,8 +6,6 @@ import (
 
 	beaconAPI "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governanceAPI "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registryAPI "github.com/oasisprotocol/oasis-core/go/registry/api"
@@ -105,21 +103,11 @@ func (cc *ConsensusClient) BlockData(ctx context.Context, height int64) (*storag
 		return nil, err
 	}
 
-	transactions := make([]*transaction.SignedTransaction, 0, len(transactionsWithResults.Transactions))
-	for _, bytes := range transactionsWithResults.Transactions {
-		var transaction transaction.SignedTransaction
-		if err := cbor.Unmarshal(bytes, &transaction); err != nil {
-			return nil, err
-		}
-		transactions = append(transactions, &transaction)
-	}
-
 	return &storage.ConsensusBlockData{
-		Height:       height,
-		BlockHeader:  block,
-		Epoch:        epoch,
-		Transactions: transactions,
-		Results:      transactionsWithResults.Results,
+		Height:                  height,
+		BlockHeader:             block,
+		Epoch:                   epoch,
+		TransactionsWithResults: transactionsWithResults,
 	}, nil
 }
 

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -7,10 +7,6 @@ import (
 	beaconAPI "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	"github.com/oasisprotocol/oasis-core/go/common"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	governanceAPI "github.com/oasisprotocol/oasis-core/go/governance/api"
-	registryAPI "github.com/oasisprotocol/oasis-core/go/registry/api"
-	schedulerAPI "github.com/oasisprotocol/oasis-core/go/scheduler/api"
-	stakingAPI "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 
@@ -139,21 +135,21 @@ func (cc *ConsensusClient) RegistryData(ctx context.Context, height int64) (*sto
 		return nil, err
 	}
 
-	var runtimeEvents []*registryAPI.RuntimeEvent
-	var entityEvents []*registryAPI.EntityEvent
-	var nodeEvents []*registryAPI.NodeEvent
-	var nodeUnfrozenEvents []*registryAPI.NodeUnfrozenEvent
+	var runtimeEvents []nodeapi.RuntimeEvent
+	var entityEvents []nodeapi.EntityEvent
+	var nodeEvents []nodeapi.NodeEvent
+	var nodeUnfrozenEvents []nodeapi.NodeUnfrozenEvent
 
 	for _, event := range events {
 		switch e := event; {
-		case e.RuntimeEvent != nil:
-			runtimeEvents = append(runtimeEvents, e.RuntimeEvent)
-		case e.EntityEvent != nil:
-			entityEvents = append(entityEvents, e.EntityEvent)
-		case e.NodeEvent != nil:
-			nodeEvents = append(nodeEvents, e.NodeEvent)
-		case e.NodeUnfrozenEvent != nil:
-			nodeUnfrozenEvents = append(nodeUnfrozenEvents, e.NodeUnfrozenEvent)
+		case e.RegistryRuntime != nil:
+			runtimeEvents = append(runtimeEvents, *e.RegistryRuntime)
+		case e.RegistryEntity != nil:
+			entityEvents = append(entityEvents, *e.RegistryEntity)
+		case e.RegistryNode != nil:
+			nodeEvents = append(nodeEvents, *e.RegistryNode)
+		case e.RegistryNodeUnfrozen != nil:
+			nodeUnfrozenEvents = append(nodeUnfrozenEvents, *e.RegistryNodeUnfrozen)
 		}
 	}
 
@@ -179,32 +175,44 @@ func (cc *ConsensusClient) StakingData(ctx context.Context, height int64) (*stor
 		return nil, err
 	}
 
-	var transfers []*stakingAPI.TransferEvent
-	var burns []*stakingAPI.BurnEvent
-	var escrows []*stakingAPI.EscrowEvent
-	var allowanceChanges []*stakingAPI.AllowanceChangeEvent
+	var transfers []nodeapi.TransferEvent
+	var burns []nodeapi.BurnEvent
+	var addEscrows []nodeapi.AddEscrowEvent
+	var reclaimEscrows []nodeapi.ReclaimEscrowEvent
+	var debondingStartEscrows []nodeapi.DebondingStartEscrowEvent
+	var takeEscrows []nodeapi.TakeEscrowEvent
+	var allowanceChanges []nodeapi.AllowanceChangeEvent
 
 	for _, event := range events {
 		switch e := event; {
-		case e.Transfer != nil:
-			transfers = append(transfers, event.Transfer)
-		case e.Burn != nil:
-			burns = append(burns, event.Burn)
-		case e.Escrow != nil:
-			escrows = append(escrows, event.Escrow)
-		case e.AllowanceChange != nil:
-			allowanceChanges = append(allowanceChanges, event.AllowanceChange)
+		case e.StakingTransfer != nil:
+			transfers = append(transfers, *event.StakingTransfer)
+		case e.StakingBurn != nil:
+			burns = append(burns, *event.StakingBurn)
+		case e.StakingAddEscrow != nil:
+			addEscrows = append(addEscrows, *event.StakingAddEscrow)
+		case e.StakingReclaimEscrow != nil:
+			reclaimEscrows = append(reclaimEscrows, *event.StakingReclaimEscrow)
+		case e.StakingDebondingStart != nil:
+			debondingStartEscrows = append(debondingStartEscrows, *event.StakingDebondingStart)
+		case e.StakingTakeEscrow != nil:
+			takeEscrows = append(takeEscrows, *event.StakingTakeEscrow)
+		case e.StakingAllowanceChange != nil:
+			allowanceChanges = append(allowanceChanges, *event.StakingAllowanceChange)
 		}
 	}
 
 	return &storage.StakingData{
-		Height:           height,
-		Epoch:            epoch,
-		Events:           events,
-		Transfers:        transfers,
-		Burns:            burns,
-		Escrows:          escrows,
-		AllowanceChanges: allowanceChanges,
+		Height:                height,
+		Epoch:                 epoch,
+		Events:                events,
+		Transfers:             transfers,
+		Burns:                 burns,
+		AddEscrows:            addEscrows,
+		ReclaimEscrows:        reclaimEscrows,
+		DebondingStartEscrows: debondingStartEscrows,
+		TakeEscrows:           takeEscrows,
+		AllowanceChanges:      allowanceChanges,
 	}, nil
 }
 
@@ -215,7 +223,7 @@ func (cc *ConsensusClient) SchedulerData(ctx context.Context, height int64) (*st
 		return nil, err
 	}
 
-	committees := make(map[common.Namespace][]*schedulerAPI.Committee, len(cc.network.ParaTimes.All))
+	committees := make(map[common.Namespace][]nodeapi.Committee, len(cc.network.ParaTimes.All))
 
 	for name := range cc.network.ParaTimes.All {
 		var runtimeID common.Namespace
@@ -244,29 +252,29 @@ func (cc *ConsensusClient) GovernanceData(ctx context.Context, height int64) (*s
 		return nil, err
 	}
 
-	var submissions []*governanceAPI.Proposal
-	var executions []*governanceAPI.ProposalExecutedEvent
-	var finalizations []*governanceAPI.Proposal
-	var votes []*governanceAPI.VoteEvent
+	var submissions []nodeapi.Proposal
+	var executions []nodeapi.ProposalExecutedEvent
+	var finalizations []nodeapi.Proposal
+	var votes []nodeapi.VoteEvent
 
 	for _, event := range events {
-		switch e := event; {
-		case e.ProposalSubmitted != nil:
-			proposal, err := cc.nodeApi.GetProposal(ctx, height, event.ProposalSubmitted.ID)
+		switch {
+		case event.GovernanceProposalSubmitted != nil:
+			proposal, err := cc.nodeApi.GetProposal(ctx, height, event.GovernanceProposalSubmitted.ID)
 			if err != nil {
 				return nil, err
 			}
-			submissions = append(submissions, proposal)
-		case e.ProposalExecuted != nil:
-			executions = append(executions, event.ProposalExecuted)
-		case e.ProposalFinalized != nil:
-			proposal, err := cc.nodeApi.GetProposal(ctx, height, event.ProposalFinalized.ID)
+			submissions = append(submissions, *proposal)
+		case event.GovernanceProposalExecuted != nil:
+			executions = append(executions, *event.GovernanceProposalExecuted)
+		case event.GovernanceProposalFinalized != nil:
+			proposal, err := cc.nodeApi.GetProposal(ctx, height, event.GovernanceProposalFinalized.ID)
 			if err != nil {
 				return nil, err
 			}
-			finalizations = append(finalizations, proposal)
-		case e.Vote != nil:
-			votes = append(votes, event.Vote)
+			finalizations = append(finalizations, *proposal)
+		case event.GovernanceVote != nil:
+			votes = append(votes, *event.GovernanceVote)
 		}
 	}
 	return &storage.GovernanceData{

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -13,7 +13,15 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
 
-// ConsensusClient is a client to the consensus backends.
+// ConsensusClient is a client to the consensus methods/data of oasis node. It
+// differs from the nodeapi.ConsensusApiLite in that:
+//   - Its methods may collect data using multiple RPCs each.
+//   - The return types make no effort to closely resemble oasis-core types
+//     in structure. Instead, they are structured in a way that is most convenient
+//     for the analyzer.
+//     TODO: The benefits of this are miniscule, and introduce considerable
+//     boilerplate. Consider removing most types from this package, and
+//     using nodeapi types directly.
 type ConsensusClient struct {
 	nodeApi nodeapi.ConsensusApiLite
 	network *config.Network

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -47,13 +47,15 @@ type ConsensusApiLite interface {
 // A lightweight subset of `consensus.TransactionsWithResults`.
 type TransactionWithResults struct {
 	Transaction consensusTransaction.SignedTransaction
-	Result      Result
+	Result      TxResult
 }
 
-type Result struct {
-	Error  consensusResults.Error
+type TxResult struct {
+	Error  TxError
 	Events []Event
 }
+
+type TxError consensusResults.Error
 
 // A lightweight version of "consensus/api/transactions/results".Event.
 //
@@ -77,6 +79,7 @@ type Event struct {
 	StakingTakeEscrow           *TakeEscrowEvent
 	StakingEscrowDebondingStart *DebondingStartEscrowEvent
 	StakingReclaimEscrow        *ReclaimEscrowEvent
+	StakingDebondingStart       *DebondingStartEscrowEvent // Available starting in Damask.
 	StakingAllowanceChange      *AllowanceChangeEvent
 
 	RegistryRuntime      *RuntimeEvent

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -68,7 +68,7 @@ type Event struct {
 
 	// The fine-grained Event struct directly from oasis-core; corresponds to
 	// at most one of the fields below (StakingTransfer, StakingBurn, etc.).
-	Raw interface{}
+	Body interface{}
 
 	// Called "Kind" in oasis-core but "Type" in indexer APIs and DBs.
 	Type apiTypes.ConsensusEventType

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -97,13 +97,18 @@ type Event struct {
 	GovernanceVote              *VoteEvent
 }
 
-type TransferEvent staking.TransferEvent // NOTE: NewShares field is available starting with Damask.
-type BurnEvent staking.BurnEvent
-type AddEscrowEvent staking.AddEscrowEvent // NOTE: NewShares field is available starting with Damask.
-type TakeEscrowEvent staking.TakeEscrowEvent
-type DebondingStartEscrowEvent staking.DebondingStartEscrowEvent
-type ReclaimEscrowEvent staking.ReclaimEscrowEvent
-type AllowanceChangeEvent staking.AllowanceChangeEvent
+// .................... Staking  ....................
+type (
+	TransferEvent             staking.TransferEvent // NOTE: NewShares field is available starting with Damask.
+	BurnEvent                 staking.BurnEvent
+	AddEscrowEvent            staking.AddEscrowEvent // NOTE: NewShares field is available starting with Damask.
+	TakeEscrowEvent           staking.TakeEscrowEvent
+	DebondingStartEscrowEvent staking.DebondingStartEscrowEvent
+	ReclaimEscrowEvent        staking.ReclaimEscrowEvent
+	AllowanceChangeEvent      staking.AllowanceChangeEvent
+)
+
+// .................... Registry ....................
 
 // RuntimeEvent signifies new runtime registration.
 type RuntimeEvent struct {
@@ -113,39 +118,55 @@ type RuntimeEvent struct {
 	KeyManager  *coreCommon.Namespace // Key manager runtime ID.
 	TEEHardware string                // enum: "invalid" (= no TEE), "intel-sgx"
 }
-type EntityEvent registry.EntityEvent
-type NodeEvent struct {
-	NodeID             signature.PublicKey
-	EntityID           signature.PublicKey
-	Expiration         uint64 // Epoch in which the node expires.
-	RuntimeIDs         []coreCommon.Namespace
-	VRFPubKey          *signature.PublicKey
-	TLSAddresses       []string // TCP addresses of the node's TLS-enabled gRPC endpoint.
-	TLSPubKey          signature.PublicKey
-	TLSNextPubKey      signature.PublicKey
-	P2PID              signature.PublicKey
-	P2PAddresses       []string // TCP addresses of the node's P2P endpoint.
-	ConsensusID        signature.PublicKey
-	ConsensusAddresses []string // TCP addresses of the node's tendermint endpoint.
-	Roles              []string // enum: "compute", "key-manager", "validator", "consensus-rpc", "storage-rpc"
-	SoftwareVersion    string
-	IsRegistration     bool
-}
+type (
+	EntityEvent registry.EntityEvent
+	NodeEvent   struct {
+		NodeID             signature.PublicKey
+		EntityID           signature.PublicKey
+		Expiration         uint64 // Epoch in which the node expires.
+		RuntimeIDs         []coreCommon.Namespace
+		VRFPubKey          *signature.PublicKey
+		TLSAddresses       []string // TCP addresses of the node's TLS-enabled gRPC endpoint.
+		TLSPubKey          signature.PublicKey
+		TLSNextPubKey      signature.PublicKey
+		P2PID              signature.PublicKey
+		P2PAddresses       []string // TCP addresses of the node's P2P endpoint.
+		ConsensusID        signature.PublicKey
+		ConsensusAddresses []string // TCP addresses of the node's tendermint endpoint.
+		Roles              []string // enum: "compute", "key-manager", "validator", "consensus-rpc", "storage-rpc"
+		SoftwareVersion    string
+		IsRegistration     bool
+	}
+)
 type NodeUnfrozenEvent registry.NodeUnfrozenEvent
+
+// .................... RootHash  ....................
 
 type ExecutorCommittedEvent struct {
 	NodeID *signature.PublicKey // Available starting in Damask.
 }
 
-type ProposalSubmittedEvent governance.ProposalSubmittedEvent
-type ProposalExecutedEvent governance.ProposalExecutedEvent
-type ProposalFinalizedEvent governance.ProposalFinalizedEvent
-type VoteEvent struct {
-	ID        uint64
-	Submitter staking.Address
-	Vote      string // enum: "yes", "no", "abstain"
-}
+// .................... Governance ....................
 
-type Validator scheduler.Validator
-type Committee scheduler.Committee
+type (
+	ProposalSubmittedEvent governance.ProposalSubmittedEvent
+	ProposalExecutedEvent  governance.ProposalExecutedEvent
+	ProposalFinalizedEvent governance.ProposalFinalizedEvent
+	VoteEvent              struct {
+		ID        uint64
+		Submitter staking.Address
+		Vote      string // enum: "yes", "no", "abstain"
+	}
+)
+
+// .................... Scheduler ....................
+
+type (
+	Validator scheduler.Validator
+	Committee scheduler.Committee
+	Proposal  governance.Proposal
+)
+
+// .................... Governance ....................
+
 type Proposal governance.Proposal

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -4,14 +4,19 @@ import (
 	"context"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common"
+	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
+	hash "github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
+	consensusTransaction "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction"
+	consensusResults "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
+	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 )
 
 // ConsensusApiLite provides low-level access to the consensus API of one or
@@ -28,13 +33,95 @@ type ConsensusApiLite interface {
 	GetGenesisDocument(ctx context.Context) (*genesis.Document, error)
 	StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error)
 	GetBlock(ctx context.Context, height int64) (*consensus.Block, error)
-	GetTransactionsWithResults(ctx context.Context, height int64) (*consensus.TransactionsWithResults, error)
+	GetTransactionsWithResults(ctx context.Context, height int64) ([]*TransactionWithResults, error)
 	GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error)
 	RegistryEvents(ctx context.Context, height int64) ([]*registry.Event, error)
 	StakingEvents(ctx context.Context, height int64) ([]*staking.Event, error)
 	GovernanceEvents(ctx context.Context, height int64) ([]*governance.Event, error)
 	RoothashEvents(ctx context.Context, height int64) ([]*roothash.Event, error)
 	GetValidators(ctx context.Context, height int64) ([]*scheduler.Validator, error)
-	GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]*scheduler.Committee, error)
+	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]*scheduler.Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*governance.Proposal, error)
+}
+
+// A lightweight subset of `consensus.TransactionsWithResults`.
+type TransactionWithResults struct {
+	Transaction consensusTransaction.SignedTransaction
+	Result      Result
+}
+
+type Result struct {
+	Error  consensusResults.Error
+	Events []Event
+}
+
+// A lightweight version of "consensus/api/transactions/results".Event.
+//
+// NOTE: Not all types of events are expressed as sub-structs, only those that
+// the indexer actively inspects (as opposed to just logging them) to perform
+// dead reckoning or similar state updates.
+type Event struct {
+	Height int64
+	TxHash hash.Hash
+
+	// The fine-grained Event struct directly from oasis-core; corresponds to
+	// at most one of the fields below (StakingTransfer, StakingBurn, etc.).
+	Raw interface{}
+
+	// Called "Kind" in oasis-core but "Type" in indexer APIs and DBs.
+	Type apiTypes.ConsensusEventType
+
+	StakingTransfer             *TransferEvent
+	StakingBurn                 *BurnEvent
+	StakingAddEscrow            *AddEscrowEvent
+	StakingTakeEscrow           *TakeEscrowEvent
+	StakingEscrowDebondingStart *DebondingStartEscrowEvent
+	StakingReclaimEscrow        *ReclaimEscrowEvent
+	StakingAllowanceChange      *AllowanceChangeEvent
+
+	RegistryRuntime      *RuntimeEvent
+	RegistryEntity       *EntityEvent
+	RegistryNode         *NodeEvent
+	RegistryNodeUnfrozen *NodeUnfrozenEvent
+
+	RoothashExecutorCommitted *ExecutorCommittedEvent
+
+	GovernanceProposalSubmitted *ProposalSubmittedEvent
+	GovernanceVote              *VoteEvent
+}
+
+type TransferEvent staking.TransferEvent // NOTE: NewShares field is not always populated.
+type BurnEvent staking.BurnEvent
+type AddEscrowEvent staking.AddEscrowEvent // NOTE: NewShares field is not always populated.
+type TakeEscrowEvent staking.TakeEscrowEvent
+type DebondingStartEscrowEvent staking.DebondingStartEscrowEvent
+type ReclaimEscrowEvent staking.ReclaimEscrowEvent
+type AllowanceChangeEvent staking.AllowanceChangeEvent
+
+// RuntimeEvent signifies new runtime registration.
+type RuntimeEvent struct {
+	ID coreCommon.Namespace
+
+	// EntityID is the public key identifying the Entity controlling
+	// the runtime.
+	EntityID signature.PublicKey
+}
+type EntityEvent registry.EntityEvent
+type NodeEvent struct {
+	NodeID         signature.PublicKey
+	EntityID       signature.PublicKey
+	RuntimeIDs     []coreCommon.Namespace
+	IsRegistration bool
+}
+type NodeUnfrozenEvent registry.NodeUnfrozenEvent
+
+type ExecutorCommittedEvent struct {
+	NodeID *signature.PublicKey // Available starting in Damask.
+}
+
+type ProposalSubmittedEvent struct {
+	Submitter staking.Address
+}
+type VoteEvent struct {
+	Submitter staking.Address
 }

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -13,7 +13,6 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -33,12 +32,12 @@ type ConsensusApiLite interface {
 	GetGenesisDocument(ctx context.Context) (*genesis.Document, error)
 	StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error)
 	GetBlock(ctx context.Context, height int64) (*consensus.Block, error)
-	GetTransactionsWithResults(ctx context.Context, height int64) ([]*TransactionWithResults, error)
+	GetTransactionsWithResults(ctx context.Context, height int64) ([]TransactionWithResults, error)
 	GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error)
-	RegistryEvents(ctx context.Context, height int64) ([]*registry.Event, error)
-	StakingEvents(ctx context.Context, height int64) ([]*staking.Event, error)
-	GovernanceEvents(ctx context.Context, height int64) ([]*governance.Event, error)
-	RoothashEvents(ctx context.Context, height int64) ([]*roothash.Event, error)
+	RegistryEvents(ctx context.Context, height int64) ([]Event, error)
+	StakingEvents(ctx context.Context, height int64) ([]Event, error)
+	GovernanceEvents(ctx context.Context, height int64) ([]Event, error)
+	RoothashEvents(ctx context.Context, height int64) ([]Event, error)
 	GetValidators(ctx context.Context, height int64) ([]*scheduler.Validator, error)
 	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]*scheduler.Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*governance.Proposal, error)

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -164,7 +164,6 @@ type (
 type (
 	Validator scheduler.Validator
 	Committee scheduler.Committee
-	Proposal  governance.Proposal
 )
 
 // .................... Governance ....................

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -21,14 +21,17 @@ import (
 // ConsensusApiLite provides low-level access to the consensus API of one or
 // more (versions of) Oasis nodes.
 //
-// Each method is intended to be a thin wrapper around a corresponding gRPC
-// method of the node. In this sense, this is a reimplentation of convenience
-// methods in oasis-core.
+// Each method of this corresponds to a gRPC method of the node. In this sense,
+// this is a reimplementation of convenience gRPC wrapers in oasis-core.
+// However, this interface ONLY supports methods needed by the indexer, and the
+// return values (events, genesis doc, ...) are converted to simplified internal
+// types that mirror oasis-core types but contain only the fields relevant to
+// the indexer.
 //
-// The difference is that this interface only supports methods needed by the
-// indexer, and that implementations allow handling different versions of Oasis
-// nodes.
+// Since the types are simpler and fewer, their structure is, in
+// places, flattened compared to their counterparts in oasis-core.
 type ConsensusApiLite interface {
+	// TODO: Introduce internal, stripped-down version of `genesis.Document`.
 	GetGenesisDocument(ctx context.Context) (*genesis.Document, error)
 	StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error)
 	GetBlock(ctx context.Context, height int64) (*consensus.Block, error)

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -116,7 +116,7 @@ type NodeEvent struct {
 	EntityID           signature.PublicKey
 	Expiration         uint64 // Epoch in which the node expires.
 	RuntimeIDs         []coreCommon.Namespace
-	VRFPubKey          signature.PublicKey
+	VRFPubKey          *signature.PublicKey
 	TLSAddresses       []string // TCP addresses of the node's TLS-enabled gRPC endpoint.
 	TLSPubKey          signature.PublicKey
 	TLSNextPubKey      signature.PublicKey

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -237,7 +237,7 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 			}
 		case e.Registry.NodeEvent != nil:
-			var vrfID *signature.PublicKey = nil
+			var vrfID *signature.PublicKey
 			if e.Registry.NodeEvent.Node.VRF != nil {
 				vrfID = &e.Registry.NodeEvent.Node.VRF.ID
 			}

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -3,6 +3,7 @@ package cobalt
 import (
 	"strings"
 
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 
 	// indexer-internal data types.
@@ -236,6 +237,10 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 			}
 		case e.Registry.NodeEvent != nil:
+			var vrfID *signature.PublicKey = nil
+			if e.Registry.NodeEvent.Node.VRF != nil {
+				vrfID = &e.Registry.NodeEvent.Node.VRF.ID
+			}
 			runtimeIDs := make([]common.Namespace, len(e.Registry.NodeEvent.Node.Runtimes))
 			for i, r := range e.Registry.NodeEvent.Node.Runtimes {
 				runtimeIDs[i] = r.ID
@@ -257,7 +262,7 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					NodeID:             e.Registry.NodeEvent.Node.ID,
 					EntityID:           e.Registry.NodeEvent.Node.EntityID,
 					Expiration:         e.Registry.NodeEvent.Node.Expiration,
-					VRFPubKey:          e.Registry.NodeEvent.Node.VRF.ID,
+					VRFPubKey:          vrfID,
 					TLSAddresses:       tlsAddresses,
 					TLSPubKey:          e.Registry.NodeEvent.Node.TLS.PubKey,
 					TLSNextPubKey:      e.Registry.NodeEvent.Node.TLS.NextPubKey,

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -154,7 +154,7 @@ func ConvertGenesis(d genesisCobalt.Document) *genesis.Document {
 	}
 }
 
-func convertTxResult(r txResultsCobalt.Result) nodeapi.Result {
+func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 	events := make([]nodeapi.Event, len(r.Events))
 	for i, e := range r.Events {
 		switch {
@@ -315,8 +315,8 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.Result {
 		}
 	}
 
-	return nodeapi.Result{
-		Error:  consensusTxResults.Error(r.Error),
+	return nodeapi.TxResult{
+		Error:  nodeapi.TxError(r.Error),
 		Events: events,
 	}
 }

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -154,165 +154,171 @@ func ConvertGenesis(d genesisCobalt.Document) *genesis.Document {
 	}
 }
 
+func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
+	ret := nodeapi.Event{}
+	switch {
+	case e.Staking != nil:
+		switch {
+		case e.Staking.Transfer != nil:
+			ret = nodeapi.Event{
+				StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
+				Body:            e.Staking.Transfer,
+				Type:            apiTypes.ConsensusEventTypeStakingTransfer,
+			}
+		case e.Staking.Burn != nil:
+			ret = nodeapi.Event{
+				StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
+				Body:        e.Staking.Burn,
+				Type:        apiTypes.ConsensusEventTypeStakingBurn,
+			}
+		case e.Staking.Escrow != nil:
+			switch {
+			case e.Staking.Escrow.Add != nil:
+				ret = nodeapi.Event{
+					StakingAddEscrow: &nodeapi.AddEscrowEvent{
+						Owner:     e.Staking.Escrow.Add.Owner,
+						Escrow:    e.Staking.Escrow.Add.Escrow,
+						Amount:    e.Staking.Escrow.Add.Amount,
+						NewShares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
+					},
+					Body: e.Staking.Escrow.Add,
+					Type: apiTypes.ConsensusEventTypeStakingEscrowAdd,
+				}
+			case e.Staking.Escrow.Take != nil:
+				ret = nodeapi.Event{
+					StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
+					Body:              e.Staking.Escrow.Take,
+					Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
+				}
+			case e.Staking.Escrow.Reclaim != nil:
+				ret = nodeapi.Event{
+					StakingReclaimEscrow: &nodeapi.ReclaimEscrowEvent{
+						Owner:  e.Staking.Escrow.Reclaim.Owner,
+						Escrow: e.Staking.Escrow.Reclaim.Escrow,
+						Amount: e.Staking.Escrow.Reclaim.Amount,
+						Shares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
+					},
+					Body: e.Staking.Escrow.Reclaim,
+					Type: apiTypes.ConsensusEventTypeStakingEscrowReclaim,
+				}
+				// NOTE: There is no Staking.Escrow.DebondingStart event in Cobalt.
+			}
+		case e.Staking.AllowanceChange != nil:
+			ret = nodeapi.Event{
+				StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
+				Body:                   e.Staking.AllowanceChange,
+				Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
+			}
+		}
+		ret.Height = e.Staking.Height
+		ret.TxHash = e.Staking.TxHash
+		// End Staking.
+	case e.Registry != nil:
+		switch {
+		case e.Registry.RuntimeEvent != nil && e.Registry.RuntimeEvent.Runtime != nil:
+			ret = nodeapi.Event{
+				RegistryRuntime: &nodeapi.RuntimeEvent{
+					ID:       e.Registry.RuntimeEvent.Runtime.ID,
+					EntityID: e.Registry.RuntimeEvent.Runtime.EntityID,
+				},
+				Body: e.Registry.RuntimeEvent,
+				Type: apiTypes.ConsensusEventTypeRegistryRuntime,
+			}
+		case e.Registry.EntityEvent != nil:
+			ret = nodeapi.Event{
+				RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
+				Body:           e.Registry.EntityEvent,
+				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
+			}
+		case e.Registry.NodeEvent != nil:
+			runtimeIDs := make([]common.Namespace, len(e.Registry.NodeEvent.Node.Runtimes))
+			for i, r := range e.Registry.NodeEvent.Node.Runtimes {
+				runtimeIDs[i] = r.ID
+			}
+			ret = nodeapi.Event{
+				RegistryNode: &nodeapi.NodeEvent{
+					NodeID:         e.Registry.NodeEvent.Node.EntityID,
+					EntityID:       e.Registry.NodeEvent.Node.EntityID,
+					RuntimeIDs:     runtimeIDs,
+					IsRegistration: e.Registry.NodeEvent.IsRegistration,
+				},
+				Body: e.Registry.NodeEvent,
+				Type: apiTypes.ConsensusEventTypeRegistryNode,
+			}
+		case e.Registry.NodeUnfrozenEvent != nil:
+			ret = nodeapi.Event{
+				RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
+				Body:                 e.Registry.NodeUnfrozenEvent,
+				Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
+			}
+		}
+		ret.Height = e.Registry.Height
+		ret.TxHash = e.Registry.TxHash
+		// End Registry.
+	case e.RootHash != nil:
+		switch {
+		case e.RootHash.ExecutorCommitted != nil:
+			ret = nodeapi.Event{
+				RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
+					NodeID: nil, // Not available in Cobalt.
+				},
+				Body: e.RootHash.ExecutorCommitted,
+				Type: apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
+			}
+		case e.RootHash.ExecutionDiscrepancyDetected != nil:
+			ret = nodeapi.Event{
+				Body: e.RootHash.ExecutionDiscrepancyDetected,
+				Type: apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
+			}
+		case e.RootHash.Finalized != nil:
+			ret = nodeapi.Event{
+				Body: e.RootHash.Finalized,
+				Type: apiTypes.ConsensusEventTypeRoothashFinalized,
+			}
+		}
+		ret.Height = e.RootHash.Height
+		ret.TxHash = e.RootHash.TxHash
+		// End RootHash.
+	case e.Governance != nil:
+		switch {
+		case e.Governance.ProposalSubmitted != nil:
+			ret = nodeapi.Event{
+				GovernanceProposalSubmitted: &nodeapi.ProposalSubmittedEvent{
+					Submitter: e.Governance.ProposalSubmitted.Submitter,
+				},
+				Body: e.Governance.ProposalSubmitted,
+				Type: apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
+			}
+		case e.Governance.ProposalExecuted != nil:
+			ret = nodeapi.Event{
+				Body: e.Governance.ProposalExecuted,
+				Type: apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
+			}
+		case e.Governance.ProposalFinalized != nil:
+			ret = nodeapi.Event{
+				Body: e.Governance.ProposalFinalized,
+				Type: apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
+			}
+		case e.Governance.Vote != nil:
+			ret = nodeapi.Event{
+				GovernanceVote: &nodeapi.VoteEvent{
+					Submitter: e.Governance.Vote.Submitter,
+				},
+				Body: e.Governance.Vote,
+				Type: apiTypes.ConsensusEventTypeGovernanceVote,
+			}
+		}
+		ret.Height = e.Governance.Height
+		ret.TxHash = e.Governance.TxHash
+		// End Governance.
+	}
+	return ret
+}
+
 func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 	events := make([]nodeapi.Event, len(r.Events))
 	for i, e := range r.Events {
-		switch {
-		case e.Staking != nil:
-			switch {
-			case e.Staking.Transfer != nil:
-				events[i] = nodeapi.Event{
-					StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
-					Body:            e.Staking.Transfer,
-					Type:            apiTypes.ConsensusEventTypeStakingTransfer,
-				}
-			case e.Staking.Burn != nil:
-				events[i] = nodeapi.Event{
-					StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
-					Body:        e.Staking.Burn,
-					Type:        apiTypes.ConsensusEventTypeStakingBurn,
-				}
-			case e.Staking.Escrow != nil:
-				switch {
-				case e.Staking.Escrow.Add != nil:
-					events[i] = nodeapi.Event{
-						StakingAddEscrow: &nodeapi.AddEscrowEvent{
-							Owner:     e.Staking.Escrow.Add.Owner,
-							Escrow:    e.Staking.Escrow.Add.Escrow,
-							Amount:    e.Staking.Escrow.Add.Amount,
-							NewShares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
-						},
-						Body: e.Staking.Escrow.Add,
-						Type: apiTypes.ConsensusEventTypeStakingEscrowAdd,
-					}
-				case e.Staking.Escrow.Take != nil:
-					events[i] = nodeapi.Event{
-						StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
-						Body:              e.Staking.Escrow.Take,
-						Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
-					}
-				case e.Staking.Escrow.Reclaim != nil:
-					events[i] = nodeapi.Event{
-						StakingReclaimEscrow: &nodeapi.ReclaimEscrowEvent{
-							Owner:  e.Staking.Escrow.Reclaim.Owner,
-							Escrow: e.Staking.Escrow.Reclaim.Escrow,
-							Amount: e.Staking.Escrow.Reclaim.Amount,
-							Shares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
-						},
-						Body: e.Staking.Escrow.Reclaim,
-						Type: apiTypes.ConsensusEventTypeStakingEscrowReclaim,
-					}
-					// NOTE: There is no Staking.Escrow.DebondingStart event in Cobalt.
-				}
-			case e.Staking.AllowanceChange != nil:
-				events[i] = nodeapi.Event{
-					StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
-					Body:                   e.Staking.AllowanceChange,
-					Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
-				}
-			}
-			events[i].Height = e.Staking.Height
-			events[i].TxHash = e.Staking.TxHash
-			// End Staking.
-		case e.Registry != nil:
-			switch {
-			case e.Registry.RuntimeEvent != nil && e.Registry.RuntimeEvent.Runtime != nil:
-				events[i] = nodeapi.Event{
-					RegistryRuntime: &nodeapi.RuntimeEvent{
-						ID:       e.Registry.RuntimeEvent.Runtime.ID,
-						EntityID: e.Registry.RuntimeEvent.Runtime.EntityID,
-					},
-					Body: e.Registry.RuntimeEvent,
-					Type: apiTypes.ConsensusEventTypeRegistryRuntime,
-				}
-			case e.Registry.EntityEvent != nil:
-				events[i] = nodeapi.Event{
-					RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
-					Body:           e.Registry.EntityEvent,
-					Type:           apiTypes.ConsensusEventTypeRegistryEntity,
-				}
-			case e.Registry.NodeEvent != nil:
-				runtimeIDs := make([]common.Namespace, len(e.Registry.NodeEvent.Node.Runtimes))
-				for i, r := range e.Registry.NodeEvent.Node.Runtimes {
-					runtimeIDs[i] = r.ID
-				}
-				events[i] = nodeapi.Event{
-					RegistryNode: &nodeapi.NodeEvent{
-						NodeID:         e.Registry.NodeEvent.Node.EntityID,
-						EntityID:       e.Registry.NodeEvent.Node.EntityID,
-						RuntimeIDs:     runtimeIDs,
-						IsRegistration: e.Registry.NodeEvent.IsRegistration,
-					},
-					Body: e.Registry.NodeEvent,
-					Type: apiTypes.ConsensusEventTypeRegistryNode,
-				}
-			case e.Registry.NodeUnfrozenEvent != nil:
-				events[i] = nodeapi.Event{
-					RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
-					Body:                 e.Registry.NodeUnfrozenEvent,
-					Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
-				}
-			}
-			events[i].Height = e.Registry.Height
-			events[i].TxHash = e.Registry.TxHash
-			// End Registry.
-		case e.RootHash != nil:
-			switch {
-			case e.RootHash.ExecutorCommitted != nil:
-				events[i] = nodeapi.Event{
-					RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
-						NodeID: nil, // Not available in Cobalt.
-					},
-					Body: e.RootHash.ExecutorCommitted,
-					Type: apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
-				}
-			case e.RootHash.ExecutionDiscrepancyDetected != nil:
-				events[i] = nodeapi.Event{
-					Body: e.RootHash.ExecutionDiscrepancyDetected,
-					Type: apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
-				}
-			case e.RootHash.Finalized != nil:
-				events[i] = nodeapi.Event{
-					Body: e.RootHash.Finalized,
-					Type: apiTypes.ConsensusEventTypeRoothashFinalized,
-				}
-			}
-			events[i].Height = e.RootHash.Height
-			events[i].TxHash = e.RootHash.TxHash
-			// End RootHash.
-		case e.Governance != nil:
-			switch {
-			case e.Governance.ProposalSubmitted != nil:
-				events[i] = nodeapi.Event{
-					GovernanceProposalSubmitted: &nodeapi.ProposalSubmittedEvent{
-						Submitter: e.Governance.ProposalSubmitted.Submitter,
-					},
-					Body: e.Governance.ProposalSubmitted,
-					Type: apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
-				}
-			case e.Governance.ProposalExecuted != nil:
-				events[i] = nodeapi.Event{
-					Body: e.Governance.ProposalExecuted,
-					Type: apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
-				}
-			case e.Governance.ProposalFinalized != nil:
-				events[i] = nodeapi.Event{
-					Body: e.Governance.ProposalFinalized,
-					Type: apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
-				}
-			case e.Governance.Vote != nil:
-				events[i] = nodeapi.Event{
-					GovernanceVote: &nodeapi.VoteEvent{
-						Submitter: e.Governance.Vote.Submitter,
-					},
-					Body: e.Governance.Vote,
-					Type: apiTypes.ConsensusEventTypeGovernanceVote,
-				}
-			}
-			events[i].Height = e.Governance.Height
-			events[i].TxHash = e.Governance.TxHash
-			// End Governance.
-		}
+		events[i] = convertEvent(*e)
 	}
 
 	return nodeapi.TxResult{

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -163,13 +163,13 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 			case e.Staking.Transfer != nil:
 				events[i] = nodeapi.Event{
 					StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
-					Raw:             e.Staking.Transfer,
+					Body:            e.Staking.Transfer,
 					Type:            apiTypes.ConsensusEventTypeStakingTransfer,
 				}
 			case e.Staking.Burn != nil:
 				events[i] = nodeapi.Event{
 					StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
-					Raw:         e.Staking.Burn,
+					Body:        e.Staking.Burn,
 					Type:        apiTypes.ConsensusEventTypeStakingBurn,
 				}
 			case e.Staking.Escrow != nil:
@@ -182,13 +182,13 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 							Amount:    e.Staking.Escrow.Add.Amount,
 							NewShares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
 						},
-						Raw:  e.Staking.Escrow.Add,
+						Body: e.Staking.Escrow.Add,
 						Type: apiTypes.ConsensusEventTypeStakingEscrowAdd,
 					}
 				case e.Staking.Escrow.Take != nil:
 					events[i] = nodeapi.Event{
 						StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
-						Raw:               e.Staking.Escrow.Take,
+						Body:              e.Staking.Escrow.Take,
 						Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
 					}
 				case e.Staking.Escrow.Reclaim != nil:
@@ -199,7 +199,7 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 							Amount: e.Staking.Escrow.Reclaim.Amount,
 							Shares: quantity.Quantity{}, // NOTE: not available in the Cobalt API
 						},
-						Raw:  e.Staking.Escrow.Reclaim,
+						Body: e.Staking.Escrow.Reclaim,
 						Type: apiTypes.ConsensusEventTypeStakingEscrowReclaim,
 					}
 					// NOTE: There is no Staking.Escrow.DebondingStart event in Cobalt.
@@ -207,7 +207,7 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 			case e.Staking.AllowanceChange != nil:
 				events[i] = nodeapi.Event{
 					StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
-					Raw:                    e.Staking.AllowanceChange,
+					Body:                   e.Staking.AllowanceChange,
 					Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
 				}
 			}
@@ -222,13 +222,13 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 						ID:       e.Registry.RuntimeEvent.Runtime.ID,
 						EntityID: e.Registry.RuntimeEvent.Runtime.EntityID,
 					},
-					Raw:  e.Registry.RuntimeEvent,
+					Body: e.Registry.RuntimeEvent,
 					Type: apiTypes.ConsensusEventTypeRegistryRuntime,
 				}
 			case e.Registry.EntityEvent != nil:
 				events[i] = nodeapi.Event{
 					RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
-					Raw:            e.Registry.EntityEvent,
+					Body:           e.Registry.EntityEvent,
 					Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 				}
 			case e.Registry.NodeEvent != nil:
@@ -243,13 +243,13 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 						RuntimeIDs:     runtimeIDs,
 						IsRegistration: e.Registry.NodeEvent.IsRegistration,
 					},
-					Raw:  e.Registry.NodeEvent,
+					Body: e.Registry.NodeEvent,
 					Type: apiTypes.ConsensusEventTypeRegistryNode,
 				}
 			case e.Registry.NodeUnfrozenEvent != nil:
 				events[i] = nodeapi.Event{
 					RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
-					Raw:                  e.Registry.NodeUnfrozenEvent,
+					Body:                 e.Registry.NodeUnfrozenEvent,
 					Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
 				}
 			}
@@ -263,17 +263,17 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 					RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
 						NodeID: nil, // Not available in Cobalt.
 					},
-					Raw:  e.RootHash.ExecutorCommitted,
+					Body: e.RootHash.ExecutorCommitted,
 					Type: apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
 				}
 			case e.RootHash.ExecutionDiscrepancyDetected != nil:
 				events[i] = nodeapi.Event{
-					Raw:  e.RootHash.ExecutionDiscrepancyDetected,
+					Body: e.RootHash.ExecutionDiscrepancyDetected,
 					Type: apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
 				}
 			case e.RootHash.Finalized != nil:
 				events[i] = nodeapi.Event{
-					Raw:  e.RootHash.Finalized,
+					Body: e.RootHash.Finalized,
 					Type: apiTypes.ConsensusEventTypeRoothashFinalized,
 				}
 			}
@@ -287,17 +287,17 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 					GovernanceProposalSubmitted: &nodeapi.ProposalSubmittedEvent{
 						Submitter: e.Governance.ProposalSubmitted.Submitter,
 					},
-					Raw:  e.Governance.ProposalSubmitted,
+					Body: e.Governance.ProposalSubmitted,
 					Type: apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
 				}
 			case e.Governance.ProposalExecuted != nil:
 				events[i] = nodeapi.Event{
-					Raw:  e.Governance.ProposalExecuted,
+					Body: e.Governance.ProposalExecuted,
 					Type: apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
 				}
 			case e.Governance.ProposalFinalized != nil:
 				events[i] = nodeapi.Event{
-					Raw:  e.Governance.ProposalFinalized,
+					Body: e.Governance.ProposalFinalized,
 					Type: apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
 				}
 			case e.Governance.Vote != nil:
@@ -305,7 +305,7 @@ func convertTxResult(r txResultsCobalt.Result) nodeapi.TxResult {
 					GovernanceVote: &nodeapi.VoteEvent{
 						Submitter: e.Governance.Vote.Submitter,
 					},
-					Raw:  e.Governance.Vote,
+					Body: e.Governance.Vote,
 					Type: apiTypes.ConsensusEventTypeGovernanceVote,
 				}
 			}

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -150,15 +150,19 @@ func (c *CobaltConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]*scheduler.Validator, error) {
+func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	rsp, err := c.damaskClient.Scheduler().GetValidators(ctx, height)
 	if err != nil {
 		return nil, fmt.Errorf("calling GetValidators() on Cobalt node using Damask ABI: %w", err)
 	}
-	return rsp, nil
+	validators := make([]nodeapi.Validator, len(rsp))
+	for i, v := range rsp {
+		validators[i] = nodeapi.Validator(*v)
+	}
+	return validators, nil
 }
 
-func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]*scheduler.Committee, error) {
+func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
 	rsp, err := c.damaskClient.Scheduler().GetCommittees(ctx, &scheduler.GetCommitteesRequest{
 		Height:    height,
 		RuntimeID: runtimeID,
@@ -166,10 +170,14 @@ func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64
 	if err != nil {
 		return nil, fmt.Errorf("calling GetCommittees() on Cobalt node using Damask ABI: %w", err)
 	}
-	return rsp, nil
+	committees := make([]nodeapi.Committee, len(rsp))
+	for i, c := range rsp {
+		committees[i] = nodeapi.Committee(*c)
+	}
+	return committees, nil
 }
 
-func (c *CobaltConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*governance.Proposal, error) {
+func (c *CobaltConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
 	rsp, err := c.damaskClient.Governance().Proposal(ctx, &governance.ProposalQuery{
 		Height:     height,
 		ProposalID: proposalID,
@@ -177,5 +185,5 @@ func (c *CobaltConsensusApiLite) GetProposal(ctx context.Context, height int64, 
 	if err != nil {
 		return nil, fmt.Errorf("calling GetProposal() on Cobalt node using Damask ABI: %w", err)
 	}
-	return rsp, nil
+	return (*nodeapi.Proposal)(rsp), nil
 }

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"google.golang.org/grpc"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 
 	// indexer-internal data types.
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"

--- a/storage/oasis/nodeapi/damask/convert.go
+++ b/storage/oasis/nodeapi/damask/convert.go
@@ -1,11 +1,9 @@
 package damask
 
 import (
-
-	// indexer-internal data types.
-
 	"strings"
 
+	// indexer-internal data types.
 	"github.com/oasisprotocol/oasis-core/go/common"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -90,7 +88,7 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 			}
 		case e.Registry.NodeEvent != nil:
-			var vrfID *signature.PublicKey = nil
+			var vrfID *signature.PublicKey
 			if e.Registry.NodeEvent.Node.VRF != nil {
 				vrfID = &e.Registry.NodeEvent.Node.VRF.ID
 			}

--- a/storage/oasis/nodeapi/damask/convert.go
+++ b/storage/oasis/nodeapi/damask/convert.go
@@ -1,0 +1,216 @@
+package damask
+
+import (
+
+	// indexer-internal data types.
+
+	"strings"
+
+	"github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
+	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
+
+	// data types for Damask gRPC APIs.
+	txResultsDamask "github.com/oasisprotocol/oasis-core/go/consensus/api/transaction/results"
+)
+
+func convertEvent(e txResultsDamask.Event) nodeapi.Event {
+	ret := nodeapi.Event{}
+	switch {
+	case e.Staking != nil:
+		switch {
+		case e.Staking.Transfer != nil:
+			ret = nodeapi.Event{
+				StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
+				Body:            e.Staking.Transfer,
+				Type:            apiTypes.ConsensusEventTypeStakingTransfer,
+			}
+		case e.Staking.Burn != nil:
+			ret = nodeapi.Event{
+				StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
+				Body:        e.Staking.Burn,
+				Type:        apiTypes.ConsensusEventTypeStakingBurn,
+			}
+		case e.Staking.Escrow != nil:
+			switch {
+			case e.Staking.Escrow.Add != nil:
+				ret = nodeapi.Event{
+					StakingAddEscrow: (*nodeapi.AddEscrowEvent)(e.Staking.Escrow.Add),
+					Body:             e.Staking.Escrow.Add,
+					Type:             apiTypes.ConsensusEventTypeStakingEscrowAdd,
+				}
+			case e.Staking.Escrow.Take != nil:
+				ret = nodeapi.Event{
+					StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
+					Body:              e.Staking.Escrow.Take,
+					Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
+				}
+			case e.Staking.Escrow.Reclaim != nil:
+				ret = nodeapi.Event{
+					StakingReclaimEscrow: (*nodeapi.ReclaimEscrowEvent)(e.Staking.Escrow.Reclaim),
+					Body:                 e.Staking.Escrow.Reclaim,
+					Type:                 apiTypes.ConsensusEventTypeStakingEscrowReclaim,
+				}
+			case e.Staking.Escrow.DebondingStart != nil:
+				ret = nodeapi.Event{
+					StakingDebondingStart: (*nodeapi.DebondingStartEscrowEvent)(e.Staking.Escrow.DebondingStart),
+					Body:                  e.Staking.Escrow.DebondingStart,
+					Type:                  apiTypes.ConsensusEventTypeStakingEscrowDebondingStart,
+				}
+			}
+		case e.Staking.AllowanceChange != nil:
+			ret = nodeapi.Event{
+				StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
+				Body:                   e.Staking.AllowanceChange,
+				Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
+			}
+		}
+		ret.Height = e.Staking.Height
+		ret.TxHash = e.Staking.TxHash
+		// End Staking.
+	case e.Registry != nil:
+		switch {
+		case e.Registry.RuntimeEvent != nil && e.Registry.RuntimeEvent.Runtime != nil:
+			ret = nodeapi.Event{
+				RegistryRuntime: &nodeapi.RuntimeEvent{
+					ID:          e.Registry.RuntimeEvent.Runtime.ID,
+					EntityID:    e.Registry.RuntimeEvent.Runtime.EntityID,
+					Kind:        e.Registry.RuntimeEvent.Runtime.Kind.String(),
+					KeyManager:  e.Registry.RuntimeEvent.Runtime.KeyManager,
+					TEEHardware: e.Registry.RuntimeEvent.Runtime.TEEHardware.String(),
+				},
+				Body: e.Registry.RuntimeEvent,
+				Type: apiTypes.ConsensusEventTypeRegistryRuntime,
+			}
+		case e.Registry.EntityEvent != nil:
+			ret = nodeapi.Event{
+				RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
+				Body:           e.Registry.EntityEvent,
+				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
+			}
+		case e.Registry.NodeEvent != nil:
+			var vrfID *signature.PublicKey = nil
+			if e.Registry.NodeEvent.Node.VRF != nil {
+				vrfID = &e.Registry.NodeEvent.Node.VRF.ID
+			}
+			runtimeIDs := make([]common.Namespace, len(e.Registry.NodeEvent.Node.Runtimes))
+			for i, r := range e.Registry.NodeEvent.Node.Runtimes {
+				runtimeIDs[i] = r.ID
+			}
+			tlsAddresses := make([]string, len(e.Registry.NodeEvent.Node.TLS.Addresses))
+			for i, a := range e.Registry.NodeEvent.Node.TLS.Addresses {
+				tlsAddresses[i] = a.String()
+			}
+			p2pAddresses := make([]string, len(e.Registry.NodeEvent.Node.P2P.Addresses))
+			for i, a := range e.Registry.NodeEvent.Node.P2P.Addresses {
+				p2pAddresses[i] = a.String()
+			}
+			consensusAddresses := make([]string, len(e.Registry.NodeEvent.Node.Consensus.Addresses))
+			for i, a := range e.Registry.NodeEvent.Node.Consensus.Addresses {
+				consensusAddresses[i] = a.String()
+			}
+			ret = nodeapi.Event{
+				RegistryNode: &nodeapi.NodeEvent{
+					NodeID:             e.Registry.NodeEvent.Node.ID,
+					EntityID:           e.Registry.NodeEvent.Node.EntityID,
+					Expiration:         e.Registry.NodeEvent.Node.Expiration,
+					VRFPubKey:          vrfID,
+					TLSAddresses:       tlsAddresses,
+					TLSPubKey:          e.Registry.NodeEvent.Node.TLS.PubKey,
+					TLSNextPubKey:      e.Registry.NodeEvent.Node.TLS.NextPubKey,
+					P2PID:              e.Registry.NodeEvent.Node.P2P.ID,
+					P2PAddresses:       p2pAddresses,
+					RuntimeIDs:         runtimeIDs,
+					ConsensusID:        e.Registry.NodeEvent.Node.Consensus.ID,
+					ConsensusAddresses: consensusAddresses,
+					IsRegistration:     e.Registry.NodeEvent.IsRegistration,
+					Roles:              strings.Split(e.Registry.NodeEvent.Node.Roles.String(), ","),
+					SoftwareVersion:    e.Registry.NodeEvent.Node.SoftwareVersion,
+				},
+				Body: e.Registry.NodeEvent,
+				Type: apiTypes.ConsensusEventTypeRegistryNode,
+			}
+		case e.Registry.NodeUnfrozenEvent != nil:
+			ret = nodeapi.Event{
+				RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
+				Body:                 e.Registry.NodeUnfrozenEvent,
+				Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
+			}
+		}
+		ret.Height = e.Registry.Height
+		ret.TxHash = e.Registry.TxHash
+		// End Registry.
+	case e.RootHash != nil:
+		switch {
+		case e.RootHash.ExecutorCommitted != nil:
+			ret = nodeapi.Event{
+				RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
+					NodeID: &e.RootHash.ExecutorCommitted.Commit.NodeID,
+				},
+				Body: e.RootHash.ExecutorCommitted,
+				Type: apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
+			}
+		case e.RootHash.ExecutionDiscrepancyDetected != nil:
+			ret = nodeapi.Event{
+				Body: e.RootHash.ExecutionDiscrepancyDetected,
+				Type: apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
+			}
+		case e.RootHash.Finalized != nil:
+			ret = nodeapi.Event{
+				Body: e.RootHash.Finalized,
+				Type: apiTypes.ConsensusEventTypeRoothashFinalized,
+			}
+		}
+		ret.Height = e.RootHash.Height
+		ret.TxHash = e.RootHash.TxHash
+		// End RootHash.
+	case e.Governance != nil:
+		switch {
+		case e.Governance.ProposalSubmitted != nil:
+			ret = nodeapi.Event{
+				GovernanceProposalSubmitted: (*nodeapi.ProposalSubmittedEvent)(e.Governance.ProposalSubmitted),
+				Body:                        e.Governance.ProposalSubmitted,
+				Type:                        apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
+			}
+		case e.Governance.ProposalExecuted != nil:
+			ret = nodeapi.Event{
+				GovernanceProposalExecuted: (*nodeapi.ProposalExecutedEvent)(e.Governance.ProposalExecuted),
+				Body:                       e.Governance.ProposalExecuted,
+				Type:                       apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
+			}
+		case e.Governance.ProposalFinalized != nil:
+			ret = nodeapi.Event{
+				GovernanceProposalFinalized: (*nodeapi.ProposalFinalizedEvent)(e.Governance.ProposalFinalized),
+				Body:                        e.Governance.ProposalFinalized,
+				Type:                        apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
+			}
+		case e.Governance.Vote != nil:
+			ret = nodeapi.Event{
+				GovernanceVote: &nodeapi.VoteEvent{
+					ID:        e.Governance.Vote.ID,
+					Submitter: e.Governance.Vote.Submitter,
+					Vote:      e.Governance.Vote.Vote.String(),
+				},
+				Body: e.Governance.Vote,
+				Type: apiTypes.ConsensusEventTypeGovernanceVote,
+			}
+		}
+		ret.Height = e.Governance.Height
+		ret.TxHash = e.Governance.TxHash
+		// End Governance.
+	}
+	return ret
+}
+
+func convertTxResult(r txResultsDamask.Result) nodeapi.TxResult {
+	events := make([]nodeapi.Event, len(r.Events))
+	for i, e := range r.Events {
+		events[i] = convertEvent(*e)
+	}
+
+	return nodeapi.TxResult{
+		Error:  nodeapi.TxError(r.Error),
+		Events: events,
+	}
+}

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -124,20 +124,40 @@ func (c *DamaskConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 	return events, nil
 }
 
-func (c *DamaskConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]*scheduler.Validator, error) {
-	return c.client.Scheduler().GetValidators(ctx, height)
+func (c *DamaskConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
+	rsp, err := c.client.Scheduler().GetValidators(ctx, height)
+	if err != nil {
+		return nil, err
+	}
+	validators := make([]nodeapi.Validator, len(rsp))
+	for i, v := range rsp {
+		validators[i] = nodeapi.Validator(*v)
+	}
+	return validators, nil
 }
 
-func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]*scheduler.Committee, error) {
-	return c.client.Scheduler().GetCommittees(ctx, &scheduler.GetCommitteesRequest{
+func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
+	rsp, err := c.client.Scheduler().GetCommittees(ctx, &scheduler.GetCommitteesRequest{
 		Height:    height,
 		RuntimeID: runtimeID,
 	})
+	if err != nil {
+		return nil, err
+	}
+	committees := make([]nodeapi.Committee, len(rsp))
+	for i, c := range rsp {
+		committees[i] = nodeapi.Committee(*c)
+	}
+	return committees, nil
 }
 
-func (c *DamaskConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*governance.Proposal, error) {
-	return c.client.Governance().Proposal(ctx, &governance.ProposalQuery{
+func (c *DamaskConsensusApiLite) GetProposal(ctx context.Context, height int64, proposalID uint64) (*nodeapi.Proposal, error) {
+	rsp, err := c.client.Governance().Proposal(ctx, &governance.ProposalQuery{
 		Height:     height,
 		ProposalID: proposalID,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return (*nodeapi.Proposal)(rsp), nil
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/8669n7f27, partially resolves https://app.clickup.com/t/8669n7gt3 (for most of consensus types)

This PR:
- Implements the rest of `ConsensusApiLite` (introduced in #326), an interface that unifies communication with Cobalt and Damask nodes.
- Migrates that interface from using the latest oasis-core types to using internal types.

The latter has considerable fallout, and introduces considerable boilerplate :/. That said, it's the best solution I see. Re-posting my Slack reasoning for visibility:
>  The initial plan was to grab the Cobalt response, convert it to a Damask response, and then reuse our existing analyzer code from there. There are two issues with this:
> * It's more work than it should be. For example, in `TransactionsWithResults`, which includes all the events, some types are more complex than I expected, and can differ quite a lot between versions. For example, when a runtime registers, the registration includes a ton of parameters (executors, TEE hardware, admission policies for nodes, staking rules, etc), and many of them changed their types between versions. I plowed into converting those types, but 150 lines in, I gave up. They were lines that come slowly, because you have to manually hunt down every field and try to cast it, then failing that, convert manually, carefully comparing the fields. With 150 lines of boilerplate-looking, easy-to-make-mistakes code, I was nowhere near done with the conversion. The kicker is that indexer doesn't really use almost any of those fields. But I cannot just replace them with `nil`, read on.
> * It loses information. We _do_ use all events at a surface level in that we index them, i.e. we store their raw JSON into the DB (and will probably expose it via the web UI). When converting cobalt events to the damask-event format, some fields are lost, some are made up ... and only then does the analyzer get to see the value and store it into the DB.
> * It is not future-proof because indexer will eventually depend on an even newer oasis-core. We've known this, and we planned for it tentatively in https://app.clickup.com/t/8669n7gt3; that task now got largely folded into this PR.

**Testing:**
- I ran 10k rounds of consensus pre- and post-PR, will compare DB dumps. Results:
    - There was a bug in storing the body of `staking.allowance_change` events. The old analyzer stored the base64-encoded JSON representation, but all other events are just plain JSON. This PR fixes that.
    - For nodes that had no TLS addresses (= they were not listening for TLS connections; I'm not clear on what protocol under TLS), we used to store their addresses as `{''}`. Now, it's correctly `{}`. (Curlies are how postgres represents arrays.) That said, I see those addresses are now [deprecated](https://github.com/oasisprotocol/oasis-core/blob/7e226c391c477cbcbb492a8dbe4cfce88bc8cb46/go/common/node/node.go#L455-L455) anyway :). Same for P2P addresses, which are _not_ deprecated.
    - For nodes, various addresses were incorrectly stored doubly-quoted (= as a string with literal `'` at beginning and end); fixed now.
    - No other differences.
- I ran the consensus analyzer against a Cobalt node (except non-tx registry events, because they're not whitelisted by our current node instance) for a good number of rounds. No errors or crashes. I did not go to the trouble of retrofitting statecheck for Cobalt.