### PR TITLE
nodeapi: Store raw oasis-core in serialized form

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -37,7 +37,7 @@ type EventType = apiTypes.ConsensusEventType // alias for brevity
 
 type parsedEvent struct {
 	ty               EventType
-	rawBodyJSON      json.RawMessage
+	rawBody          json.RawMessage
 	relatedAddresses []staking.Address
 }
 
@@ -482,7 +482,7 @@ func (m *Main) queueTxEventInserts(batch *storage.QueryBatch, data *storage.Cons
 			eventData := m.extractEventData(event)
 			txAccounts = append(txAccounts, eventData.relatedAddresses...)
 			accounts := extractUniqueAddresses(eventData.relatedAddresses)
-			body, err := json.Marshal(eventData.rawBodyJSON)
+			body, err := json.Marshal(eventData.rawBody)
 			if err != nil {
 				return err
 			}
@@ -915,7 +915,7 @@ func (m *Main) queueGovernanceEventInserts(batch *storage.QueryBatch, data *stor
 
 func (m *Main) queueSingleEventInserts(batch *storage.QueryBatch, eventData *parsedEvent, height int64) error {
 	accounts := extractUniqueAddresses(eventData.relatedAddresses)
-	body, err := json.Marshal(eventData.rawBodyJSON)
+	body, err := json.Marshal(eventData.rawBody)
 	if err != nil {
 		return err
 	}
@@ -950,8 +950,8 @@ func extractUniqueAddresses(accounts []staking.Address) []string {
 // extractEventData extracts the type, the body (JSON-serialized), and the related accounts of an event.
 func (m *Main) extractEventData(event nodeapi.Event) parsedEvent {
 	eventData := parsedEvent{
-		ty:          event.Type,
-		rawBodyJSON: event.RawBodyJSON,
+		ty:      event.Type,
+		rawBody: event.RawBody,
 	}
 
 	// Fill in related accounts.

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -90,7 +90,7 @@ type Event struct {
 	// field will be populated.
 	// We convert to JSON and effectively erase the type here in order to decouple
 	// oasis-core types (which vary between versions) from the indexer.
-	RawBodyJSON json.RawMessage
+	RawBody json.RawMessage
 
 	// Called "Kind" in oasis-core but "Type" in indexer APIs and DBs.
 	Type apiTypes.ConsensusEventType

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -171,13 +171,13 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 		case e.Staking.Transfer != nil:
 			ret = nodeapi.Event{
 				StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
-				RawBodyJSON:     common.TryAsJSON(e.Staking.Transfer),
+				RawBody:         common.TryAsJSON(e.Staking.Transfer),
 				Type:            apiTypes.ConsensusEventTypeStakingTransfer,
 			}
 		case e.Staking.Burn != nil:
 			ret = nodeapi.Event{
 				StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
-				RawBodyJSON: common.TryAsJSON(e.Staking.Burn),
+				RawBody:     common.TryAsJSON(e.Staking.Burn),
 				Type:        apiTypes.ConsensusEventTypeStakingBurn,
 			}
 		case e.Staking.Escrow != nil:
@@ -185,19 +185,19 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 			case e.Staking.Escrow.Add != nil:
 				ret = nodeapi.Event{
 					StakingAddEscrow: (*nodeapi.AddEscrowEvent)(e.Staking.Escrow.Add),
-					RawBodyJSON:      common.TryAsJSON(e.Staking.Escrow.Add),
+					RawBody:          common.TryAsJSON(e.Staking.Escrow.Add),
 					Type:             apiTypes.ConsensusEventTypeStakingEscrowAdd,
 				}
 			case e.Staking.Escrow.Take != nil:
 				ret = nodeapi.Event{
 					StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
-					RawBodyJSON:       common.TryAsJSON(e.Staking.Escrow.Take),
+					RawBody:           common.TryAsJSON(e.Staking.Escrow.Take),
 					Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
 				}
 			case e.Staking.Escrow.Reclaim != nil:
 				ret = nodeapi.Event{
 					StakingReclaimEscrow: (*nodeapi.ReclaimEscrowEvent)(e.Staking.Escrow.Reclaim),
-					RawBodyJSON:          common.TryAsJSON(e.Staking.Escrow.Reclaim),
+					RawBody:              common.TryAsJSON(e.Staking.Escrow.Reclaim),
 					Type:                 apiTypes.ConsensusEventTypeStakingEscrowReclaim,
 				}
 				// NOTE: There is no Staking.Escrow.DebondingStart event in Cobalt.
@@ -205,7 +205,7 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 		case e.Staking.AllowanceChange != nil:
 			ret = nodeapi.Event{
 				StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
-				RawBodyJSON:            common.TryAsJSON(e.Staking.AllowanceChange),
+				RawBody:                common.TryAsJSON(e.Staking.AllowanceChange),
 				Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
 			}
 		}
@@ -223,13 +223,13 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					KeyManager:  e.Registry.RuntimeEvent.Runtime.KeyManager,
 					TEEHardware: e.Registry.RuntimeEvent.Runtime.TEEHardware.String(),
 				},
-				RawBodyJSON: common.TryAsJSON(e.Registry.RuntimeEvent),
-				Type:        apiTypes.ConsensusEventTypeRegistryRuntime,
+				RawBody: common.TryAsJSON(e.Registry.RuntimeEvent),
+				Type:    apiTypes.ConsensusEventTypeRegistryRuntime,
 			}
 		case e.Registry.EntityEvent != nil:
 			ret = nodeapi.Event{
 				RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
-				RawBodyJSON:    common.TryAsJSON(e.Registry.EntityEvent),
+				RawBody:        common.TryAsJSON(e.Registry.EntityEvent),
 				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 			}
 		case e.Registry.NodeEvent != nil:
@@ -271,13 +271,13 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					Roles:              strings.Split(e.Registry.NodeEvent.Node.Roles.String(), ","),
 					SoftwareVersion:    e.Registry.NodeEvent.Node.SoftwareVersion,
 				},
-				RawBodyJSON: common.TryAsJSON(e.Registry.NodeEvent),
-				Type:        apiTypes.ConsensusEventTypeRegistryNode,
+				RawBody: common.TryAsJSON(e.Registry.NodeEvent),
+				Type:    apiTypes.ConsensusEventTypeRegistryNode,
 			}
 		case e.Registry.NodeUnfrozenEvent != nil:
 			ret = nodeapi.Event{
 				RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
-				RawBodyJSON:          common.TryAsJSON(e.Registry.NodeUnfrozenEvent),
+				RawBody:              common.TryAsJSON(e.Registry.NodeUnfrozenEvent),
 				Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
 			}
 		}
