### PR TITLE
EVM: download tokens at last processed round

### DIFF
--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -118,7 +118,6 @@ func NewMain(
 type StaleTokenBalance struct {
 	TokenAddr                    string
 	AccountAddr                  string
-	LastMutateRound              uint64
 	Type                         *runtime.EVMTokenType
 	Balance                      *big.Int
 	TokenAddrContextIdentifier   string
@@ -127,6 +126,7 @@ type StaleTokenBalance struct {
 	AccountAddrContextIdentifier string
 	AccountAddrContextVersion    int
 	AccountAddrData              []byte
+	DownloadRound                uint64
 }
 
 func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTokenBalance, error) {
@@ -142,7 +142,6 @@ func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTok
 		if err = rows.Scan(
 			&staleTokenBalance.TokenAddr,
 			&staleTokenBalance.AccountAddr,
-			&staleTokenBalance.LastMutateRound,
 			&staleTokenBalance.Type,
 			&balanceC,
 			&staleTokenBalance.TokenAddrContextIdentifier,
@@ -151,6 +150,7 @@ func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTok
 			&staleTokenBalance.AccountAddrContextIdentifier,
 			&staleTokenBalance.AccountAddrContextVersion,
 			&staleTokenBalance.AccountAddrData,
+			&staleTokenBalance.DownloadRound,
 		); err != nil {
 			return nil, fmt.Errorf("scanning stale token balance: %w", err)
 		}
@@ -176,7 +176,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 			ctx,
 			m.logger,
 			m.cfg.Source,
-			staleTokenBalance.LastMutateRound,
+			staleTokenBalance.DownloadRound,
 			tokenEthAddr,
 			accountEthAddr,
 			*staleTokenBalance.Type,
@@ -195,7 +195,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 				m.logger.Warn("correcting reckoned balance of token to downloaded balance",
 					"token_addr", staleTokenBalance.TokenAddr,
 					"account_addr", staleTokenBalance.AccountAddr,
-					"download_round", staleTokenBalance.LastMutateRound,
+					"download_round", staleTokenBalance.DownloadRound,
 					"reckoned_balance", staleTokenBalance.Balance,
 					"downloaded_balance", balanceData,
 					"correction", correction,
@@ -213,7 +213,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 		m.runtime,
 		staleTokenBalance.TokenAddr,
 		staleTokenBalance.AccountAddr,
-		staleTokenBalance.LastMutateRound,
+		staleTokenBalance.DownloadRound,
 	)
 	return nil
 }

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -73,12 +73,12 @@ func NewMain(
 
 type StaleToken struct {
 	Addr                  string
-	LastMutateRound       uint64
 	LastDownloadRound     *uint64
 	Type                  *runtime.EVMTokenType
 	AddrContextIdentifier string
 	AddrContextVersion    int
 	AddrData              []byte
+	DownloadRound         uint64
 }
 
 func (m Main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, error) {
@@ -92,12 +92,12 @@ func (m Main) getStaleTokens(ctx context.Context, limit int) ([]*StaleToken, err
 		var staleToken StaleToken
 		if err = rows.Scan(
 			&staleToken.Addr,
-			&staleToken.LastMutateRound,
 			&staleToken.LastDownloadRound,
 			&staleToken.Type,
 			&staleToken.AddrContextIdentifier,
 			&staleToken.AddrContextVersion,
 			&staleToken.AddrData,
+			&staleToken.DownloadRound,
 		); err != nil {
 			return nil, fmt.Errorf("scanning discovered token: %w", err)
 		}
@@ -118,7 +118,7 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			ctx,
 			m.logger,
 			m.cfg.Source,
-			staleToken.LastMutateRound,
+			staleToken.DownloadRound,
 			tokenEthAddr,
 		)
 		if err != nil {
@@ -140,7 +140,7 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			ctx,
 			m.logger,
 			m.cfg.Source,
-			staleToken.LastMutateRound,
+			staleToken.DownloadRound,
 			tokenEthAddr,
 			*staleToken.Type,
 		)
@@ -155,7 +155,7 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			)
 		}
 	}
