### PR TITLE
bugfix: Ignore entities with no address

### DIFF
--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -98,15 +98,26 @@ const (
 
 	Entities = `
 		SELECT id, address
-			FROM chain.entities
+		FROM chain.entities
+		-- The metadata_registry analyzer does not receive entity addresses from git, only metadata.
+		-- Addresses come from registry events in the consensus layer. Ignore entities that only the
+		-- metadata_registry analyzer knows about; they are irrelevant to the current state of the
+		-- chain, and our API guarantees a non-null address.
+		WHERE (address IS NOT NULL)
 		ORDER BY id
 		LIMIT $1::bigint
 		OFFSET $2::bigint`
 
 	Entity = `
 		SELECT id, address
-			FROM chain.entities
-			WHERE id = $1::text`
+		FROM chain.entities
+		WHERE
+			(id = $1::text) AND
+			-- The metadata_registry analyzer does not receive entity addresses from git, only metadata.
+			-- Addresses come from registry events in the consensus layer. Ignore entities that only the
+			-- metadata_registry analyzer knows about; they are irrelevant to the current state of the
+			-- chain, and our API guarantees a non-null address.
+			(address IS NOT NULL)`
 
 	EntityNodeIds = `
 		SELECT id


### PR DESCRIPTION
Fixes a bug where the the indexer API potentially returned a HTTP 5xx because it tried to scan a NULL address for an entity into a string. See inline comments for explanation.

The bug was introduced in https://github.com/oasisprotocol/oasis-indexer/pull/351 which changed `UPDATE chain.entities SET meta=...` into an upsert, potentially creating a new entity row with no known address. The regression wasn't caught by that PR's e2e tests because it depends on a specific sequencing of two analyzers that (can) work in parallel.

We could introduce the old behavior (UPDATE instead of upsert), but the current behavior has the advantage that we'll be able to show an entity with all its metadata as soon as we scan its registration on the chain, instead of waiting for the metadata analyzer to do its periodic re-scan of git. I'm open to both solutions though; the advantage of UPDATE is that it's conceptually a little simpler.