@@ -291,18 +291,18 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 				RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
 					NodeID: nil, // Not available in Cobalt.
 				},
-				RawBodyJSON: common.TryAsJSON(e.RootHash.ExecutorCommitted),
-				Type:        apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
+				RawBody: common.TryAsJSON(e.RootHash.ExecutorCommitted),
+				Type:    apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
 			}
 		case e.RootHash.ExecutionDiscrepancyDetected != nil:
 			ret = nodeapi.Event{
-				RawBodyJSON: common.TryAsJSON(e.RootHash.ExecutionDiscrepancyDetected),
-				Type:        apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
+				RawBody: common.TryAsJSON(e.RootHash.ExecutionDiscrepancyDetected),
+				Type:    apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
 			}
 		case e.RootHash.Finalized != nil:
 			ret = nodeapi.Event{
-				RawBodyJSON: common.TryAsJSON(e.RootHash.Finalized),
-				Type:        apiTypes.ConsensusEventTypeRoothashFinalized,
+				RawBody: common.TryAsJSON(e.RootHash.Finalized),
+				Type:    apiTypes.ConsensusEventTypeRoothashFinalized,
 			}
 		}
 		ret.Height = e.RootHash.Height
@@ -313,13 +313,13 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 		case e.Governance.ProposalSubmitted != nil:
 			ret = nodeapi.Event{
 				GovernanceProposalSubmitted: (*nodeapi.ProposalSubmittedEvent)(e.Governance.ProposalSubmitted),
-				RawBodyJSON:                 common.TryAsJSON(e.Governance.ProposalSubmitted),
+				RawBody:                     common.TryAsJSON(e.Governance.ProposalSubmitted),
 				Type:                        apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
 			}
 		case e.Governance.ProposalExecuted != nil:
 			ret = nodeapi.Event{
 				GovernanceProposalExecuted: (*nodeapi.ProposalExecutedEvent)(e.Governance.ProposalExecuted),
-				RawBodyJSON:                common.TryAsJSON(e.Governance.ProposalExecuted),
+				RawBody:                    common.TryAsJSON(e.Governance.ProposalExecuted),
 				Type:                       apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
 			}
 		case e.Governance.ProposalFinalized != nil:
