### PR TITLE
 storage client: get entire address preimage 

### DIFF
--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/client"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis"
 )
 
@@ -162,11 +163,11 @@ func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTok
 func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.QueryBatch, staleTokenBalance *StaleTokenBalance) error {
 	m.logger.Info("downloading", "stale_token_balance", staleTokenBalance)
 	// todo: assert that token addr and account addr contexts are secp256k1
-	tokenEthAddr, err := runtime.EVMEthAddrFromPreimage(staleTokenBalance.TokenAddrContextIdentifier, staleTokenBalance.TokenAddrContextVersion, staleTokenBalance.TokenAddrData)
+	tokenEthAddr, err := client.EVMEthAddrFromPreimage(staleTokenBalance.TokenAddrContextIdentifier, staleTokenBalance.TokenAddrContextVersion, staleTokenBalance.TokenAddrData)
 	if err != nil {
 		return fmt.Errorf("token address: %w", err)
 	}
-	accountEthAddr, err := runtime.EVMEthAddrFromPreimage(staleTokenBalance.AccountAddrContextIdentifier, staleTokenBalance.AccountAddrContextVersion, staleTokenBalance.AccountAddrData)
+	accountEthAddr, err := client.EVMEthAddrFromPreimage(staleTokenBalance.AccountAddrContextIdentifier, staleTokenBalance.AccountAddrContextVersion, staleTokenBalance.AccountAddrData)
 	if err != nil {
 		return fmt.Errorf("account address: %w", err)
 	}

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/client"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis"
 )
 
@@ -107,7 +108,7 @@ func (m Main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, err
 
 func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, staleToken *StaleToken) error {
 	m.logger.Info("downloading", "stale_token", staleToken)
-	tokenEthAddr, err := runtime.EVMEthAddrFromPreimage(staleToken.AddrContextIdentifier, staleToken.AddrContextVersion, staleToken.AddrData)
+	tokenEthAddr, err := client.EVMEthAddrFromPreimage(staleToken.AddrContextIdentifier, staleToken.AddrContextVersion, staleToken.AddrData)
 	if err != nil {
 		return fmt.Errorf("token address: %w", err)
 	}

--- a/analyzer/runtime/evm.go
+++ b/analyzer/runtime/evm.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	ethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/oasisprotocol/oasis-core/go/common/errors"
-	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer/evmabi"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -75,16 +74,6 @@ var (
 	// https://github.com/oasisprotocol/oasis-sdk/blob/runtime-sdk/v0.2.0/runtime-sdk/modules/evm/src/lib.rs#L147
 	ErrEVMReverted = errors.New(EVMModuleName, 8, "reverted")
 )
