### PR TITLE
bugfix: db: Allow NULL tx body (for malformed txs)

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1983,7 +1983,7 @@ components:
     RuntimeTransaction:
       type: object
       # NOTE: Not guaranteed to be present: eth_hash, to, amount.
-      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, gas_limit, gas_used, size, method, body]
+      required: [round, index, timestamp, hash, sender_0, nonce_0, fee, gas_limit, gas_used, size]
       properties:
         round:
           type: integer
@@ -2061,10 +2061,11 @@ components:
               - "consensus.Withdraw"
               - "evm.Create"
               - "evm.Call"
+            May be null if the transaction was malformed.
           example: "evm.Call"
         body:
           type: object
-          description: The method call body.
+          description: The method call body. May be null if the transaction was malformed.
           example: {"address": "t1mAPucIdVnrYBpJOcLV2nZoOFo=", "data": RBo+cAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", "value": ""}
         to:
           type: string

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -48,10 +48,10 @@ CREATE TABLE chain.runtime_transactions
   size UINT31 NOT NULL,
   
   -- Transaction contents.
-  method      TEXT NOT NULL,  -- accounts.Transter, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call
-  body        JSON NOT NULL,  -- For EVM txs, the EVM method and args are encoded in here.
-  "to"        oasis_addr,     -- Exact semantics depend on method. Extracted from body; for convenience only.
-  amount      UINT_NUMERIC,   -- Exact semantics depend on method. Extracted from body; for convenience only.
+  method      TEXT,         -- accounts.Transter, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call. NULL for malformed txs.
+  body        JSON,         -- For EVM txs, the EVM method and args are encoded in here. NULL for malformed txs.
+  "to"        oasis_addr,   -- Exact semantics depend on method. Extracted from body; for convenience only.
+  amount      UINT_NUMERIC, -- Exact semantics depend on method. Extracted from body; for convenience only.
 
   -- Error information.
   success       BOOLEAN,  -- NULL means success is unknown (can happen in confidential runtimes)


### PR DESCRIPTION
Fixes a crash of sapphire indexer on round 144, which seems to be the first one to contain an encrypted tx.
Explanation in comments.

Testing: None, haven't figured out a tunnel to the sapphire node yet.