### PR TITLE
db: Prefer JSONB column type over JSON

### DIFF
--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -227,7 +227,7 @@ const (
 				chain.entities.address AS entity_address,
 				chain.nodes.id AS node_address,
 				chain.accounts.escrow_balance_active AS escrow,
-				COALESCE(chain.commissions.schedule, '{}'::json) AS commissions_schedule,
+				COALESCE(chain.commissions.schedule, '{}'::JSONB) AS commissions_schedule,
 				CASE WHEN EXISTS(SELECT null FROM chain.nodes WHERE chain.entities.id = chain.nodes.entity_id AND voting_power > 0) THEN true ELSE false END AS active,
 				CASE WHEN EXISTS(SELECT null FROM chain.nodes WHERE chain.entities.id = chain.nodes.entity_id AND chain.nodes.roles like '%validator%') THEN true ELSE false END AS status,
 				chain.entities.meta AS meta
@@ -255,7 +255,7 @@ const (
 				chain.entities.address AS entity_address,
 				chain.nodes.id AS node_address,
 				chain.accounts.escrow_balance_active AS escrow,
-				COALESCE(chain.commissions.schedule, '{}'::json) AS commissions_schedule,
+				COALESCE(chain.commissions.schedule, '{}'::JSONB) AS commissions_schedule,
 				CASE WHEN EXISTS(SELECT NULL FROM chain.nodes WHERE chain.entities.id = chain.nodes.entity_id AND voting_power > 0) THEN true ELSE false END AS active,
 				CASE WHEN EXISTS(SELECT NULL FROM chain.nodes WHERE chain.entities.id = chain.nodes.entity_id AND chain.nodes.roles like '%validator%') THEN true ELSE false END AS status,
 				chain.entities.meta AS meta

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -31,7 +31,7 @@ CREATE TABLE chain.blocks
   root_hash HEX64 NOT NULL,
 
   beacon     BYTEA,
-  metadata   JSON
+  metadata   JSONB
 );
 CREATE INDEX ix_blocks_time ON chain.blocks (time);
 
@@ -68,7 +68,7 @@ CREATE TABLE chain.events
   tx_index  UINT31,
 
   type    TEXT NOT NULL,  -- Enum with many values, see https://github.com/oasisprotocol/oasis-indexer/blob/89b68717205809b491d7926533d096444611bd6b/analyzer/api.go#L171-L171
-  body    JSON,
+  body    JSONB,
   tx_hash   HEX64, -- could be fetched from `transactions` table; denormalized for efficiency
   related_accounts TEXT[],
 
@@ -94,7 +94,7 @@ CREATE TABLE chain.entities
 (
   id      base64_ed25519_pubkey PRIMARY KEY,
   address oasis_addr NOT NULL, -- Deterministically derived from the ID.
-  meta    JSON  -- Signed statements about the entity from https://github.com/oasisprotocol/metadata-registry
+  meta    JSONB  -- Signed statements about the entity from https://github.com/oasisprotocol/metadata-registry
 );
 
 CREATE TABLE chain.nodes
@@ -198,7 +198,7 @@ CREATE TABLE chain.allowances
 CREATE TABLE chain.commissions
 (
   address  oasis_addr PRIMARY KEY NOT NULL REFERENCES chain.accounts(address) DEFERRABLE INITIALLY DEFERRED,
-  schedule JSON
+  schedule JSONB
 );
 
 CREATE TABLE chain.delegations

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -49,7 +49,7 @@ CREATE TABLE chain.runtime_transactions
   
   -- Transaction contents.
   method      TEXT,         -- accounts.Transter, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call. NULL for malformed and encrypted txs.
-  body        JSON,         -- For EVM txs, the EVM method and args are encoded in here. NULL for malformed and encrypted txs.
+  body        JSONB,        -- For EVM txs, the EVM method and args are encoded in here. NULL for malformed and encrypted txs.
   "to"        oasis_addr,   -- Exact semantics depend on method. Extracted from body; for convenience only.
   amount      UINT_NUMERIC, -- Exact semantics depend on method. Extracted from body; for convenience only.
 
@@ -106,7 +106,7 @@ CREATE TABLE chain.runtime_events
   -- `evm.log` events are further parsed into known event types,
   -- e.g. (ERC20) Transfer, to populate the `evm_log_name` and
   -- `evm_log_params` fields below.
-  body JSON NOT NULL,
+  body JSONB NOT NULL,
   evm_log_name TEXT,
   -- The event signature, if it exists, will be the first topic.
   evm_log_signature TEXT GENERATED ALWAYS AS (body->'topics'->>0) STORED,


### PR DESCRIPTION
This PR switches `JSON` to the newer `JSONB` ("JSON but Better") type. From [postgres docs](https://www.postgresql.org/docs/current/datatype-json.html):
> PostgreSQL offers two types for storing JSON data: json and jsonb. 
> The major practical difference is one of efficiency. The json data type stores an exact copy of the input text, which processing functions must reparse on each execution; while jsonb data is stored in a decomposed binary format that makes it slightly slower to input due to added conversion overhead, but significantly faster to process, since no reparsing is needed. jsonb also supports indexing, which can be a significant advantage.
> Because the json type stores an exact copy of the input text, it will preserve semantically-insignificant white space between tokens, as well as the order of keys within JSON objects. By contrast, jsonb does not preserve white space, does not preserve the order of object keys, and does not keep duplicate object keys. 
> In general, **most applications should prefer to store JSON data as jsonb**, unless there are quite specialized needs, such as legacy assumptions about ordering of object keys.

Prompted by @pro-wh 's offhand comment in slack where he noticed we use both JSON and JSONB.

*Testing*: reindex-and-run.sh, 100 blocks.