### PR TITLE
bugfix: Typo in GetCommittees RPC method name

### DIFF
--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -163,7 +163,7 @@ func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64
 
 func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64, runtimeID common.Namespace) ([]nodeapi.Committee, error) {
 	var rsp []*schedulerCobalt.Committee
-	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittee", &scheduler.GetCommitteesRequest{
+	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetCommittees", &scheduler.GetCommitteesRequest{
 		Height:    height,
 		RuntimeID: runtimeID,
 	}, &rsp); err != nil {


### PR DESCRIPTION
An unknown side effect of #352 was that it fixed (via refactoring internal Network representations) the set of runtimes being sent to the consensus analyzer, from the empty set to all supported runtimes. The consensus analyzer uses that list to call `GetCommittees` via node gRPC for each runtime. There was a typo in the Cobalt implementation of that RPC method's client, but the code was never exercised before #352 because consensus analyzer was not made aware of any runtimes to run this method against.

Before this PR but after #352, trying to process consensus blocks in Damask results in an error: `unknown method GetCommittee for service oasis-core.Scheduler`

*Testing*: Processed a handful of Cobalt rounds. Error message is gone.