### PR TITLE
analyzer: remove the 100ms timeout before processing every block

### DIFF
--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/rewards"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 


### PR DESCRIPTION
Removes the artificial 100ms timeout before processing every block. I noticed this while working on parallelizing the block processing, and it looks to me that this timeout is unintended.

Should help with https://github.com/oasisprotocol/oasis-indexer/issues/179 - likely also affects the analysis done in that issue, since the indexer was artificially slowing itself down.

## Testing

Only quickly tested consensus analyzer. On my node, this increases the consensus analyzer block process rate from:~6 per second, to: ~20 per second