@@ -329,8 +329,8 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					// This assumes that the ProposalState enum is backwards-compatible
 					State: governance.ProposalState(e.Governance.ProposalFinalized.State),
 				},
-				RawBodyJSON: common.TryAsJSON(e.Governance.ProposalFinalized),
-				Type:        apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
+				RawBody: common.TryAsJSON(e.Governance.ProposalFinalized),
+				Type:    apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
 			}
 		case e.Governance.Vote != nil:
 			ret = nodeapi.Event{
@@ -339,8 +339,8 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					Submitter: e.Governance.Vote.Submitter,
 					Vote:      e.Governance.Vote.Vote.String(),
 				},
-				RawBodyJSON: common.TryAsJSON(e.Governance.Vote),
-				Type:        apiTypes.ConsensusEventTypeGovernanceVote,
+				RawBody: common.TryAsJSON(e.Governance.Vote),
+				Type:    apiTypes.ConsensusEventTypeGovernanceVote,
 			}
 		}
 		ret.Height = e.Governance.Height

--- a/storage/oasis/nodeapi/damask/convert.go
+++ b/storage/oasis/nodeapi/damask/convert.go
@@ -22,13 +22,13 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 		case e.Staking.Transfer != nil:
 			ret = nodeapi.Event{
 				StakingTransfer: (*nodeapi.TransferEvent)(e.Staking.Transfer),
-				RawBodyJSON:     common.TryAsJSON(e.Staking.Transfer),
+				RawBody:         common.TryAsJSON(e.Staking.Transfer),
 				Type:            apiTypes.ConsensusEventTypeStakingTransfer,
 			}
 		case e.Staking.Burn != nil:
 			ret = nodeapi.Event{
 				StakingBurn: (*nodeapi.BurnEvent)(e.Staking.Burn),
-				RawBodyJSON: common.TryAsJSON(e.Staking.Burn),
+				RawBody:     common.TryAsJSON(e.Staking.Burn),
 				Type:        apiTypes.ConsensusEventTypeStakingBurn,
 			}
 		case e.Staking.Escrow != nil:
@@ -36,32 +36,32 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 			case e.Staking.Escrow.Add != nil:
 				ret = nodeapi.Event{
 					StakingAddEscrow: (*nodeapi.AddEscrowEvent)(e.Staking.Escrow.Add),
-					RawBodyJSON:      common.TryAsJSON(e.Staking.Escrow.Add),
+					RawBody:          common.TryAsJSON(e.Staking.Escrow.Add),
 					Type:             apiTypes.ConsensusEventTypeStakingEscrowAdd,
 				}
 			case e.Staking.Escrow.Take != nil:
 				ret = nodeapi.Event{
 					StakingTakeEscrow: (*nodeapi.TakeEscrowEvent)(e.Staking.Escrow.Take),
-					RawBodyJSON:       common.TryAsJSON(e.Staking.Escrow.Take),
+					RawBody:           common.TryAsJSON(e.Staking.Escrow.Take),
 					Type:              apiTypes.ConsensusEventTypeStakingEscrowTake,
 				}
 			case e.Staking.Escrow.Reclaim != nil:
 				ret = nodeapi.Event{
 					StakingReclaimEscrow: (*nodeapi.ReclaimEscrowEvent)(e.Staking.Escrow.Reclaim),
-					RawBodyJSON:          common.TryAsJSON(e.Staking.Escrow.Reclaim),
+					RawBody:              common.TryAsJSON(e.Staking.Escrow.Reclaim),
 					Type:                 apiTypes.ConsensusEventTypeStakingEscrowReclaim,
 				}
 			case e.Staking.Escrow.DebondingStart != nil:
 				ret = nodeapi.Event{
 					StakingDebondingStart: (*nodeapi.DebondingStartEscrowEvent)(e.Staking.Escrow.DebondingStart),
-					RawBodyJSON:           common.TryAsJSON(e.Staking.Escrow.DebondingStart),
+					RawBody:               common.TryAsJSON(e.Staking.Escrow.DebondingStart),
 					Type:                  apiTypes.ConsensusEventTypeStakingEscrowDebondingStart,
 				}
 			}
 		case e.Staking.AllowanceChange != nil:
 			ret = nodeapi.Event{
 				StakingAllowanceChange: (*nodeapi.AllowanceChangeEvent)(e.Staking.AllowanceChange),
-				RawBodyJSON:            common.TryAsJSON(e.Staking.AllowanceChange),
+				RawBody:                common.TryAsJSON(e.Staking.AllowanceChange),
 				Type:                   apiTypes.ConsensusEventTypeStakingAllowanceChange,
 			}
 		}
