### PR TITLE
bugfix: Make entities.address NOT NULL

### DIFF
--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	registry "github.com/oasisprotocol/metadata-registry-tools"
+	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/config"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -79,6 +80,7 @@ func (a *MetadataRegistryAnalyzer) queueUpdates(ctx context.Context, batch *stor
 		batch.Queue(
 			queries.ConsensusEntityMetaUpsert,
 			id.String(),
+			staking.NewAddress(id).String(),
 			meta,
 		)
 	}

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -116,10 +116,10 @@ const (
     DELETE FROM chain.nodes WHERE id = $1`
 
 	ConsensusEntityMetaUpsert = `
-    INSERT INTO chain.entities(id, meta)
-      VALUES ($1, $2)
-    ON CONFLICT (id) DO UPDATE
-      SET meta = $2`
+    INSERT INTO chain.entities(id, address, meta)
+      VALUES ($1, $2, $3)
+    ON CONFLICT (id) DO UPDATE SET
+      meta = excluded.meta`
 
 	ConsensusIncreaseGeneralBalanceUpsert = `
     INSERT INTO chain.accounts (address, general_balance)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -98,26 +98,15 @@ const (
 
 	Entities = `
 		SELECT id, address
-		FROM chain.entities
-		-- The metadata_registry analyzer does not receive entity addresses from git, only metadata.
-		-- Addresses come from registry events in the consensus layer. Ignore entities that only the
-		-- metadata_registry analyzer knows about; they are irrelevant to the current state of the
-		-- chain, and our API guarantees a non-null address.
-		WHERE (address IS NOT NULL)
+			FROM chain.entities
 		ORDER BY id
 		LIMIT $1::bigint
 		OFFSET $2::bigint`
 
 	Entity = `
 		SELECT id, address
-		FROM chain.entities
-		WHERE
-			(id = $1::text) AND
-			-- The metadata_registry analyzer does not receive entity addresses from git, only metadata.
-			-- Addresses come from registry events in the consensus layer. Ignore entities that only the
-			-- metadata_registry analyzer knows about; they are irrelevant to the current state of the
-			-- chain, and our API guarantees a non-null address.
-			(address IS NOT NULL)`
+			FROM chain.entities
+			WHERE id = $1::text`
 
 	EntityNodeIds = `
 		SELECT id

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -93,9 +93,8 @@ CREATE TABLE chain.epochs
 CREATE TABLE chain.entities
 (
   id      base64_ed25519_pubkey PRIMARY KEY,
-  address oasis_addr,
-  -- Signed statements about the entity from https://github.com/oasisprotocol/metadata-registry
-  meta    JSON
+  address oasis_addr NOT NULL, -- Deterministically derived from the ID.
+  meta    JSON  -- Signed statements about the entity from https://github.com/oasisprotocol/metadata-registry
 );
 
 CREATE TABLE chain.nodes


### PR DESCRIPTION
This reverts commit #366 and solves the same problem in a different way: Marks the `entities.address` as NOT NULL in the consensus db, and always generates the address.

I accidentally merged #366; I wanted to address @gw0 's comment and rework the PR before merging.

See also https://github.com/oasisprotocol/oasis-indexer/pull/366#issuecomment-1490883784


Testing: Half-hearted, because it's a small change ... reindex_and_run.sh for 100 blocks just to index a few blocks and exercise the API endpoint at least once.