-	batch.Queue(queries.RuntimeEVMTokenAnalysisUpdate, m.runtime, staleToken.Addr, staleToken.LastMutateRound)
+	batch.Queue(queries.RuntimeEVMTokenAnalysisUpdate, m.runtime, staleToken.Addr, staleToken.DownloadRound)
 	return nil
 }
 

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -313,12 +313,12 @@ const (
 	RuntimeEVMTokenAnalysisStale = `
     SELECT
       evm_token_analysis.token_address,
-      evm_token_analysis.last_mutate_round,
       evm_token_analysis.last_download_round,
       evm_tokens.token_type,
       address_preimages.context_identifier,
       address_preimages.context_version,
-      address_preimages.address_data
+      address_preimages.address_data,
+      (SELECT MAX(height) FROM chain.processed_blocks WHERE analyzer = evm_token_analysis.runtime::text) AS download_round
     FROM chain.evm_token_analysis
     LEFT JOIN chain.evm_tokens USING (runtime, token_address)
     LEFT JOIN chain.address_preimages ON
@@ -367,7 +367,6 @@ const (
     SELECT
       evm_token_balance_analysis.token_address,
       evm_token_balance_analysis.account_address,
-      evm_token_balance_analysis.last_mutate_round,
       evm_tokens.token_type,
       evm_token_balances.balance,
       token_address_preimage.context_identifier,
@@ -375,7 +374,8 @@ const (
       token_address_preimage.address_data,
       account_address_preimage.context_identifier,
       account_address_preimage.context_version,
-      account_address_preimage.address_data
+      account_address_preimage.address_data,
+      (SELECT MAX(height) FROM chain.processed_blocks WHERE analyzer = evm_token_balance_analysis.runtime::text) AS download_round
     FROM chain.evm_token_balance_analysis
     JOIN chain.evm_token_analysis USING (runtime, token_address)
     LEFT JOIN chain.evm_tokens USING (runtime, token_address)

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -302,13 +302,13 @@ const (
 
 	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisInsert = `
-	INSERT INTO chain.evm_token_balance_analysis
-		(runtime, token_address, account_address, last_mutate_round)
-	VALUES
-		($1, $2, $3, $4)
-	ON CONFLICT (runtime, token_address, account_address) DO UPDATE
-	SET
-		last_mutate_round = excluded.last_mutate_round`
+    INSERT INTO chain.evm_token_balance_analysis
+      (runtime, token_address, account_address, last_mutate_round)
+    VALUES
+      ($1, $2, $3, $4)
+    ON CONFLICT (runtime, token_address, account_address) DO UPDATE
+    SET
+      last_mutate_round = excluded.last_mutate_round`
 
 	RuntimeEVMTokenAnalysisStale = `
     SELECT
@@ -364,44 +364,44 @@ const (
 
 	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisStale = `
-	SELECT
-		evm_token_balance_analysis.token_address,
-		evm_token_balance_analysis.account_address,
-		evm_token_balance_analysis.last_mutate_round,
-		evm_tokens.token_type,
-		evm_token_balances.balance,
-		token_address_preimage.context_identifier,
-		token_address_preimage.context_version,
-		token_address_preimage.address_data,
-		account_address_preimage.context_identifier,
-		account_address_preimage.context_version,
-		account_address_preimage.address_data
-	FROM chain.evm_token_balance_analysis
-	JOIN chain.evm_token_analysis USING (runtime, token_address)
-	LEFT JOIN chain.evm_tokens USING (runtime, token_address)
-	LEFT JOIN chain.evm_token_balances USING (runtime, token_address, account_address)
-	LEFT JOIN chain.address_preimages AS token_address_preimage ON
-		token_address_preimage.address = evm_token_balance_analysis.token_address
-	LEFT JOIN chain.address_preimages AS account_address_preimage ON
-		account_address_preimage.address = evm_token_balance_analysis.account_address
-	WHERE
-		evm_token_balance_analysis.runtime = $1 AND
-		(
-			evm_token_balance_analysis.last_download_round IS NULL OR
-			evm_token_balance_analysis.last_mutate_round > evm_token_balance_analysis.last_download_round
-		) AND
-		evm_token_analysis.last_download_round IS NOT NULL
-	LIMIT $2`
+    SELECT
+      evm_token_balance_analysis.token_address,
+      evm_token_balance_analysis.account_address,
+      evm_token_balance_analysis.last_mutate_round,
+      evm_tokens.token_type,
+      evm_token_balances.balance,
+      token_address_preimage.context_identifier,
+      token_address_preimage.context_version,
+      token_address_preimage.address_data,
+      account_address_preimage.context_identifier,
+      account_address_preimage.context_version,
+      account_address_preimage.address_data
+    FROM chain.evm_token_balance_analysis
+    JOIN chain.evm_token_analysis USING (runtime, token_address)
+    LEFT JOIN chain.evm_tokens USING (runtime, token_address)
+    LEFT JOIN chain.evm_token_balances USING (runtime, token_address, account_address)
+    LEFT JOIN chain.address_preimages AS token_address_preimage ON
+      token_address_preimage.address = evm_token_balance_analysis.token_address
+    LEFT JOIN chain.address_preimages AS account_address_preimage ON
+      account_address_preimage.address = evm_token_balance_analysis.account_address
+    WHERE
+      evm_token_balance_analysis.runtime = $1 AND
+      (
+        evm_token_balance_analysis.last_download_round IS NULL OR
+        evm_token_balance_analysis.last_mutate_round > evm_token_balance_analysis.last_download_round
+      ) AND
+      evm_token_analysis.last_download_round IS NOT NULL
+    LIMIT $2`
 
 	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisUpdate = `
-	UPDATE chain.evm_token_balance_analysis
-	SET
-		last_download_round = $4
-	WHERE
-		runtime = $1 AND
-		token_address = $2 AND
-		account_address = $3`
+    UPDATE chain.evm_token_balance_analysis
+    SET
+      last_download_round = $4
+    WHERE
+      runtime = $1 AND
+      token_address = $2 AND
+      account_address = $3`
 
 	RefreshDailyTxVolume = `
     REFRESH MATERIALIZED VIEW stats.daily_tx_volume

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -300,7 +300,6 @@ const (
     ON CONFLICT (runtime, token_address, account_address) DO
       UPDATE SET balance = chain.evm_token_balances.balance + $4`
 
-	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisInsert = `
     INSERT INTO chain.evm_token_balance_analysis
       (runtime, token_address, account_address, last_mutate_round)
@@ -362,7 +361,6 @@ const (
       runtime = $1 AND
       token_address = $2`
 
-	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisStale = `
     SELECT
       evm_token_balance_analysis.token_address,
@@ -393,7 +391,6 @@ const (
       evm_token_analysis.last_download_round IS NOT NULL
     LIMIT $2`
 
-	//nolint:gosec // thinks this is an authentication "token"
 	RuntimeEVMTokenBalanceAnalysisUpdate = `
     UPDATE chain.evm_token_balance_analysis
     SET

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -287,7 +287,7 @@ CREATE TABLE chain.processed_blocks
   analyzer       TEXT NOT NULL,
   processed_time TIMESTAMP WITH TIME ZONE NOT NULL,
 
-  PRIMARY KEY (height, analyzer)
+  PRIMARY KEY (analyzer, height)
 );
 
 -- Keeps track of chains for which we've already processed the genesis data.


### PR DESCRIPTION
a preview of what it will be like to do EVM queries for downloading token data + token balances at the ~latest round instead of the last mutated round

this is for sapphire where blocks far in the past aren't accessible

tested on emerald, where I ran the block scanner over a range of blocks with token and token balance analyzers disabled then ran with only token analyzer and token balance analyzer. checked that tokens and token balances are still downloaded successfully and recorded to have been downloaded at the latest scanned block round