-
-func EVMEthAddrFromPreimage(contextIdentifier string, contextVersion int, data []byte) ([]byte, error) {
-	if contextIdentifier != sdkTypes.AddressV0Secp256k1EthContext.Identifier {
-		return nil, fmt.Errorf("preimage context identifier %q, expecting %q", contextIdentifier, sdkTypes.AddressV0Secp256k1EthContext.Identifier)
-	}
-	if contextVersion != int(sdkTypes.AddressV0Secp256k1EthContext.Version) {
-		return nil, fmt.Errorf("preimage context version %d, expecting %d", contextVersion, sdkTypes.AddressV0Secp256k1EthContext.Version)
-	}
-	return data, nil
-}
 
 func evmCallWithABICustom(
 	ctx context.Context,

--- a/analyzer/uncategorized/addresses.go
+++ b/analyzer/uncategorized/addresses.go
@@ -3,8 +3,6 @@ package common
 import (
 	"fmt"
 
-	ethCommon "github.com/ethereum/go-ethereum/common"
-
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/address"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
@@ -44,15 +42,6 @@ func StringifyEthAddress(ethAddr []byte) (apiTypes.Address, error) {
 	ctx := sdkTypes.AddressV0Secp256k1EthContext
 	ocAddr := address.NewAddress(ctx, ethAddr)
 	return StringifyOcAddress(ocAddr)
-}
-
-func EthAddrReference(eth_addr_hex string) *string {
-	if len(eth_addr_hex) == 0 {
-		return nil
-	}
-
-	ref := ethCommon.HexToAddress(eth_addr_hex).String()
-	return &ref
 }
 
 func ExtractAddresses(accounts map[apiTypes.Address]bool) []string {

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -140,6 +140,12 @@ x-type-annotations:
     x-go-type: staking.Address
     x-go-type-import: { name: staking, path: "github.com/oasisprotocol/oasis-core/go/staking/api" }
     description: An oasis-style (bech32) address.
+  address: &AddressType
+    type: string
+    pattern: '^oasis1[a-z0-9]{40}$'
+    example: "oasis1qpg2xuz46g53737343r20yxeddhlvc2ldqsjh70p"
+    x-go-type: Address
+    description: An oasis-style (bech32) address.
   pubkey: &Ed25519PubKeyType
     type: string
     format: byte  # means base64-encoded raw bytes
@@ -2005,7 +2011,7 @@ components:
             Absent for non-Ethereum-format transactions.
           example: 9e6a5837c6366d4a7e477c71ffe32d40915cdef7ef209792259e5ee70caf2705
         sender_0:
-          type: string
+          <<: *AddressType
           description: |
             The Oasis address of this transaction's 0th signer.
             Unlike Ethereum, Oasis natively supports multiple-signature transactions.
@@ -2061,7 +2067,7 @@ components:
           description: The method call body. May be null if the transaction was malformed.
           example: {"address": "t1mAPucIdVnrYBpJOcLV2nZoOFo=", "data": RBo+cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "value": ""}
         to:
-          type: string
+          <<: *AddressType
           description: |
             A reasonable "to" Oasis address associated with this transaction,
             if applicable. The meaning varies based on the transaction method. Some notable examples:

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -16,8 +16,8 @@ import (
 	oasisErrors "github.com/oasisprotocol/oasis-core/go/common/errors"
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
-	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	apiCommon "github.com/oasisprotocol/oasis-indexer/api"
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
@@ -1031,11 +1031,21 @@ func (c *StorageClient) RuntimeBlocks(ctx context.Context, p apiTypes.GetRuntime
 	return &bs, nil
 }
 
+func EVMEthAddrFromPreimage(contextIdentifier string, contextVersion int, data []byte) ([]byte, error) {
+	if contextIdentifier != sdkTypes.AddressV0Secp256k1EthContext.Identifier {
+		return nil, fmt.Errorf("preimage context identifier %q, expecting %q", contextIdentifier, sdkTypes.AddressV0Secp256k1EthContext.Identifier)
+	}
+	if contextVersion != int(sdkTypes.AddressV0Secp256k1EthContext.Version) {
+		return nil, fmt.Errorf("preimage context version %d, expecting %d", contextVersion, sdkTypes.AddressV0Secp256k1EthContext.Version)
+	}
+	return data, nil
+}
+
 // EthChecksumAddrFromPreimage gives the friendly Ethereum-style mixed-case
 // checksum address (see ERC-55) for an address preimage or nil if the
 // preimage context is not AddressV0Secp256k1EthContext.
 func EthChecksumAddrFromPreimage(contextIdentifier string, contextVersion int, data []byte) *string {
-	ethAddr, err := runtime.EVMEthAddrFromPreimage(contextIdentifier, contextVersion, data)
+	ethAddr, err := EVMEthAddrFromPreimage(contextIdentifier, contextVersion, data)
 	if err != nil {
 		// Ignore error about the preimage not being AddressV0Secp256k1EthContext.
 		return nil


### PR DESCRIPTION
~~fixes #365~~

1. adjust some specs to use our custom string Address type
2. ~~get all related address preimage info when querying transaction~~
3. ~~don't set incorrect xxx_eth address when preimage is not secp256k1eth~~

EthAddrReference is moved out to client package. changed to EthChecksumAddrFromPreimage