@@ -79,13 +79,13 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 					KeyManager:  e.Registry.RuntimeEvent.Runtime.KeyManager,
 					TEEHardware: e.Registry.RuntimeEvent.Runtime.TEEHardware.String(),
 				},
-				RawBodyJSON: common.TryAsJSON(e.Registry.RuntimeEvent),
-				Type:        apiTypes.ConsensusEventTypeRegistryRuntime,
+				RawBody: common.TryAsJSON(e.Registry.RuntimeEvent),
+				Type:    apiTypes.ConsensusEventTypeRegistryRuntime,
 			}
 		case e.Registry.EntityEvent != nil:
 			ret = nodeapi.Event{
 				RegistryEntity: (*nodeapi.EntityEvent)(e.Registry.EntityEvent),
-				RawBodyJSON:    common.TryAsJSON(e.Registry.EntityEvent),
+				RawBody:        common.TryAsJSON(e.Registry.EntityEvent),
 				Type:           apiTypes.ConsensusEventTypeRegistryEntity,
 			}
 		case e.Registry.NodeEvent != nil:
@@ -127,13 +127,13 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 					Roles:              strings.Split(e.Registry.NodeEvent.Node.Roles.String(), ","),
 					SoftwareVersion:    e.Registry.NodeEvent.Node.SoftwareVersion,
 				},
-				RawBodyJSON: common.TryAsJSON(e.Registry.NodeEvent),
-				Type:        apiTypes.ConsensusEventTypeRegistryNode,
+				RawBody: common.TryAsJSON(e.Registry.NodeEvent),
+				Type:    apiTypes.ConsensusEventTypeRegistryNode,
 			}
 		case e.Registry.NodeUnfrozenEvent != nil:
 			ret = nodeapi.Event{
 				RegistryNodeUnfrozen: (*nodeapi.NodeUnfrozenEvent)(e.Registry.NodeUnfrozenEvent),
-				RawBodyJSON:          common.TryAsJSON(e.Registry.NodeUnfrozenEvent),
+				RawBody:              common.TryAsJSON(e.Registry.NodeUnfrozenEvent),
 				Type:                 apiTypes.ConsensusEventTypeRegistryNodeUnfrozen,
 			}
 		}
@@ -147,18 +147,18 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 				RoothashExecutorCommitted: &nodeapi.ExecutorCommittedEvent{
 					NodeID: &e.RootHash.ExecutorCommitted.Commit.NodeID,
 				},
-				RawBodyJSON: common.TryAsJSON(e.RootHash.ExecutorCommitted),
-				Type:        apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
+				RawBody: common.TryAsJSON(e.RootHash.ExecutorCommitted),
+				Type:    apiTypes.ConsensusEventTypeRoothashExecutorCommitted,
 			}
 		case e.RootHash.ExecutionDiscrepancyDetected != nil:
 			ret = nodeapi.Event{
-				RawBodyJSON: common.TryAsJSON(e.RootHash.ExecutionDiscrepancyDetected),
-				Type:        apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
+				RawBody: common.TryAsJSON(e.RootHash.ExecutionDiscrepancyDetected),
+				Type:    apiTypes.ConsensusEventTypeRoothashExecutionDiscrepancy,
 			}
 		case e.RootHash.Finalized != nil:
 			ret = nodeapi.Event{
-				RawBodyJSON: common.TryAsJSON(e.RootHash.Finalized),
-				Type:        apiTypes.ConsensusEventTypeRoothashFinalized,
+				RawBody: common.TryAsJSON(e.RootHash.Finalized),
+				Type:    apiTypes.ConsensusEventTypeRoothashFinalized,
 			}
 		}
 		ret.Height = e.RootHash.Height
