### PR TITLE
add index for runtime rel tx queries

### DIFF
--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -78,6 +78,7 @@ CREATE TABLE chain.runtime_related_transactions
 );
 CREATE INDEX ix_runtime_related_transactions_address ON chain.runtime_related_transactions (runtime, account_address);
 CREATE INDEX ix_runtime_related_transactions_round_index ON chain.runtime_related_transactions (runtime, tx_round, tx_index);
+CREATE INDEX ix_runtime_related_transactions_address_round_index ON chain.runtime_related_transactions (runtime, account_address, tx_round, tx_index);
 
 -- Events emitted from the runtimes. Includes deeply-parsed EVM events from EVM runtimes.
 CREATE TABLE chain.runtime_events


### PR DESCRIPTION
@csillag reported that this query was timing out:
https://index-staging.oasislabs.com/v1/emerald/transactions?limit=10&offset=0&rel=oasis1qzl89gapk5y3e8fk6x7d6zrmz2qvedjsqg6q4lxp

Further investigation revealed that the query plan was not able to use the existing indexes effectively:
```QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.12..5141.91 rows=10 width=658) (actual time=26604.205..50493.305 rows=10 loops=1)
   ->  Nested Loop  (cost=1.12..22890383.61 rows=44527 width=658) (actual time=26604.203..50493.292 rows=10 loops=1)
         ->  Index Scan Backward using ix_runtime_related_transactions_round_index on runtime_related_transactions rel  (cost=0.56..22108269.69 rows=2775 width=16) (actual time=26599.103..50461.452 rows=10 loops=1)
               Index Cond: (runtime = 'emerald'::indexer.runtime)
               Filter: ((account_address)::text = 'oasis1qzl89gapk5y3e8fk6x7d6zrmz2qvedjsqg6q4lxp'::text)
               Rows Removed by Filter: 16653310
         ->  Index Scan using runtime_transactions_pkey on runtime_transactions txs  (cost=0.56..8.50 rows=1 width=630) (actual time=1.127..1.127 rows=1 loops=10)
               Index Cond: ((runtime = 'emerald'::indexer.runtime) AND ((round)::bigint = (rel.tx_round)::bigint) AND ((tx_index)::integer = (rel.tx_index)::integer))
         SubPlan 1
           ->  Aggregate  (cost=17.03..17.04 rows=1 width=32) (actual time=2.037..2.037 rows=1 loops=10)
                 ->  Nested Loop  (cost=0.98..17.02 rows=1 width=69) (actual time=0.487..2.001 rows=4 loops=10)
                       ->  Index Scan using ix_runtime_related_transactions_round_index on runtime_related_transactions rel_1  (cost=0.56..8.58 rows=1 width=47) (actual time=0.320..0.324 rows=4 loops=10)
                             Index Cond: ((runtime = txs.runtime) AND ((tx_round)::bigint = (txs.round)::bigint) AND ((tx_index)::integer = (txs.tx_index)::integer))
                       ->  Index Scan using address_preimages_pkey on address_preimages pre  (cost=0.41..8.43 rows=1 width=69) (actual time=0.415..0.415 rows=1 loops=40)
                             Index Cond: ((address)::text = (rel_1.account_address)::text)
 Planning Time: 0.913 ms
 Execution Time: 50493.390 ms
```

We do have indexes for `address` and `(round, index)` separately, but most rel tx queries normally have `order by round desc` and require filtering on both address and round. The query planner ends up traversing the txs in reverse chronological order until it finds enough txs that are linked to the rel address, which becomes problematic at scale.

Adding this index reduces the query time back to ~5ms in staging testing.