### PR TITLE
bugfix: analyzer: evm events: Represent big int values as string, not float

### DIFF
--- a/analyzer/runtime/incoming.go
+++ b/analyzer/runtime/incoming.go
@@ -490,7 +490,9 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						{
 							Name:    "value",
 							EvmType: "uint256",
-							Value:   amount,
+							// JSON supports encoding big integers, but many clients (javascript, jq, etc.)
+							// will incorrectly parse them as floats. So we encode uint256 as a string instead.
+							Value: amount.String(),
 						},
 					}
 					eventData := EventData{
@@ -537,7 +539,9 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						{
 							Name:    "value",
 							EvmType: "uint256",
-							Value:   amount,
+							// JSON supports encoding big integers, but many clients (javascript, jq, etc.)
+							// will incorrectly parse them as floats. So we encode uint256 as a string instead.
+							Value: amount.String(),
 						},
 					}
 					eventData := EventData{

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1961,8 +1961,12 @@ components:
           description: The solidity type of the event parameter.
         value:
           description: The parameter value.
-      description: A decoded parameter of an event emitted from an evm runtime.
-
+      description: |
+        A decoded parameter of an event emitted from an EVM runtime.
+        Values of EVM type `int128`, `uint128`, `int256`, `uint256`, `fixed`, and `ufixed` are represented as strings.
+        Values of EVM type `address` and `address payable` are represented as lowercase hex strings with a "0x" prefix.
+        Values of EVM type `bytes` and `bytes<N>` are represented as base64 strings.
+        Values of other EVM types (integer types, strings, arrays, etc.) are represented as their JSON conterpart.
     RuntimeTransactionList:
       allOf:
         - $ref: '#/components/schemas/List'

--- a/tests/e2e_regression/run.sh
+++ b/tests/e2e_regression/run.sh
@@ -62,8 +62,8 @@ testCases=(
   'emerald_blocks           /v1/emerald/blocks'
   'emerald_tokens           /v1/emerald/tokens'
   'emerald_txs              /v1/emerald/transactions'
-  'emerald_events           /v1/consensus/events'
-  'emerald_events_by_type   /v1/consensus/events?type=sdf'
+  'emerald_events           /v1/emerald/events'
+  'emerald_events_by_type   /v1/emerald/events?type=sdf'
   'emerald_status           /v1/emerald/status'
 )
 nCases=${#testCases[@]}


### PR DESCRIPTION
Before this PR, large-enough integer values in EVM event params were encoded as floats in the API response:
```
{"evm_type":"uint256","name":"value","value":2.70272e+22}
```

The value was correct in the DB's internal JSON representation (270272000...00) but got incorrectly serialized as a float when inserting it into the API response.


This PR changes the return type of the web API such that all integer values are represented as strings.
(first approach taken by this PR shown with ~strikeout~)

It does so by
~1. changing the internal API type of the `value` field to be `json.RawMessage`, essentially meaning "take whatever encoding the DB gives you, trust that it's valid JSON, and when you're asked to serialize yourself, just regurgitate the bytes". This makes the API correctly return `270272000...00`.~
~2. encoding integer values as strings on the fly as they are fetched from the DB. While `270272000...00` is technically correct, `jq` and presumably most JS clients mis-parse such large int as floats (again). Our web API already represents all BigInts as strings, so this is consistent with the rest of the API.~
1. Serializing the uint256 EVM type into a JSON string, rather than a JSON number.

**Testing:**
- Tested the API manually by querying `localhost:8008/v1/emerald/events`. Numbers appear as strings, other kinds of values are unaffected.
- Tested the modified analyzer by running for 1000 blocks and diffing the DB dump. No diffs.