### PR TITLE
statecheck: Do not use indexer-internal APIs for node access

### DIFF
--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -32,11 +32,6 @@ func (cc *ConsensusClient) GenesisDocument(ctx context.Context) (*genesisAPI.Doc
 	return cc.nodeApi.GetGenesisDocument(ctx)
 }
 
-// GenesisDocumentAtHeight returns the genesis document at the provided height.
-func (cc *ConsensusClient) GenesisDocumentAtHeight(ctx context.Context, height int64) (*genesisAPI.Document, error) {
-	return cc.nodeApi.StateToGenesis(ctx, height)
-}
-
 // Name returns the name of the client, for the ConsensusSourceStorage interface.
 func (cc *ConsensusClient) Name() string {
 	return fmt.Sprintf("%s_consensus", moduleName)

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -7,7 +7,6 @@ import (
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
 	runtimeSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
@@ -63,14 +62,6 @@ func (rc *RuntimeClient) BlockData(ctx context.Context, round uint64) (*storage.
 
 func (rc *RuntimeClient) GetEventsRaw(ctx context.Context, round uint64) ([]*sdkTypes.Event, error) {
 	return rc.client.GetEventsRaw(ctx, round)
-}
-
-func (rc *RuntimeClient) GetAccountAddresses(ctx context.Context, round uint64, denomination sdkTypes.Denomination) (accounts.Addresses, error) {
-	return rc.client.Accounts.Addresses(ctx, round, denomination)
-}
-
-func (rc *RuntimeClient) GetAccountBalances(ctx context.Context, round uint64, addr sdkTypes.Address) (*accounts.AccountBalances, error) {
-	return rc.client.Accounts.Balances(ctx, round, addr)
 }
 
 func (rc *RuntimeClient) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -10,9 +10,9 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
-	"github.com/oasisprotocol/oasis-indexer/storage/oasis"
 	"github.com/oasisprotocol/oasis-indexer/storage/postgres"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,12 +28,12 @@ func newTargetClient(t *testing.T) (*postgres.Client, error) {
 	return postgres.NewClient(connString, logger)
 }
 
-func newSourceClientFactory() (*oasis.ClientFactory, error) {
-	network := &oasisConfig.Network{
+func newSdkConnection(ctx context.Context) (connection.Connection, error) {
+	net := &oasisConfig.Network{
 		ChainContext: os.Getenv("HEALTHCHECK_TEST_CHAIN_CONTEXT"),
 		RPC:          os.Getenv("HEALTHCHECK_TEST_NODE_RPC"),
 	}
-	return oasis.NewClientFactory(context.Background(), network, true)
+	return connection.ConnectNoVerify(ctx, net)
 }
 
 func snapshotBackends(target *postgres.Client, analyzer string, tables []string) (int64, error) {


### PR DESCRIPTION
Before this PR, statecheck used indexer's internal libraries to access the node. This
- Makes for less than ideal separation: Indexer proper now has methods that exist only for tests to run.
- Makes it slightly harder/messier/more boilerplate-y to refactor those libraries for multiple-version support.

This PR makes the statecheck depend on the indexer less (actually not at all, except for DB utility wrappers). It does mean that we concede we won't run statecheck on anything but the version of oasis-core and oasis-sdk that it was compiled against. Not a loss IMO; we don't need huge generality there.

Testing: None :grimacing: because it's a bit of a pain to do, and the changes are such that the compiler should have caught any problems. Also, the statecheck is not hooked up to any alerts yet.