@@ -169,19 +169,19 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 		case e.Governance.ProposalSubmitted != nil:
 			ret = nodeapi.Event{
 				GovernanceProposalSubmitted: (*nodeapi.ProposalSubmittedEvent)(e.Governance.ProposalSubmitted),
-				RawBodyJSON:                 common.TryAsJSON(e.Governance.ProposalSubmitted),
+				RawBody:                     common.TryAsJSON(e.Governance.ProposalSubmitted),
 				Type:                        apiTypes.ConsensusEventTypeGovernanceProposalSubmitted,
 			}
 		case e.Governance.ProposalExecuted != nil:
 			ret = nodeapi.Event{
 				GovernanceProposalExecuted: (*nodeapi.ProposalExecutedEvent)(e.Governance.ProposalExecuted),
-				RawBodyJSON:                common.TryAsJSON(e.Governance.ProposalExecuted),
+				RawBody:                    common.TryAsJSON(e.Governance.ProposalExecuted),
 				Type:                       apiTypes.ConsensusEventTypeGovernanceProposalExecuted,
 			}
 		case e.Governance.ProposalFinalized != nil:
 			ret = nodeapi.Event{
 				GovernanceProposalFinalized: (*nodeapi.ProposalFinalizedEvent)(e.Governance.ProposalFinalized),
-				RawBodyJSON:                 common.TryAsJSON(e.Governance.ProposalFinalized),
+				RawBody:                     common.TryAsJSON(e.Governance.ProposalFinalized),
 				Type:                        apiTypes.ConsensusEventTypeGovernanceProposalFinalized,
 			}
 		case e.Governance.Vote != nil:
@@ -191,8 +191,8 @@ func convertEvent(e txResultsDamask.Event) nodeapi.Event {
 					Submitter: e.Governance.Vote.Submitter,
 					Vote:      e.Governance.Vote.Vote.String(),
 				},
-				RawBodyJSON: common.TryAsJSON(e.Governance.Vote),
-				Type:        apiTypes.ConsensusEventTypeGovernanceVote,
+				RawBody: common.TryAsJSON(e.Governance.Vote),
+				Type:    apiTypes.ConsensusEventTypeGovernanceVote,
 			}
 		}
 		ret.Height = e.Governance.Height


### PR DESCRIPTION
**Background:** The indexer-internal `nodeapi.Event` type that represents an oasis-core consensus event has a `Body` field. It stores the raw body of the Event as received from oasis-core, but intentionally erases the type (by using the `interface{}` type) so that the rest of the indexer doesn't need to support all the variants of Event types from all the oasis-core versions. We just dump the raw body into the DB as json, for anybody who might want to inspect it later.

**Problem:** #360 is introducing a caching layer, as part of which all oasis-core responses (= `nodeapi` types) are (de)serialized to/from the disk. The `interface{}` type does not round-trip losslessly and throws errors when deserialzing back from on-disk JSON or CBOR.

**Solution / This PR:** This PR changes the `nodeapi` representation of the event to store a _serialized_ version (JSON) of the oasis-core Event, not just a type-erased version (interface{}). Instead of JSON, we could choose CBOR; CBOR makes more sense in that it's used everywhere internally. But since the goal of this field is to store it in the DB (which offers native JSON columns) and then present it via HTTP API (again JSON), I'm going with JSON.

**Note on runtimes:** The runtime part of `nodeapi` has no such issue because the event types have been stable across all versions of the sdk, so the `nodeapi` Event representation does not erase the types and uses the current oasis-sdk types. At some point when types change enough, we might well need to introduce a similar solution there.

**Testing:** Indexed 100 blocks of consensus and compared DB table contents. No diffs.
