### PR TITLE
Support for pre-Damask runtime rounds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
 builds:
   - binary: oasis-indexer
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=0  # build statically-linked binaries
     flags:
       - -trimpath
     ldflags:

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -107,6 +107,10 @@ const (
 
 // FromChainContext identifies a Network using its ChainContext.
 func FromChainContext(chainContext string) (Network, error) {
+	// TODO: Remove this hardcoded value once indexer config supports multiple nodes.
+	if chainContext == "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898" {
+		return NetworkMainnet, nil // cobalt mainnet
+	}
 	var network Network
 	for name, nw := range oasisConfig.DefaultNetworks.All {
 		if nw.ChainContext == chainContext {

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -500,7 +500,7 @@ func (m *Main) queueTxEventInserts(batch *storage.QueryBatch, data *storage.Cons
 }
 
 func (m *Main) queueRuntimeRegistrations(batch *storage.QueryBatch, data *storage.RegistryData) error {
-	for _, runtimeEvent := range data.RuntimeEvents {
+	for _, runtimeEvent := range data.RuntimeRegisteredEvents {
 		var keyManager *string
 
 		if runtimeEvent.KeyManager != nil {

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -15,8 +15,7 @@ import (
 // module-independent way. It only records effects for which an understanding of
 // the module's semantics is necessary.
 func (m *Main) queueAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
-	allEvents := append(blockData.EventData, blockData.NonTxEvents...) //nolint: gocritic
-	for _, event := range allEvents {
+	for _, event := range blockData.EventData {
 		if event.WithScope.Accounts == nil {
 			continue
 		}

--- a/analyzer/runtime/consensusaccounts.go
+++ b/analyzer/runtime/consensusaccounts.go
@@ -13,8 +13,7 @@ import (
 // module-independent way. It only records effects for which an understanding of
 // the module's semantics is necessary.
 func (m *Main) queueConsensusAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
-	allEvents := append(blockData.EventData, blockData.NonTxEvents...) //nolint: gocritic
-	for _, event := range allEvents {
+	for _, event := range blockData.EventData {
 		if event.WithScope.ConsensusAccounts == nil {
 			continue
 		}

--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
+	types "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+)
+
+func DecodeCoreEvent(event *types.Event) ([]core.Event, error) {
+	if event.Module != core.ModuleName {
+		return nil, nil
+	}
+	var events []core.Event
+	switch event.Code {
+	case core.GasUsedEventCode:
+		var evs []*core.GasUsedEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode core gas used event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, core.Event{GasUsed: ev})
+		}
+	default:
+		return nil, fmt.Errorf("invalid core event code: %v", event.Code)
+	}
+	return events, nil
+}
+
+func DecodeAccountsEvent(event *types.Event) ([]accounts.Event, error) {
+	if event.Module != accounts.ModuleName {
+		return nil, nil
+	}
+	var events []accounts.Event
+	switch event.Code {
+	case accounts.TransferEventCode:
+		var evs []*accounts.TransferEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode account transfer event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, accounts.Event{Transfer: ev})
+		}
+	case accounts.BurnEventCode:
+		var evs []*accounts.BurnEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode account burn event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, accounts.Event{Burn: ev})
+		}
+	case accounts.MintEventCode:
+		var evs []*accounts.MintEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode account mint event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, accounts.Event{Mint: ev})
+		}
+	default:
+		return nil, fmt.Errorf("invalid accounts event code: %v", event.Code)
+	}
+	return events, nil
+}
+
+func DecodeConsensusAccountsEvent(event *types.Event) ([]consensusaccounts.Event, error) {
+	if event.Module != consensusaccounts.ModuleName {
+		return nil, nil
+	}
+	var events []consensusaccounts.Event
+	switch event.Code {
+	case consensusaccounts.DepositEventCode:
+		var evs []*consensusaccounts.DepositEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode consensus accounts deposit event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, consensusaccounts.Event{Deposit: ev})
+		}
+	case consensusaccounts.WithdrawEventCode:
+		var evs []*consensusaccounts.WithdrawEvent
+		if err := unmarshalSingleOrArray(event.Value, &evs); err != nil {
+			return nil, fmt.Errorf("decode consensus accounts withdraw event value: %w", err)
+		}
+		for _, ev := range evs {
+			events = append(events, consensusaccounts.Event{Withdraw: ev})
+		}
+	default:
+		return nil, fmt.Errorf("invalid consensus accounts event code: %v", event.Code)
+	}
+	return events, nil
+}
+
+func DecodeEVMEvent(event *types.Event) ([]evm.Event, error) {
+	if event.Module != evm.ModuleName {
+		return nil, nil
+	}
+	var events []evm.Event
+	switch event.Code {
+	case 1: // There's a single event code, and it doesn't have an associated constant.
+		if err := unmarshalSingleOrArray(event.Value, &events); err != nil {
+			return nil, fmt.Errorf("evm event value unmarshal failed: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("invalid evm event code: %v", event.Code)
+	}
+	return events, nil
+}
+
+// unmarshalSingleOrArray tries to interpret `data` as an array of `T`.
+// Failing that, it interprets it as a single `T`, and returns a slice
+// of size 1 containing that `T`.
+func unmarshalSingleOrArray[T any](data []byte, dst *[]T) error {
+	if err := cbor.Unmarshal(data, &dst); err != nil {
+		var single T
+		if err := cbor.Unmarshal(data, &single); err != nil {
+			return fmt.Errorf("unmarshal single or array: %w", err)
+		}
+		*dst = []T{single}
+	}
+	return nil
+}

--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -11,7 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 )
 
-func DecodeCoreEvent(event *nodeapi.SdkEvent) ([]core.Event, error) {
+func DecodeCoreEvent(event *nodeapi.RuntimeEvent) ([]core.Event, error) {
 	if event.Module != core.ModuleName {
 		return nil, nil
 	}
@@ -31,7 +31,7 @@ func DecodeCoreEvent(event *nodeapi.SdkEvent) ([]core.Event, error) {
 	return events, nil
 }
 
-func DecodeAccountsEvent(event *nodeapi.SdkEvent) ([]accounts.Event, error) {
+func DecodeAccountsEvent(event *nodeapi.RuntimeEvent) ([]accounts.Event, error) {
 	if event.Module != accounts.ModuleName {
 		return nil, nil
 	}
@@ -67,7 +67,7 @@ func DecodeAccountsEvent(event *nodeapi.SdkEvent) ([]accounts.Event, error) {
 	return events, nil
 }
 
-func DecodeConsensusAccountsEvent(event *nodeapi.SdkEvent) ([]consensusaccounts.Event, error) {
+func DecodeConsensusAccountsEvent(event *nodeapi.RuntimeEvent) ([]consensusaccounts.Event, error) {
 	if event.Module != consensusaccounts.ModuleName {
 		return nil, nil
 	}
@@ -95,7 +95,7 @@ func DecodeConsensusAccountsEvent(event *nodeapi.SdkEvent) ([]consensusaccounts.
 	return events, nil
 }
 
-func DecodeEVMEvent(event *nodeapi.SdkEvent) ([]evm.Event, error) {
+func DecodeEVMEvent(event *nodeapi.RuntimeEvent) ([]evm.Event, error) {
 	if event.Module != evm.ModuleName {
 		return nil, nil
 	}

--- a/analyzer/runtime/decode_events.go
+++ b/analyzer/runtime/decode_events.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
-	types "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
-func DecodeCoreEvent(event *types.Event) ([]core.Event, error) {
+func DecodeCoreEvent(event *nodeapi.SdkEvent) ([]core.Event, error) {
 	if event.Module != core.ModuleName {
 		return nil, nil
 	}
@@ -31,7 +31,7 @@ func DecodeCoreEvent(event *types.Event) ([]core.Event, error) {
 	return events, nil
 }
 
-func DecodeAccountsEvent(event *types.Event) ([]accounts.Event, error) {
+func DecodeAccountsEvent(event *nodeapi.SdkEvent) ([]accounts.Event, error) {
 	if event.Module != accounts.ModuleName {
 		return nil, nil
 	}
@@ -67,7 +67,7 @@ func DecodeAccountsEvent(event *types.Event) ([]accounts.Event, error) {
 	return events, nil
 }
 
-func DecodeConsensusAccountsEvent(event *types.Event) ([]consensusaccounts.Event, error) {
+func DecodeConsensusAccountsEvent(event *nodeapi.SdkEvent) ([]consensusaccounts.Event, error) {
 	if event.Module != consensusaccounts.ModuleName {
 		return nil, nil
 	}
@@ -95,7 +95,7 @@ func DecodeConsensusAccountsEvent(event *types.Event) ([]consensusaccounts.Event
 	return events, nil
 }
 
-func DecodeEVMEvent(event *types.Event) ([]evm.Event, error) {
+func DecodeEVMEvent(event *nodeapi.SdkEvent) ([]evm.Event, error) {
 	if event.Module != evm.ModuleName {
 		return nil, nil
 	}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -17,7 +17,6 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
 	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	sdkClient "github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
@@ -28,6 +27,7 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
 	"github.com/oasisprotocol/oasis-indexer/log"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 type BlockTransactionSignerData struct {
@@ -241,7 +241,7 @@ func registerTokenDecrease(tokenChanges map[TokenChangeKey]*big.Int, contractAdd
 	change.Sub(change, amount)
 }
 
-func ExtractRound(blockHeader block.Header, txrs []*sdkClient.TransactionWithResults, rawEvents []*sdkTypes.Event, logger *log.Logger) (*BlockData, error) {
+func ExtractRound(blockHeader block.Header, txrs []*nodeapi.RuntimeTransactionWithResults, rawEvents []*sdkTypes.Event, logger *log.Logger) (*BlockData, error) {
 	blockData := BlockData{
 		Header:              blockHeader,
 		Hash:                blockHeader.EncodedHash().String(),

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -241,7 +241,7 @@ func registerTokenDecrease(tokenChanges map[TokenChangeKey]*big.Int, contractAdd
 	change.Sub(change, amount)
 }
 
-func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.RuntimeTransactionWithResults, rawEvents []*nodeapi.SdkEvent, logger *log.Logger) (*BlockData, error) {
+func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.RuntimeTransactionWithResults, rawEvents []*nodeapi.RuntimeEvent, logger *log.Logger) (*BlockData, error) {
 	blockData := BlockData{
 		Header:              blockHeader,
 		Hash:                hash.NewFrom(blockHeader).String(),
@@ -256,7 +256,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.Runtim
 	}
 
 	// Extract info from non-tx events.
-	rawNonTxEvents := []*nodeapi.SdkEvent{}
+	rawNonTxEvents := []*nodeapi.RuntimeEvent{}
 	for _, e := range rawEvents {
 		if e.TxHash.String() == util.ZeroTxHash {
 			rawNonTxEvents = append(rawNonTxEvents, e)
@@ -344,9 +344,9 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.Runtim
 				return nil, fmt.Errorf("tx %d: %w", txIndex, err)
 			}
 		}
-		txEvents := make([]*nodeapi.SdkEvent, len(txr.Events))
+		txEvents := make([]*nodeapi.RuntimeEvent, len(txr.Events))
 		for i, e := range txr.Events {
-			txEvents[i] = (*nodeapi.SdkEvent)(e)
+			txEvents[i] = (*nodeapi.RuntimeEvent)(e)
 		}
 		res, err := extractEvents(&blockData, blockTransactionData.RelatedAccountAddresses, txEvents)
 		if err != nil {
@@ -383,7 +383,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.Runtim
 	return &blockData, nil
 }
 
-func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Address]bool, eventsRaw []*nodeapi.SdkEvent) (*extractEventResult, error) {
+func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Address]bool, eventsRaw []*nodeapi.RuntimeEvent) (*extractEventResult, error) {
 	extractedEvents := []*EventData{}
 	foundGasUsedEvent := false
 	var txGasUsed uint64

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -16,7 +16,6 @@ import (
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
@@ -244,8 +243,8 @@ func registerTokenDecrease(tokenChanges map[TokenChangeKey]*big.Int, contractAdd
 func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.RuntimeTransactionWithResults, rawEvents []*nodeapi.RuntimeEvent, logger *log.Logger) (*BlockData, error) {
 	blockData := BlockData{
 		Header:              blockHeader,
-		Hash:                hash.NewFrom(blockHeader).String(),
-		Timestamp:           time.Unix(int64(blockHeader.Timestamp), 0 /* nanos */),
+		Hash:                blockHeader.Hash.Hex(),
+		Timestamp:           blockHeader.Timestamp,
 		NumTransactions:     len(txrs),
 		TransactionData:     make([]*BlockTransactionData, 0, len(txrs)),
 		EventData:           []*EventData{},

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -345,6 +345,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.Runtim
 		}
 		// Populate eventData with tx-specific data.
 		for _, eventData := range res.ExtractedEvents {
+			txIndex := txIndex // const local copy of loop variable
 			eventData.TxIndex = &txIndex
 			eventData.TxHash = &blockTransactionData.Hash
 		}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -351,8 +351,14 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.Runtim
 				logger.Info("tx didn't emit a core.GasUsed event, assuming it used max allowed gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", tx.AuthInfo.Fee.Gas)
 				txGasUsed = tx.AuthInfo.Fee.Gas
 			} else {
-				// Inaccurate: Treat as not using any gas.
-				// TODO: Decode the tx; if it failed with "out of gas", assume it used all the gas.
+				// Very rough heuristic: Treat as not using any gas.
+				//
+				// It's probably closer to truth to guess that all gas was used, unless
+				// there was an auth or insufficient-funds error, but a very simple
+				// heuristic is nice in its own right; it's easy to explain.
+				//
+				// Beware that some failed txs have an enormous (e.g. MAX_INT64) gas
+				// limit.
 				logger.Info("tx didn't emit a core.GasUsed event and failed, assuming it used no gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", 0)
 				txGasUsed = 0
 			}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"time"
 
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
@@ -90,10 +89,8 @@ type TokenChangeKey struct {
 }
 
 type BlockData struct {
-	Header              nodeapi.RuntimeBlockHeader // TODO: deduplicate with Hash, Timestamp.
-	Hash                string
-	Timestamp           time.Time
-	NumTransactions     int
+	Header              nodeapi.RuntimeBlockHeader
+	NumTransactions     int // Might be different from len(TransactionData) if some transactions are malformed.
 	GasUsed             uint64
 	Size                int
 	TransactionData     []*BlockTransactionData
@@ -101,8 +98,7 @@ type BlockData struct {
 	NonTxEvents         []*EventData // TODO: Can we fold these events into `EventData`?
 	AddressPreimages    map[apiTypes.Address]*AddressPreimageData
 	TokenBalanceChanges map[TokenChangeKey]*big.Int
-	// key is oasis bech32 address
-	PossibleTokens map[apiTypes.Address]*EVMPossibleToken
+	PossibleTokens      map[apiTypes.Address]*EVMPossibleToken // key is oasis bech32 address
 }
 
 // Function naming conventions in this file:
@@ -243,8 +239,6 @@ func registerTokenDecrease(tokenChanges map[TokenChangeKey]*big.Int, contractAdd
 func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []*nodeapi.RuntimeTransactionWithResults, rawEvents []*nodeapi.RuntimeEvent, logger *log.Logger) (*BlockData, error) {
 	blockData := BlockData{
 		Header:              blockHeader,
-		Hash:                blockHeader.Hash.Hex(),
-		Timestamp:           blockHeader.Timestamp,
 		NumTransactions:     len(txrs),
 		TransactionData:     make([]*BlockTransactionData, 0, len(txrs)),
 		EventData:           []*EventData{},

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -223,7 +223,7 @@ func (m *Main) processRound(ctx context.Context, round uint64) error {
 	}
 
 	// Preprocess data.
-	blockData, err := ExtractRound(data.BlockData.BlockHeader.Header, data.BlockData.TransactionsWithResults, data.RawEvents, m.logger)
+	blockData, err := ExtractRound(*data.BlockData.BlockHeader, data.BlockData.TransactionsWithResults, data.RawEvents, m.logger)
 	if err != nil {
 		return err
 	}

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -298,7 +298,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			transactionData.EthHash,
 			transactionData.GasUsed,
 			transactionData.Size,
-			data.Timestamp,
+			data.Header.Timestamp,
 			transactionData.Raw,
 			transactionData.RawResult,
 		)

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -262,7 +263,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		data.Header.Round,
 		data.Header.Version,
 		time.Unix(int64(data.Header.Timestamp), 0 /* nanos */),
-		data.Header.EncodedHash().Hex(),
+		hash.NewFrom(data.Header).Hex(),
 		data.Header.PreviousHash.Hex(),
 		data.Header.IORoot.Hex(),
 		data.Header.StateRoot.Hex(),

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
@@ -262,8 +261,8 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		m.runtime,
 		data.Header.Round,
 		data.Header.Version,
-		time.Unix(int64(data.Header.Timestamp), 0 /* nanos */),
-		hash.NewFrom(data.Header).Hex(),
+		data.Header.Timestamp,
+		data.Header.Hash,
 		data.Header.PreviousHash.Hex(),
 		data.Header.IORoot.Hex(),
 		data.Header.StateRoot.Hex(),

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -223,7 +223,7 @@ func (m *Main) processRound(ctx context.Context, round uint64) error {
 	}
 
 	// Preprocess data.
-	blockData, err := ExtractRound(*data.BlockData.BlockHeader, data.BlockData.TransactionsWithResults, data.RawEvents, m.logger)
+	blockData, err := ExtractRound(data.BlockHeader, data.TransactionsWithResults, data.RawEvents, m.logger)
 	if err != nil {
 		return err
 	}

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -304,7 +304,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		)
 	}
 
-	// Insert tx-related events.
+	// Insert events.
 	for _, eventData := range data.EventData {
 		eventRelatedAddresses := common.ExtractAddresses(eventData.RelatedAddresses)
 		batch.Queue(
@@ -313,23 +313,6 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			data.Header.Round,
 			eventData.TxIndex,
 			eventData.TxHash,
-			eventData.Type,
-			eventData.Body,
-			eventData.EvmLogName,
-			eventData.EvmLogParams,
-			eventRelatedAddresses,
-		)
-	}
-
-	// Insert non-tx events.
-	for _, eventData := range data.NonTxEvents {
-		eventRelatedAddresses := common.ExtractAddresses(eventData.RelatedAddresses)
-		batch.Queue(
-			queries.RuntimeEventInsert,
-			m.runtime,
-			data.Header.Round,
-			nil, // non-tx event has no tx index
-			nil, // non-tx event has no tx hash
 			eventData.Type,
 			eventData.Body,
 			eventData.EvmLogName,

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -103,7 +103,7 @@ type SdkEventHandler struct {
 	EVM               func(event *evm.Event) error
 }
 
-func VisitSdkEvent(event *nodeapi.SdkEvent, handler *SdkEventHandler) error {
+func VisitSdkEvent(event *nodeapi.RuntimeEvent, handler *SdkEventHandler) error {
 	if handler.Core != nil {
 		coreEvents, err := DecodeCoreEvent(event)
 		if err != nil {
@@ -151,7 +151,7 @@ func VisitSdkEvent(event *nodeapi.SdkEvent, handler *SdkEventHandler) error {
 	return nil
 }
 
-func VisitSdkEvents(events []*nodeapi.SdkEvent, handler *SdkEventHandler) error {
+func VisitSdkEvents(events []*nodeapi.RuntimeEvent, handler *SdkEventHandler) error {
 	for i, event := range events {
 		if err := VisitSdkEvent(event, handler); err != nil {
 			return fmt.Errorf("event %d: %w", i, err)

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -104,61 +104,45 @@ type SdkEventHandler struct {
 
 func VisitSdkEvent(event *sdkTypes.Event, handler *SdkEventHandler) error {
 	if handler.Core != nil {
-		coreEvents, err := core.DecodeEvent(event)
+		coreEvents, err := DecodeCoreEvent(event)
 		if err != nil {
 			return fmt.Errorf("decode core: %w", err)
 		}
-		for i, coreEvent := range coreEvents {
-			coreEventCast, ok := coreEvent.(*core.Event)
-			if !ok {
-				return fmt.Errorf("decoded event %d could not cast to core.Event", i)
-			}
-			if err = handler.Core(coreEventCast); err != nil {
+		for i := range coreEvents {
+			if err = handler.Core(&coreEvents[i]); err != nil {
 				return fmt.Errorf("decoded event %d core: %w", i, err)
 			}
 		}
 	}
 	if handler.Accounts != nil {
-		accountEvents, err := accounts.DecodeEvent(event)
+		accountEvents, err := DecodeAccountsEvent(event)
 		if err != nil {
 			return fmt.Errorf("decode accounts: %w", err)
 		}
-		for i, accountEvent := range accountEvents {
-			accountEventCast, ok := accountEvent.(*accounts.Event)
-			if !ok {
-				return fmt.Errorf("decoded event %d could not cast to accounts.Event", i)
-			}
-			if err = handler.Accounts(accountEventCast); err != nil {
+		for i := range accountEvents {
+			if err = handler.Accounts(&accountEvents[i]); err != nil {
 				return fmt.Errorf("decoded event %d accounts: %w", i, err)
 			}
 		}
 	}
 	if handler.ConsensusAccounts != nil {
-		consensusAccountsEvents, err := consensusaccounts.DecodeEvent(event)
+		consensusAccountsEvents, err := DecodeConsensusAccountsEvent(event)
 		if err != nil {
 			return fmt.Errorf("decode consensus accounts: %w", err)
 		}
-		for i, consensusAccountsEvent := range consensusAccountsEvents {
-			consensusAccountsEventCast, ok := consensusAccountsEvent.(*consensusaccounts.Event)
-			if !ok {
-				return fmt.Errorf("decoded event %d could not cast to consensusaccounts.Event", i)
-			}
-			if err = handler.ConsensusAccounts(consensusAccountsEventCast); err != nil {
+		for i := range consensusAccountsEvents {
+			if err = handler.ConsensusAccounts(&consensusAccountsEvents[i]); err != nil {
 				return fmt.Errorf("decoded event %d consensus accounts: %w", i, err)
 			}
 		}
 	}
 	if handler.EVM != nil {
-		evmEvents, err := evm.DecodeEvent(event)
+		evmEvents, err := DecodeEVMEvent(event)
 		if err != nil {
 			return fmt.Errorf("decode evm: %w", err)
 		}
-		for i, evmEvent := range evmEvents {
-			evmEventCast, ok := evmEvent.(*evm.Event)
-			if !ok {
-				return fmt.Errorf("decoded event %d could not cast to evm.Event", i)
-			}
-			if err = handler.EVM(evmEventCast); err != nil {
+		for i := range evmEvents {
+			if err = handler.EVM(&evmEvents[i]); err != nil {
 				return fmt.Errorf("decoded event %d evm: %w", i, err)
 			}
 		}

--- a/analyzer/runtime/visitors.go
+++ b/analyzer/runtime/visitors.go
@@ -12,6 +12,7 @@ import (
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	evmCommon "github.com/oasisprotocol/oasis-indexer/analyzer/uncategorized"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 type CallHandler struct {
@@ -102,7 +103,7 @@ type SdkEventHandler struct {
 	EVM               func(event *evm.Event) error
 }
 
-func VisitSdkEvent(event *sdkTypes.Event, handler *SdkEventHandler) error {
+func VisitSdkEvent(event *nodeapi.SdkEvent, handler *SdkEventHandler) error {
 	if handler.Core != nil {
 		coreEvents, err := DecodeCoreEvent(event)
 		if err != nil {
@@ -150,7 +151,7 @@ func VisitSdkEvent(event *sdkTypes.Event, handler *SdkEventHandler) error {
 	return nil
 }
 
-func VisitSdkEvents(events []*sdkTypes.Event, handler *SdkEventHandler) error {
+func VisitSdkEvents(events []*nodeapi.SdkEvent, handler *SdkEventHandler) error {
 	for i, event := range events {
 		if err := VisitSdkEvent(event, handler); err != nil {
 			return fmt.Errorf("event %d: %w", i, err)

--- a/api/v1/types/util.go
+++ b/api/v1/types/util.go
@@ -2,9 +2,11 @@ package types
 
 import "fmt"
 
+// Hardcoded event names emitted by ERC-20 contracts.
+// TODO: Remove these once we are able to query the ABI of the contract.
 const (
-	Erc20Transfer = "erc20.transfer"
-	Erc20Approval = "erc20.approval"
+	Erc20Transfer = "Transfer"
+	Erc20Approval = "Approval"
 )
 
 type Address string

--- a/api/v1/types/util.go
+++ b/api/v1/types/util.go
@@ -3,7 +3,7 @@ package types
 import "fmt"
 
 // Hardcoded event names emitted by ERC-20 contracts.
-// TODO: Remove these once we are able to query the ABI of the contract.
+// TODO: Query the ABI of the contract for the event names, remove these.
 const (
 	Erc20Transfer = "Transfer"
 	Erc20Approval = "Approval"

--- a/coreapi/v21.1.1/roothash/api/block/header.go
+++ b/coreapi/v21.1.1/roothash/api/block/header.go
@@ -84,7 +84,9 @@ type Header struct { // nolint: maligned
 // removed func
 
 // EncodedHash returns the encoded cryptographic hash of the header.
-// removed func
+func (h *Header) EncodedHash() hash.Hash {
+	return hash.NewFrom(h)
+}
 
 // StorageRoots returns the storage roots contained in this header.
 // removed func

--- a/storage/api.go
+++ b/storage/api.go
@@ -11,9 +11,7 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	"github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
@@ -223,14 +221,6 @@ type RuntimeSourceStorage interface {
 	// AllData returns all data tied to a specific round.
 	AllData(ctx context.Context, round uint64) (*RuntimeAllData, error)
 
-	// BlockData gets block data in the specified round. This includes all
-	// block header information, as well as transactions and events included
-	// within that block.
-	BlockData(ctx context.Context, round uint64) (*RuntimeBlockData, error)
-
-	// EventsData gets all events in the specified round, including non-tx events.
-	GetEventsRaw(ctx context.Context, round uint64) ([]*sdkTypes.Event, error)
-
 	// EVMSimulateCall gets the result of the given EVM simulate call query.
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 
@@ -244,15 +234,10 @@ type RuntimeSourceStorage interface {
 }
 
 type RuntimeAllData struct {
-	Round     uint64
-	BlockData *RuntimeBlockData
-	RawEvents []*sdkTypes.Event
-}
-
-// RuntimeBlockData represents data for a runtime block during a given round.
-type RuntimeBlockData struct {
-	BlockHeader             *block.Header
-	TransactionsWithResults []*client.TransactionWithResults
+	Round                   uint64
+	BlockHeader             nodeapi.RuntimeBlockHeader
+	RawEvents               []*nodeapi.SdkEvent
+	TransactionsWithResults []*nodeapi.RuntimeTransactionWithResults
 }
 
 // TransactionWithResults contains a verified transaction, and the results of

--- a/storage/api.go
+++ b/storage/api.go
@@ -161,11 +161,11 @@ type BeaconData struct {
 type RegistryData struct {
 	Height int64
 
-	Events             []nodeapi.Event
-	RuntimeEvents      []nodeapi.RuntimeEvent
-	EntityEvents       []nodeapi.EntityEvent
-	NodeEvents         []nodeapi.NodeEvent
-	NodeUnfrozenEvents []nodeapi.NodeUnfrozenEvent
+	Events                  []nodeapi.Event
+	RuntimeRegisteredEvents []nodeapi.RuntimeRegisteredEvent
+	EntityEvents            []nodeapi.EntityEvent
+	NodeEvents              []nodeapi.NodeEvent
+	NodeUnfrozenEvents      []nodeapi.NodeUnfrozenEvent
 }
 
 // StakingData represents data for accounts at a given height.
@@ -233,7 +233,7 @@ type RuntimeSourceStorage interface {
 type RuntimeAllData struct {
 	Round                   uint64
 	BlockHeader             nodeapi.RuntimeBlockHeader
-	RawEvents               []*nodeapi.SdkEvent
+	RawEvents               []*nodeapi.RuntimeEvent
 	TransactionsWithResults []*nodeapi.RuntimeTransactionWithResults
 }
 

--- a/storage/api.go
+++ b/storage/api.go
@@ -224,9 +224,6 @@ type RuntimeSourceStorage interface {
 	// EVMSimulateCall gets the result of the given EVM simulate call query.
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 
-	// Name returns the name of the source storage.
-	Name() string
-
 	// StringifyDenomination returns a string representation of the given denomination.
 	// This is simply the denomination's symbol; notably, for the native denomination,
 	// this is looked up from network config.

--- a/storage/api.go
+++ b/storage/api.go
@@ -251,17 +251,13 @@ type RuntimeAllData struct {
 
 // RuntimeBlockData represents data for a runtime block during a given round.
 type RuntimeBlockData struct {
-	Round uint64
-
-	BlockHeader             *block.Block
+	BlockHeader             *block.Header
 	TransactionsWithResults []*client.TransactionWithResults
 }
 
 // TransactionWithResults contains a verified transaction, and the results of
 // executing that transactions.
 type TransactionWithResults struct {
-	Round uint64
-
 	Tx     *sdkTypes.Transaction
 	Result sdkTypes.CallResult
 	Events []*sdkTypes.Event

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -13,7 +13,6 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi/damask"
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	runtimeSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -110,12 +109,8 @@ func (cf *ClientFactory) Runtime(runtimeID string) (*RuntimeClient, error) {
 		return nil, err
 	}
 
-	rtCtx := runtimeSignature.DeriveChainContext(info.ID, cf.network.ChainContext)
 	return &RuntimeClient{
-		client:   client,
-		grpcConn: grpcConn,
-		network:  cf.network,
-		info:     info,
-		rtCtx:    rtCtx,
+		nodeApi: nodeapi.NewUniversalRuntimeApiLite(info.ID, grpcConn, &client),
+		info:    info,
 	}, nil
 }

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -16,6 +16,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 const (
@@ -24,8 +25,9 @@ const (
 
 // ClientFactory supports connections to an oasis-node instance.
 type ClientFactory struct {
-	connection *connection.Connection
-	network    *config.Network
+	connection        *connection.Connection
+	rawGrpcConnection *grpc.ClientConn
+	network           *config.Network
 }
 
 // NewClientFactory creates a new oasis-node client factory.
@@ -43,10 +45,15 @@ func NewClientFactory(ctx context.Context, network *config.Network, skipChainCon
 	if err != nil {
 		return nil, err
 	}
+	rawConn, err := ConnectNoVerify(ctx, network)
+	if err != nil {
+		return nil, err
+	}
 
 	return &ClientFactory{
-		connection: &conn,
-		network:    network,
+		connection:        &conn,
+		rawGrpcConnection: rawConn,
+		network:           network,
 	}, nil
 }
 
@@ -59,13 +66,7 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 	var nodeApi nodeapi.ConsensusApiLite
 	if cf.network.ChainContext == "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898" {
 		// Cobalt mainnet.
-		creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-		dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-		grpcConn, err := cmnGrpc.Dial(cf.network.RPC, dialOpts...)
-		if err != nil {
-			return nil, err
-		}
-		nodeApi = cobalt.NewCobaltConsensusApiLite(grpcConn)
+		nodeApi = cobalt.NewCobaltConsensusApiLite(cf.rawGrpcConnection)
 	} else {
 		// Assume Damask.
 		client := (*cf.connection).Consensus()
@@ -87,30 +88,38 @@ func (cf *ClientFactory) Consensus() (*ConsensusClient, error) {
 func (cf *ClientFactory) Runtime(runtimeID string) (*RuntimeClient, error) {
 	ctx := context.Background()
 
-	// A new runtime client, with convenience methods implemented by oasis-sdk.
-	connection := *cf.connection
-	client := connection.Runtime(&config.ParaTime{
-		ID: runtimeID,
-	})
-
-	// A raw gRPC client to the node, for accessing archive nodes with incompatible CBOR types.
-	creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
-	grpcConn, err := cmnGrpc.Dial(cf.network.RPC, dialOpts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// Configure chain context for all signatures using chain domain separation.
-	signature.SetChainContext(cf.network.ChainContext)
-
+	client := (*cf.connection).Runtime(&config.ParaTime{ID: runtimeID})
 	info, err := client.GetInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
 
+	nodeApi := nodeapi.NewUniversalRuntimeApiLite(info.ID, cf.rawGrpcConnection, &client)
+
+	// Configure chain context for all signatures using chain domain separation.
+	signature.SetChainContext(cf.network.ChainContext)
+
 	return &RuntimeClient{
-		nodeApi: nodeapi.NewUniversalRuntimeApiLite(info.ID, grpcConn, &client),
+		nodeApi: nodeApi,
 		info:    info,
 	}, nil
+}
+
+// ConnectNoVerify establishes gRPC connection with the target URL,
+// omitting the chain context check.
+// This is a clone of the oasis-copy `ConnectNoVerify()` function,
+// but returns a raw gRPC connection instead of the oasis-sdk `Connection` wrapper.
+func ConnectNoVerify(ctx context.Context, net *config.Network) (*grpc.ClientConn, error) {
+	var dialOpts []grpc.DialOption
+	switch net.IsLocalRPC() {
+	case true:
+		// No TLS needed for local nodes.
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	case false:
+		// Configure TLS for non-local nodes.
+		creds := credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
+	}
+
+	return cmnGrpc.Dial(net.RPC, dialOpts...)
 }

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -138,15 +138,15 @@ func (cc *ConsensusClient) RegistryData(ctx context.Context, height int64) (*sto
 		return nil, err
 	}
 
-	var runtimeEvents []nodeapi.RuntimeEvent
+	var runtimeRegisteredEvents []nodeapi.RuntimeRegisteredEvent
 	var entityEvents []nodeapi.EntityEvent
 	var nodeEvents []nodeapi.NodeEvent
 	var nodeUnfrozenEvents []nodeapi.NodeUnfrozenEvent
 
 	for _, event := range events {
 		switch e := event; {
-		case e.RegistryRuntime != nil:
-			runtimeEvents = append(runtimeEvents, *e.RegistryRuntime)
+		case e.RegistryRuntimeRegistered != nil:
+			runtimeRegisteredEvents = append(runtimeRegisteredEvents, *e.RegistryRuntimeRegistered)
 		case e.RegistryEntity != nil:
 			entityEvents = append(entityEvents, *e.RegistryEntity)
 		case e.RegistryNode != nil:
@@ -157,12 +157,12 @@ func (cc *ConsensusClient) RegistryData(ctx context.Context, height int64) (*sto
 	}
 
 	return &storage.RegistryData{
-		Height:             height,
-		Events:             events,
-		RuntimeEvents:      runtimeEvents,
-		EntityEvents:       entityEvents,
-		NodeEvents:         nodeEvents,
-		NodeUnfrozenEvents: nodeUnfrozenEvents,
+		Height:                  height,
+		Events:                  events,
+		RuntimeRegisteredEvents: runtimeRegisteredEvents,
+		EntityEvents:            entityEvents,
+		NodeEvents:              nodeEvents,
+		NodeUnfrozenEvents:      nodeUnfrozenEvents,
 	}, nil
 }
 

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -21,6 +21,10 @@ import (
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
+// ....................................................
+// ....................  Consensus  ...................
+// ....................................................
+
 // ConsensusApiLite provides low-level access to the consensus API of one or
 // more (versions of) Oasis nodes.
 //
@@ -48,18 +52,6 @@ type ConsensusApiLite interface {
 	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*Proposal, error)
 }
-
-// Like ConsensusApiLite, but for the runtime API.
-type RuntimeApiLite interface {
-	GetEventsRaw(ctx context.Context, round uint64) ([]*RuntimeEvent, error)
-	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
-	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
-	GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error)
-}
-
-type RuntimeEvent sdkTypes.Event
-type RuntimeBlockHeader roothash.Header
-type RuntimeTransactionWithResults sdkClient.TransactionWithResults
 
 // A lightweight subset of `consensus.TransactionsWithResults`.
 type TransactionWithResults struct {
@@ -184,3 +176,21 @@ type (
 // .................... Governance ....................
 
 type Proposal governance.Proposal
+
+// ....................................................
+// ....................  Runtimes  ....................
+// ....................................................
+
+// Like ConsensusApiLite, but for the runtime API.
+type RuntimeApiLite interface {
+	GetEventsRaw(ctx context.Context, round uint64) ([]*RuntimeEvent, error)
+	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
+	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
+	GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error)
+}
+
+type (
+	RuntimeEvent                  sdkTypes.Event
+	RuntimeBlockHeader            roothash.Header
+	RuntimeTransactionWithResults sdkClient.TransactionWithResults
+)

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -2,8 +2,10 @@ package nodeapi
 
 import (
 	"context"
+	"time"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
+	"github.com/oasisprotocol/oasis-core/go/common"
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 	hash "github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -13,7 +15,6 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -191,6 +192,25 @@ type RuntimeApiLite interface {
 
 type (
 	RuntimeEvent                  sdkTypes.Event
-	RuntimeBlockHeader            roothash.Header
 	RuntimeTransactionWithResults sdkClient.TransactionWithResults
 )
+
+// Derived from oasis-core: roothash/api/block/header.go
+// Expanded to include the precomputed hash of the header;
+// we mustn't compute it on the fly because depending on the
+// node version, this header struct might not be the exact struct
+// returned from the node, so its real hash will differ.
+type RuntimeBlockHeader struct { // nolint: maligned
+	Version   uint16
+	Namespace common.Namespace
+	Round     uint64
+	Timestamp time.Time
+	// Hash of the raw header struct as received from the node API.
+	// The `PreviousHash` of the next round's block should match this.
+	Hash           hash.Hash
+	PreviousHash   hash.Hash
+	IORoot         hash.Hash
+	StateRoot      hash.Hash
+	MessagesHash   hash.Hash
+	InMessagesHash hash.Hash // NOTE: Available starting in Damask.
+}

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -51,12 +51,13 @@ type ConsensusApiLite interface {
 
 // Like ConsensusApiLite, but for the runtime API.
 type RuntimeApiLite interface {
-	GetEventsRaw(ctx context.Context, round uint64) ([]*SdkEvent, error)
+	GetEventsRaw(ctx context.Context, round uint64) ([]*RuntimeEvent, error)
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
 	GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error)
 }
-type SdkEvent sdkTypes.Event
+
+type RuntimeEvent sdkTypes.Event
 type RuntimeBlockHeader roothash.Header
 type RuntimeTransactionWithResults sdkClient.TransactionWithResults
 
@@ -98,10 +99,10 @@ type Event struct {
 	StakingDebondingStart       *DebondingStartEscrowEvent // Available starting in Damask.
 	StakingAllowanceChange      *AllowanceChangeEvent
 
-	RegistryRuntime      *RuntimeEvent
-	RegistryEntity       *EntityEvent
-	RegistryNode         *NodeEvent
-	RegistryNodeUnfrozen *NodeUnfrozenEvent
+	RegistryRuntimeRegistered *RuntimeRegisteredEvent
+	RegistryEntity            *EntityEvent
+	RegistryNode              *NodeEvent
+	RegistryNodeUnfrozen      *NodeUnfrozenEvent
 
 	RoothashExecutorCommitted *ExecutorCommittedEvent
 
@@ -124,8 +125,8 @@ type (
 
 // .................... Registry ....................
 
-// RuntimeEvent signifies new runtime registration.
-type RuntimeEvent struct {
+// RuntimeRegisteredEvent signifies new runtime registration.
+type RuntimeRegisteredEvent struct {
 	ID          coreCommon.Namespace
 	EntityID    signature.PublicKey   // The Entity controlling the runtime.
 	Kind        string                // enum: "compute", "keymanager"

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -118,6 +118,8 @@ type (
 // .................... Registry ....................
 
 // RuntimeRegisteredEvent signifies new runtime registration.
+// This is a stripped-down version of an unfortunately named `registry.RuntimeEvent` (in Cobalt and Damask).
+// Post-Damask, this is replaced by registry.RuntimeStartedEvent.
 type RuntimeRegisteredEvent struct {
 	ID          coreCommon.Namespace
 	EntityID    signature.PublicKey   // The Entity controlling the runtime.

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -13,9 +13,12 @@ import (
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	governance "github.com/oasisprotocol/oasis-core/go/governance/api"
 	registry "github.com/oasisprotocol/oasis-core/go/registry/api"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	scheduler "github.com/oasisprotocol/oasis-core/go/scheduler/api"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
+	sdkClient "github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
+	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
 // ConsensusApiLite provides low-level access to the consensus API of one or
@@ -45,6 +48,17 @@ type ConsensusApiLite interface {
 	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*Proposal, error)
 }
+
+// Like ConsensusApiLite, but for the runtime API.
+type RuntimeApiLite interface {
+	GetEventsRaw(ctx context.Context, round uint64) ([]*SdkEvent, error)
+	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
+	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
+	GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error)
+}
+type SdkEvent = sdkTypes.Event
+type RuntimeBlockHeader = roothash.Header
+type RuntimeTransactionWithResults = sdkClient.TransactionWithResults
 
 // A lightweight subset of `consensus.TransactionsWithResults`.
 type TransactionWithResults struct {

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -56,9 +56,9 @@ type RuntimeApiLite interface {
 	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
 	GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error)
 }
-type SdkEvent = sdkTypes.Event
-type RuntimeBlockHeader = roothash.Header
-type RuntimeTransactionWithResults = sdkClient.TransactionWithResults
+type SdkEvent sdkTypes.Event
+type RuntimeBlockHeader roothash.Header
+type RuntimeTransactionWithResults sdkClient.TransactionWithResults
 
 // A lightweight subset of `consensus.TransactionsWithResults`.
 type TransactionWithResults struct {

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common"
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 	hash "github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/signature"
@@ -200,9 +199,9 @@ type (
 // we mustn't compute it on the fly because depending on the
 // node version, this header struct might not be the exact struct
 // returned from the node, so its real hash will differ.
-type RuntimeBlockHeader struct { // nolint: maligned
+type RuntimeBlockHeader struct { //nolint: maligned
 	Version   uint16
-	Namespace common.Namespace
+	Namespace coreCommon.Namespace
 	Round     uint64
 	Timestamp time.Time
 	// Hash of the raw header struct as received from the node API.

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -225,7 +225,7 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 		switch {
 		case e.Registry.RuntimeEvent != nil && e.Registry.RuntimeEvent.Runtime != nil:
 			ret = nodeapi.Event{
-				RegistryRuntime: &nodeapi.RuntimeEvent{
+				RegistryRuntimeRegistered: &nodeapi.RuntimeRegisteredEvent{
 					ID:          e.Registry.RuntimeEvent.Runtime.ID,
 					EntityID:    e.Registry.RuntimeEvent.Runtime.EntityID,
 					Kind:        e.Registry.RuntimeEvent.Runtime.Kind.String(),

--- a/storage/oasis/nodeapi/damask/convert.go
+++ b/storage/oasis/nodeapi/damask/convert.go
@@ -71,7 +71,7 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 		switch {
 		case e.Registry.RuntimeEvent != nil && e.Registry.RuntimeEvent.Runtime != nil:
 			ret = nodeapi.Event{
-				RegistryRuntime: &nodeapi.RuntimeEvent{
+				RegistryRuntimeRegistered: &nodeapi.RuntimeRegisteredEvent{
 					ID:          e.Registry.RuntimeEvent.Runtime.ID,
 					EntityID:    e.Registry.RuntimeEvent.Runtime.EntityID,
 					Kind:        e.Registry.RuntimeEvent.Runtime.Kind.String(),

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -101,16 +101,16 @@ func (rc *UniversalRuntimeApiLite) GetTransactionsWithResults(ctx context.Contex
 	return txrs, nil
 }
 
-func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint64) ([]*SdkEvent, error) {
+func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint64) ([]*RuntimeEvent, error) {
 	rsp, err := rc.sdkClient.GetEventsRaw(ctx, round)
 	if err != nil {
 		return nil, err
 	}
 
 	// Convert to indexer-internal type.
-	evs := make([]*SdkEvent, len(rsp))
+	evs := make([]*RuntimeEvent, len(rsp))
 	for i, ev := range rsp {
-		evs[i] = (*SdkEvent)(ev)
+		evs[i] = (*RuntimeEvent)(ev)
 	}
 
 	return evs, nil

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -92,7 +92,7 @@ func (rc *UniversalRuntimeApiLite) GetTransactionsWithResults(ctx context.Contex
 		return nil, err
 	}
 
-	// Convert to indexer-internal type
+	// Convert to indexer-internal type.
 	txrs := make([]*RuntimeTransactionWithResults, len(rsp))
 	for i, txr := range rsp {
 		txrs[i] = (*RuntimeTransactionWithResults)(txr)
@@ -107,7 +107,7 @@ func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint6
 		return nil, err
 	}
 
-	// Convert to indexer-internal type
+	// Convert to indexer-internal type.
 	evs := make([]*SdkEvent, len(rsp))
 	for i, ev := range rsp {
 		evs[i] = (*SdkEvent)(ev)

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -1,0 +1,121 @@
+package nodeapi
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+
+	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	coreRuntimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
+	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
+)
+
+// Implementation of `RuntimeApiLite` that supports all versions of the node ABI
+// and all versions of the oasis-sdk ABI. (SDK events are CBOR-encoded according
+// to the SDK ABI, then embedded into the node's `Event` type, which is fetched
+// using the node ABI.)
+//
+// There are very few differences in the ABIs that RuntimeApiLite cares about,
+// so we implement support for all (= both) versions here, using trial-and-error
+// decoding where needed, rather than creating a new RuntimeApiLite
+// implementation for every ABI version combination.
+type UniversalRuntimeApiLite struct {
+	runtimeID coreCommon.Namespace
+
+	// A raw gRPC connection to the node. Used for fetching raw CBOR-encoded
+	// responses for RPCs whose encodings changed over time, and this class
+	// needs to handle the various formats/types.
+	grpcConn *grpc.ClientConn
+
+	// An oasis-sdk managed connection to the node. Used for RPCs that have
+	// had a stable ABI over time. That is the majority of them, and oasis-sdk
+	// provides nontrivial wrappers/parsing around raw RPC responses, making
+	// this preferable to raw gRPC.
+	sdkClient *connection.RuntimeClient
+}
+
+var _ RuntimeApiLite = (*UniversalRuntimeApiLite)(nil)
+
+func NewUniversalRuntimeApiLite(runtimeID coreCommon.Namespace, grpcConn *grpc.ClientConn, sdkClient *connection.RuntimeClient) *UniversalRuntimeApiLite {
+	return &UniversalRuntimeApiLite{
+		runtimeID: runtimeID,
+		grpcConn:  grpcConn,
+		sdkClient: sdkClient,
+	}
+}
+
+func (rc *UniversalRuntimeApiLite) GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error) {
+	// Fetch the raw CBOR first, decode later.
+	var rsp cbor.RawMessage
+	if err := rc.grpcConn.Invoke(ctx, "/oasis-core.RuntimeClient/GetBlock", &coreRuntimeClient.GetBlockRequest{
+		RuntimeID: rc.runtimeID,
+		Round:     round,
+	}, &rsp); err != nil {
+		return nil, err
+	}
+
+	// Try parsing the GetBlock response against two ABIs: Cobalt, and post-Cobalt.
+	var header RuntimeBlockHeader
+	var block roothash.Block
+	var cobaltBlock cobaltRoothash.Block
+	if err := cbor.Unmarshal(rsp, &block); err == nil {
+		// This is a post-Cobalt block. We use the same type internally in indexer.
+		header = RuntimeBlockHeader(block.Header)
+	} else if err := cbor.Unmarshal(rsp, &cobaltBlock); err == nil {
+		// This is a Cobalt block. Convert it to our internal format (= post-Cobalt block).
+		header = RuntimeBlockHeader{
+			Version:        cobaltBlock.Header.Version,
+			Namespace:      cobaltBlock.Header.Namespace,
+			Round:          cobaltBlock.Header.Round,
+			Timestamp:      roothash.Timestamp(cobaltBlock.Header.Timestamp),
+			HeaderType:     roothash.HeaderType(cobaltBlock.Header.HeaderType), // We assume a backwards-compatible enum.
+			IORoot:         cobaltBlock.Header.IORoot,
+			StateRoot:      cobaltBlock.Header.StateRoot,
+			MessagesHash:   cobaltBlock.Header.MessagesHash,
+			InMessagesHash: hash.Hash{}, // Absent in Cobalt.
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported runtime block structure: %#v", rsp)
+	}
+	return &header, nil
+}
+
+func (rc *UniversalRuntimeApiLite) GetTransactionsWithResults(ctx context.Context, round uint64) ([]*RuntimeTransactionWithResults, error) {
+	rsp, err := rc.sdkClient.GetTransactionsWithResults(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to indexer-internal type
+	txrs := make([]*RuntimeTransactionWithResults, len(rsp))
+	for i, txr := range rsp {
+		txrs[i] = (*RuntimeTransactionWithResults)(txr)
+	}
+
+	return txrs, nil
+}
+
+func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint64) ([]*SdkEvent, error) {
+	rsp, err := rc.sdkClient.GetEventsRaw(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to indexer-internal type
+	evs := make([]*SdkEvent, len(rsp))
+	for i, ev := range rsp {
+		evs[i] = (*SdkEvent)(ev)
+	}
+
+	return evs, nil
+}
+
+func (rc *UniversalRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
+	return evm.NewV1(rc.sdkClient).SimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
+}

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -2,7 +2,6 @@ package oasis
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
@@ -11,7 +10,11 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
 
-// RuntimeClient is a client to a ParaTime.
+// RuntimeClient is a client to a runtime. Unlike RuntimeApiLite implementations,
+// which provide a 1:1 mapping to the Oasis node's runtime RPCs, this client
+// is higher-level and provides a more convenient interface for the indexer.
+//
+// TODO: Get rid of this struct, it hardly provides any value.
 type RuntimeClient struct {
 	nodeApi nodeapi.RuntimeApiLite
 	info    *sdkTypes.RuntimeInfo
@@ -43,24 +46,6 @@ func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.Ru
 
 func (rc *RuntimeClient) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
 	return rc.nodeApi.EVMSimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
-}
-
-// Name returns the name of the client, for the RuntimeSourceStorage interface.
-func (rc *RuntimeClient) Name() string {
-	paratimeName := "unknown"
-	for _, network := range config.DefaultNetworks.All {
-		for pName := range network.ParaTimes.All {
-			if pName == rc.info.ID.String() {
-				paratimeName = pName
-				break
-			}
-		}
-
-		if paratimeName != "unknown" {
-			break
-		}
-	}
-	return fmt.Sprintf("%s_runtime", paratimeName)
 }
 
 func (rc *RuntimeClient) nativeTokenSymbol() string {

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -52,6 +52,9 @@ func (rc *RuntimeClient) nativeTokenSymbol() string {
 	for _, network := range config.DefaultNetworks.All {
 		// Iterate over all networks and find the one that contains the runtime.
 		// Any network will do; we assume that paratime IDs are unique across networks.
+		// TODO: Remove this assumption; paratime IDs are chosen by the entity that registers them,
+		// so conflicts (particularly intentional/malicious) are possible.
+		// https://github.com/oasisprotocol/oasis-indexer/pull/362#discussion_r1153606360
 		for _, paratime := range network.ParaTimes.All {
 			if paratime.ID == rc.info.ID.Hex() {
 				return paratime.Denominations[config.NativeDenominationKey].Symbol

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -4,17 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"google.golang.org/grpc"
-
-	"github.com/oasisprotocol/oasis-core/go/common/cbor"
-	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
-	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
-	coreRuntimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
-	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
-	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	runtimeSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/storage"
@@ -22,89 +13,36 @@ import (
 
 // RuntimeClient is a client to a ParaTime.
 type RuntimeClient struct {
-	client   connection.RuntimeClient
-	grpcConn *grpc.ClientConn
-	network  *config.Network
-
-	info  *sdkTypes.RuntimeInfo
-	rtCtx runtimeSignature.Context
+	nodeApi nodeapi.RuntimeApiLite
+	info    *sdkTypes.RuntimeInfo
 }
 
 // AllData returns all relevant data to the given round.
 func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.RuntimeAllData, error) {
-	blockData, err := rc.BlockData(ctx, round)
+	blockHeader, err := rc.nodeApi.GetBlockHeader(ctx, round)
 	if err != nil {
 		return nil, err
 	}
-	rawEvents, err := rc.GetEventsRaw(ctx, round)
+	rawEvents, err := rc.nodeApi.GetEventsRaw(ctx, round)
+	if err != nil {
+		return nil, err
+	}
+	transactionsWithResults, err := rc.nodeApi.GetTransactionsWithResults(ctx, round)
 	if err != nil {
 		return nil, err
 	}
 
 	data := storage.RuntimeAllData{
-		Round:     round,
-		BlockData: blockData,
-		RawEvents: rawEvents,
+		Round:                   round,
+		BlockHeader:             *blockHeader,
+		RawEvents:               rawEvents,
+		TransactionsWithResults: transactionsWithResults,
 	}
 	return &data, nil
 }
 
-// BlockData gets block data in the specified round.
-func (rc *RuntimeClient) BlockData(ctx context.Context, round uint64) (*storage.RuntimeBlockData, error) {
-	// TODO: Extract this into a RuntimeApiLite interface.
-	// There are very few differences in the ABIs that RuntimeApiLite cares about, so we implement
-	// support for all (= both) versions here, in this trial-and-error fashion, rather than
-	// creating a new RuntimeApiLite implementation for every node version.
-
-	// Try parsing the GetBlock response against two ABIs: Cobalt, and post-Cobalt.
-	var rsp cbor.RawMessage
-	if err := rc.grpcConn.Invoke(ctx, "/oasis-core.RuntimeClient/GetBlock", &coreRuntimeClient.GetBlockRequest{
-		RuntimeID: rc.info.ID,
-		Round:     round,
-	}, &rsp); err != nil {
-		return nil, err
-	}
-	var block roothash.Block
-	var cobaltBlock cobaltRoothash.Block
-	if err := cbor.Unmarshal(rsp, &block); err != nil {
-		// This is a post-Cobalt block.
-		// We use the same type internally to represent blocks; no further action needed.
-	} else if err := cbor.Unmarshal(rsp, &cobaltBlock); err != nil {
-		// This is a Cobalt block. Convert it to our internal format (= post-Cobalt block).
-		block = roothash.Block{
-			Header: roothash.Header{
-				Version:        cobaltBlock.Header.Version,
-				Namespace:      cobaltBlock.Header.Namespace,
-				Round:          cobaltBlock.Header.Round,
-				Timestamp:      roothash.Timestamp(cobaltBlock.Header.Timestamp),
-				HeaderType:     roothash.HeaderType(cobaltBlock.Header.HeaderType), // We assume a backwards-compatible enum.
-				IORoot:         cobaltBlock.Header.IORoot,
-				StateRoot:      cobaltBlock.Header.StateRoot,
-				MessagesHash:   cobaltBlock.Header.MessagesHash,
-				InMessagesHash: hash.Hash{}, // Absent in Cobalt.
-			},
-		}
-	} else {
-		return nil, fmt.Errorf("unsupported runtime block structure: %#v", rsp)
-	}
-
-	transactionsWithResults, err := rc.client.GetTransactionsWithResults(ctx, round)
-	if err != nil {
-		return nil, err
-	}
-
-	return &storage.RuntimeBlockData{
-		BlockHeader:             &block.Header,
-		TransactionsWithResults: transactionsWithResults,
-	}, nil
-}
-
-func (rc *RuntimeClient) GetEventsRaw(ctx context.Context, round uint64) ([]*sdkTypes.Event, error) {
-	return rc.client.GetEventsRaw(ctx, round)
-}
-
 func (rc *RuntimeClient) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
-	return evm.NewV1(rc.client).SimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
+	return rc.nodeApi.EVMSimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
 }
 
 // Name returns the name of the client, for the RuntimeSourceStorage interface.

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -87,9 +87,8 @@ func (rc *RuntimeClient) Name() string {
 
 func (rc *RuntimeClient) nativeTokenSymbol() string {
 	for _, network := range config.DefaultNetworks.All {
-		if network.ChainContext != rc.network.ChainContext {
-			continue
-		}
+		// Iterate over all networks and find the one that contains the runtime.
+		// Any network will do; we assume that paratime IDs are unique across networks.
 		for _, paratime := range network.ParaTimes.All {
 			if paratime.ID == rc.info.ID.Hex() {
 				return paratime.Denominations[config.NativeDenominationKey].Symbol

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -54,8 +54,7 @@ func (rc *RuntimeClient) BlockData(ctx context.Context, round uint64) (*storage.
 	}
 
 	return &storage.RuntimeBlockData{
-		Round:                   round,
-		BlockHeader:             block,
+		BlockHeader:             &block.Header,
 		TransactionsWithResults: transactionsWithResults,
 	}, nil
 }

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/grpc"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
+	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
+	coreRuntimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
 	config "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
 	runtimeSignature "github.com/oasisprotocol/oasis-sdk/client-sdk/go/crypto/signature"
@@ -15,8 +22,9 @@ import (
 
 // RuntimeClient is a client to a ParaTime.
 type RuntimeClient struct {
-	client  connection.RuntimeClient
-	network *config.Network
+	client   connection.RuntimeClient
+	grpcConn *grpc.ClientConn
+	network  *config.Network
 
 	info  *sdkTypes.RuntimeInfo
 	rtCtx runtimeSignature.Context
@@ -43,9 +51,41 @@ func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.Ru
 
 // BlockData gets block data in the specified round.
 func (rc *RuntimeClient) BlockData(ctx context.Context, round uint64) (*storage.RuntimeBlockData, error) {
-	block, err := rc.client.GetBlock(ctx, round)
-	if err != nil {
+	// TODO: Extract this into a RuntimeApiLite interface.
+	// There are very few differences in the ABIs that RuntimeApiLite cares about, so we implement
+	// support for all (= both) versions here, in this trial-and-error fashion, rather than
+	// creating a new RuntimeApiLite implementation for every node version.
+
+	// Try parsing the GetBlock response against two ABIs: Cobalt, and post-Cobalt.
+	var rsp cbor.RawMessage
+	if err := rc.grpcConn.Invoke(ctx, "/oasis-core.RuntimeClient/GetBlock", &coreRuntimeClient.GetBlockRequest{
+		RuntimeID: rc.info.ID,
+		Round:     round,
+	}, &rsp); err != nil {
 		return nil, err
+	}
+	var block roothash.Block
+	var cobaltBlock cobaltRoothash.Block
+	if err := cbor.Unmarshal(rsp, &block); err != nil {
+		// This is a post-Cobalt block.
+		// We use the same type internally to represent blocks; no further action needed.
+	} else if err := cbor.Unmarshal(rsp, &cobaltBlock); err != nil {
+		// This is a Cobalt block. Convert it to our internal format (= post-Cobalt block).
+		block = roothash.Block{
+			Header: roothash.Header{
+				Version:        cobaltBlock.Header.Version,
+				Namespace:      cobaltBlock.Header.Namespace,
+				Round:          cobaltBlock.Header.Round,
+				Timestamp:      roothash.Timestamp(cobaltBlock.Header.Timestamp),
+				HeaderType:     roothash.HeaderType(cobaltBlock.Header.HeaderType), // We assume a backwards-compatible enum.
+				IORoot:         cobaltBlock.Header.IORoot,
+				StateRoot:      cobaltBlock.Header.StateRoot,
+				MessagesHash:   cobaltBlock.Header.MessagesHash,
+				InMessagesHash: hash.Hash{}, // Absent in Cobalt.
+			},
+		}
+	} else {
+		return nil, fmt.Errorf("unsupported runtime block structure: %#v", rsp)
 	}
 
 	transactionsWithResults, err := rc.client.GetTransactionsWithResults(ctx, round)

--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -125,6 +125,10 @@ func testRuntimeAccounts(t *testing.T, runtime string) {
 func nativeTokenSymbol(runtimeID string) string {
 	// Iterate over all networks and find the one that contains the runtime.
 	// Any network will do; we assume that paratime IDs are unique across networks.
+	// TODO: Remove this assumption; paratime IDs are chosen by the entity that registers them,
+	// so conflicts (particularly intentional/malicious) are possible. Not that
+	// it would hurt the statecheck much, beyond generating a false alarm.
+	// https://github.com/oasisprotocol/oasis-indexer/pull/362#discussion_r1153606360
 	for _, network := range config.DefaultNetworks.All {
 		for _, paratime := range network.ParaTimes.All {
 			if paratime.ID == runtimeID {


### PR DESCRIPTION
This PR brings support for indexing "old" runtime blocks. Changes:
- Refactor: Extracts all runtime-related gRPC methods into a new RuntimeApiLite class. This mirrors the existing ConsensusApiLite in scope: provides 1:1 mapping to a subset of RPCs, responses are encoded in indexer-internal types. (Those types often contain fields from the latest oasis-core or oasis-sdk, so we're not fully disconnected from them, but it's a step in the right direction.)
- Tweaks GetBlock() so it supports old rounds. This is actually a Cobalt vs Damask issue, because we ask technically ask _consensus_ (specifically, its `roothash` app) for the runtime block info. And its API has changed going from Cobalt to Damask.
- Reimplements event parsing from oasis-sdk (and uses this reimplementation) such that each SDK Event CBOR is parsed as either a) a list of events or b) a single event. Structure (a) is used for most rounds; structure (b) is used for a few 1000 earliest rounds of Emerald :)

Testing:
- Indexed emerald from blocks 1 to 114_297, and also at recent heights. No crashes/errors.
- `reindex_and_run.sh` for 100 rounds in Damask.