### PR TITLE
config-related cleanup and opinions

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -49,8 +49,8 @@ const (
 // by (periodically) querying the `runtime_related_transactions` table.
 var dailyActiveAccountsLayers = []string{
 	layerConsensus,
-	common.RuntimeEmerald.String(),
-	common.RuntimeSapphire.String(),
+	string(common.RuntimeEmerald),
+	string(common.RuntimeSapphire),
 	// RuntimeCipher.String(), // Enable once Cipher is supported by the indexer.
 }
 

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -5,6 +5,7 @@ import (
 
 	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
 
@@ -55,6 +56,9 @@ type BlockRange struct {
 // RuntimeConfig specifies configuration parameters for
 // processing the runtime layer.
 type RuntimeConfig struct {
+	// RuntimeName is which runtime to analyze.
+	RuntimeName common.Runtime
+
 	// ParaTime is the SDK ParaTime structure describing the runtime.
 	ParaTime *sdkConfig.ParaTime
 

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -3,6 +3,8 @@ package analyzer
 import (
 	"errors"
 
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
 
@@ -53,6 +55,9 @@ type BlockRange struct {
 // RuntimeConfig specifies configuration parameters for
 // processing the runtime layer.
 type RuntimeConfig struct {
+	// ParaTime is the SDK ParaTime structure describing the runtime.
+	ParaTime *sdkConfig.ParaTime
+
 	// Range is the range of rounds to process.
 	// If this is set, the analyzer analyzes rounds in the provided range.
 	Range RoundRange

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -111,7 +111,7 @@ func NewMain(
 		runtime: runtime,
 		cfg:     ac,
 		target:  target,
-		logger:  logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime.String()),
+		logger:  logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime),
 	}, nil
 }
 
@@ -295,5 +295,5 @@ func (m Main) Start() {
 }
 
 func (m Main) Name() string {
-	return EvmTokenBalancesAnalyzerPrefix + m.runtime.String()
+	return EvmTokenBalancesAnalyzerPrefix + string(m.runtime)
 }

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -79,10 +79,9 @@ const (
 )
 
 type Main struct {
-	runtime common.Runtime
-	cfg     analyzer.RuntimeConfig
-	target  storage.TargetStorage
-	logger  *log.Logger
+	cfg    analyzer.RuntimeConfig
+	target storage.TargetStorage
+	logger *log.Logger
 }
 
 var _ analyzer.Analyzer = (*Main)(nil)
@@ -104,14 +103,14 @@ func NewMain(
 		return nil, err
 	}
 	ac := analyzer.RuntimeConfig{
-		Source: client,
+		RuntimeName: runtime,
+		Source:      client,
 	}
 
 	return &Main{
-		runtime: runtime,
-		cfg:     ac,
-		target:  target,
-		logger:  logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime),
+		cfg:    ac,
+		target: target,
+		logger: logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime),
 	}, nil
 }
 
@@ -131,7 +130,7 @@ type StaleTokenBalance struct {
 
 func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTokenBalance, error) {
 	var staleTokenBalances []*StaleTokenBalance
-	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokenBalanceAnalysisStale, m.runtime, limit)
+	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokenBalanceAnalysisStale, m.cfg.RuntimeName, limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying stale token balances: %w", err)
 	}
@@ -201,7 +200,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 					"correction", correction,
 				)
 				batch.Queue(queries.RuntimeEVMTokenBalanceUpdate,
-					m.runtime,
+					m.cfg.RuntimeName,
 					staleTokenBalance.TokenAddr,
 					staleTokenBalance.AccountAddr,
 					correction.String(),
@@ -210,7 +209,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 		}
 	}
 	batch.Queue(queries.RuntimeEVMTokenBalanceAnalysisUpdate,
-		m.runtime,
+		m.cfg.RuntimeName,
 		staleTokenBalance.TokenAddr,
 		staleTokenBalance.AccountAddr,
 		staleTokenBalance.DownloadRound,
@@ -295,5 +294,5 @@ func (m Main) Start() {
 }
 
 func (m Main) Name() string {
-	return EvmTokenBalancesAnalyzerPrefix + string(m.runtime)
+	return EvmTokenBalancesAnalyzerPrefix + string(m.cfg.RuntimeName)
 }

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -68,7 +68,7 @@ func NewMain(
 		runtime: runtime,
 		cfg:     ac,
 		target:  target,
-		logger:  logger.With("analyzer", EvmTokensAnalyzerPrefix+runtime.String()),
+		logger:  logger.With("analyzer", EvmTokensAnalyzerPrefix+runtime),
 	}, nil
 }
 
@@ -237,5 +237,5 @@ func (m Main) Start() {
 }
 
 func (m Main) Name() string {
-	return EvmTokensAnalyzerPrefix + m.runtime.String()
+	return EvmTokensAnalyzerPrefix + string(m.runtime)
 }

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -36,7 +36,7 @@ func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.Min
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeMintInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		round,
 		e.Owner.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
@@ -45,7 +45,7 @@ func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.Min
 	// Increase minter's balance.
 	batch.Queue(
 		queries.RuntimeNativeBalanceUpdate,
-		m.runtime,
+		m.cfg.RuntimeName,
 		e.Owner.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
@@ -56,7 +56,7 @@ func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.Bur
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeBurnInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		round,
 		e.Owner.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
@@ -65,7 +65,7 @@ func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.Bur
 	// Decrease burner's balance.
 	batch.Queue(
 		queries.RuntimeNativeBalanceUpdate,
-		m.runtime,
+		m.cfg.RuntimeName,
 		e.Owner.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
 		(&big.Int{}).Neg(e.Amount.Amount.ToBigInt()).String(),
@@ -76,7 +76,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeTransferInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		round,
 		e.From.String(),
 		e.To.String(),
@@ -86,7 +86,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 	// Increase receiver's balance.
 	batch.Queue(
 		queries.RuntimeNativeBalanceUpdate,
-		m.runtime,
+		m.cfg.RuntimeName,
 		e.To.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
@@ -94,7 +94,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 	// Decrease sender's balance.
 	batch.Queue(
 		queries.RuntimeNativeBalanceUpdate,
-		m.runtime,
+		m.cfg.RuntimeName,
 		e.From.String(),
 		m.StringifyDenomination(e.Amount.Denomination),
 		(&big.Int{}).Neg(e.Amount.Amount.ToBigInt()).String(),

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -3,9 +3,10 @@ package runtime
 import (
 	"math/big"
 
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
+
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/storage"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 )
 
 // queueAccountsEvents expands `batch` with DB queries that record the "effects"
@@ -38,7 +39,7 @@ func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.Min
 		m.runtime,
 		round,
 		e.Owner.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
 	)
 	// Increase minter's balance.
@@ -46,7 +47,7 @@ func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.Min
 		queries.RuntimeNativeBalanceUpdate,
 		m.runtime,
 		e.Owner.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
 	)
 }
@@ -58,7 +59,7 @@ func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.Bur
 		m.runtime,
 		round,
 		e.Owner.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
 	)
 	// Decrease burner's balance.
@@ -66,7 +67,7 @@ func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.Bur
 		queries.RuntimeNativeBalanceUpdate,
 		m.runtime,
 		e.Owner.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		(&big.Int{}).Neg(e.Amount.Amount.ToBigInt()).String(),
 	)
 }
@@ -79,7 +80,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 		round,
 		e.From.String(),
 		e.To.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
 	)
 	// Increase receiver's balance.
@@ -87,7 +88,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 		queries.RuntimeNativeBalanceUpdate,
 		m.runtime,
 		e.To.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		e.Amount.Amount.String(),
 	)
 	// Decrease sender's balance.
@@ -95,7 +96,7 @@ func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts
 		queries.RuntimeNativeBalanceUpdate,
 		m.runtime,
 		e.From.String(),
-		m.cfg.Source.StringifyDenomination(e.Amount.Denomination),
+		m.StringifyDenomination(e.Amount.Denomination),
 		(&big.Int{}).Neg(e.Amount.Amount.ToBigInt()).String(),
 	)
 }

--- a/analyzer/runtime/consensusaccounts.go
+++ b/analyzer/runtime/consensusaccounts.go
@@ -1,9 +1,10 @@
 package runtime
 
 import (
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
+
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/storage"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 )
 
 // queueConsensusAccountsEvents expands `batch` with DB queries that record the
@@ -38,7 +39,7 @@ func (m *Main) queueDeposit(batch *storage.QueryBatch, round uint64, e consensus
 	errorModule, errorCode := decomposeError(e.Error)
 	batch.Queue(
 		queries.RuntimeDepositInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		round,
 		e.From.String(),
 		e.To.String(),
@@ -63,7 +64,7 @@ func (m *Main) queueWithdraw(batch *storage.QueryBatch, round uint64, e consensu
 	errorModule, errorCode := decomposeError(e.Error)
 	batch.Queue(
 		queries.RuntimeWithdrawInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		round,
 		e.From.String(),
 		e.To.String(),

--- a/analyzer/runtime/evm_test.go
+++ b/analyzer/runtime/evm_test.go
@@ -29,7 +29,7 @@ var (
 		ChainName: ChainName,
 		Nodes: map[string]*config.NodeConfig{
 			CurrentArchiveName: {
-				RPC: sdkConfig.DefaultNetworks.All[ChainName.String()].RPC,
+				RPC: sdkConfig.DefaultNetworks.All[string(ChainName)].RPC,
 			},
 		},
 		FastStartup: false,

--- a/analyzer/runtime/evm_test.go
+++ b/analyzer/runtime/evm_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 var (
-	ChainName          = "mainnet"
+	ChainName          = common.ChainNameMainnet
 	CurrentArchiveName = config.DefaultChains[ChainName].CurrentRecord().ArchiveName
 	// TODO: Would be nice to have an offline test.
 	PublicSourceConfig = &config.SourceConfig{
 		ChainName: ChainName,
 		Nodes: map[string]*config.NodeConfig{
 			CurrentArchiveName: {
-				RPC: sdkConfig.DefaultNetworks.All[ChainName].RPC,
+				RPC: sdkConfig.DefaultNetworks.All[ChainName.String()].RPC,
 			},
 		},
 		FastStartup: false,

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -69,8 +69,8 @@ func NewRuntimeAnalyzer(
 		runtime: runtime,
 		cfg:     ac,
 		target:  target,
-		logger:  logger.With("analyzer", runtime.String()),
-		metrics: metrics.NewDefaultDatabaseMetrics(runtime.String()),
+		logger:  logger.With("analyzer", runtime),
+		metrics: metrics.NewDefaultDatabaseMetrics(string(runtime)),
 	}, nil
 }
 
@@ -145,7 +145,7 @@ func (m *Main) Start() {
 
 // Name returns the name of the Main.
 func (m *Main) Name() string {
-	return m.runtime.String()
+	return string(m.runtime)
 }
 
 // latestRound returns the latest round processed by the consensus analyzer.
@@ -156,7 +156,7 @@ func (m *Main) latestRound(ctx context.Context) (uint64, error) {
 		queries.LatestBlock,
 		// ^analyzers should only analyze for a single chain ID, and we anchor this
 		// at the starting round.
-		m.runtime.String(),
+		m.runtime,
 	).Scan(&latest); err != nil {
 		return 0, err
 	}
@@ -216,10 +216,10 @@ func (m *Main) processRound(ctx context.Context, round uint64) error {
 	batch.Queue(
 		queries.IndexingProgress,
 		round,
-		m.runtime.String(),
+		m.runtime,
 	)
 
-	opName := fmt.Sprintf("process_block_%s", m.runtime.String())
+	opName := fmt.Sprintf("process_block_%s", m.runtime)
 	timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
 	defer timer.ObserveDuration()
 

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -29,7 +29,6 @@ const (
 
 // Main is the main Analyzer for runtimes.
 type Main struct {
-	runtime common.Runtime
 	cfg     analyzer.RuntimeConfig
 	target  storage.TargetStorage
 	logger  *log.Logger
@@ -61,13 +60,13 @@ func NewRuntimeAnalyzer(
 		To:   uint64(cfg.To),
 	}
 	ac := analyzer.RuntimeConfig{
-		ParaTime: sourceConfig.SDKParaTime(runtime),
-		Range:    roundRange,
-		Source:   client,
+		RuntimeName: runtime,
+		ParaTime:    sourceConfig.SDKParaTime(runtime),
+		Range:       roundRange,
+		Source:      client,
 	}
 
 	return &Main{
-		runtime: runtime,
 		cfg:     ac,
 		target:  target,
 		logger:  logger.With("analyzer", runtime),
@@ -146,7 +145,7 @@ func (m *Main) Start() {
 
 // Name returns the name of the Main.
 func (m *Main) Name() string {
-	return string(m.runtime)
+	return string(m.cfg.RuntimeName)
 }
 
 func (m *Main) nativeTokenSymbol() string {
@@ -172,7 +171,7 @@ func (m *Main) latestRound(ctx context.Context) (uint64, error) {
 		queries.LatestBlock,
 		// ^analyzers should only analyze for a single chain ID, and we anchor this
 		// at the starting round.
-		m.runtime,
+		m.cfg.RuntimeName,
 	).Scan(&latest); err != nil {
 		return 0, err
 	}
@@ -232,10 +231,10 @@ func (m *Main) processRound(ctx context.Context, round uint64) error {
 	batch.Queue(
 		queries.IndexingProgress,
 		round,
-		m.runtime,
+		m.cfg.RuntimeName,
 	)
 
-	opName := fmt.Sprintf("process_block_%s", m.runtime)
+	opName := fmt.Sprintf("process_block_%s", m.cfg.RuntimeName)
 	timer := m.metrics.DatabaseTimer(m.target.Name(), opName)
 	defer timer.ObserveDuration()
 
@@ -252,7 +251,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 	// Block metadata.
 	batch.Queue(
 		queries.RuntimeBlockInsert,
-		m.runtime,
+		m.cfg.RuntimeName,
 		data.Header.Round,
 		data.Header.Version,
 		data.Header.Timestamp,
@@ -272,7 +271,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		for _, signerData := range transactionData.SignerData {
 			batch.Queue(
 				queries.RuntimeTransactionSignerInsert,
-				m.runtime,
+				m.cfg.RuntimeName,
 				data.Header.Round,
 				transactionData.Index,
 				signerData.Index,
@@ -281,7 +280,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			)
 		}
 		for addr := range transactionData.RelatedAccountAddresses {
-			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.runtime, addr, data.Header.Round, transactionData.Index)
+			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.cfg.RuntimeName, addr, data.Header.Round, transactionData.Index)
 		}
 		var error_module string
 		var error_code uint32
@@ -293,7 +292,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		}
 		batch.Queue(
 			queries.RuntimeTransactionInsert,
-			m.runtime,
+			m.cfg.RuntimeName,
 			data.Header.Round,
 			transactionData.Index,
 			transactionData.Hash,
@@ -319,7 +318,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		eventRelatedAddresses := uncategorized.ExtractAddresses(eventData.RelatedAddresses)
 		batch.Queue(
 			queries.RuntimeEventInsert,
-			m.runtime,
+			m.cfg.RuntimeName,
 			data.Header.Round,
 			eventData.TxIndex,
 			eventData.TxHash,
@@ -339,15 +338,15 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 	// Insert EVM token addresses.
 	for addr, possibleToken := range data.PossibleTokens {
 		if possibleToken.Mutated {
-			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateInsert, m.runtime, addr, data.Header.Round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisMutateInsert, m.cfg.RuntimeName, addr, data.Header.Round)
 		} else {
-			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.runtime, addr, data.Header.Round)
+			batch.Queue(queries.RuntimeEVMTokenAnalysisInsert, m.cfg.RuntimeName, addr, data.Header.Round)
 		}
 	}
 
 	// Update EVM token balances (dead reckoning).
 	for key, change := range data.TokenBalanceChanges {
-		batch.Queue(queries.RuntimeEVMTokenBalanceUpdate, m.runtime, key.TokenAddress, key.AccountAddress, change.String())
-		batch.Queue(queries.RuntimeEVMTokenBalanceAnalysisInsert, m.runtime, key.TokenAddress, key.AccountAddress, data.Header.Round)
+		batch.Queue(queries.RuntimeEVMTokenBalanceUpdate, m.cfg.RuntimeName, key.TokenAddress, key.AccountAddress, change.String())
+		batch.Queue(queries.RuntimeEVMTokenBalanceAnalysisInsert, m.cfg.RuntimeName, key.TokenAddress, key.AccountAddress, data.Header.Round)
 	}
 }

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -256,14 +256,14 @@ func RuntimeFromURLMiddleware(baseURL string) func(next http.Handler) http.Handl
 
 			// The first part of the path (after the version) determines the runtime.
 			// Recognize only whitelisted runtimes.
-			runtime := ""
+			var runtime common.Runtime
 			switch {
 			case strings.HasPrefix(path, "/emerald/"):
-				runtime = "emerald"
+				runtime = common.RuntimeEmerald
 			case strings.HasPrefix(path, "/sapphire/"):
-				runtime = "sapphire"
+				runtime = common.RuntimeSapphire
 			case strings.HasPrefix(path, "/cipher/"):
-				runtime = "cipher"
+				runtime = common.RuntimeCipher
 			}
 
 			if runtime != "" {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -258,8 +258,6 @@ func RuntimeFromURLMiddleware(baseURL string) func(next http.Handler) http.Handl
 			// Recognize only whitelisted runtimes.
 			runtime := ""
 			switch {
-			case strings.HasPrefix(path, "/consensus/"):
-				runtime = "consensus"
 			case strings.HasPrefix(path, "/emerald/"):
 				runtime = "emerald"
 			case strings.HasPrefix(path, "/sapphire/"):

--- a/common/types.go
+++ b/common/types.go
@@ -135,10 +135,6 @@ const (
 	ChainNameUnknown ChainName = "unknown"
 )
 
-func (cn ChainName) String() string {
-	return string(cn)
-}
-
 // Runtime is an identifier for a runtime on the Oasis Network.
 type Runtime string
 
@@ -148,8 +144,3 @@ const (
 	RuntimeSapphire Runtime = "sapphire"
 	RuntimeUnknown  Runtime = "unknown"
 )
-
-// String returns the string representation of a runtime.
-func (r Runtime) String() string {
-	return string(r)
-}

--- a/common/types.go
+++ b/common/types.go
@@ -124,14 +124,6 @@ var (
 	ErrRuntimeUnknown = errors.New("runtime unknown")
 )
 
-// ChainID is the ID of a chain.
-type ChainID string
-
-// String returns the string representation of a ChainID.
-func (c ChainID) String() string {
-	return string(c)
-}
-
 // Network is an instance of the Oasis Network.
 type Network uint8
 

--- a/common/types.go
+++ b/common/types.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
-	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
-
 	"github.com/oasisprotocol/oasis-core/go/common/quantity"
 )
 
@@ -141,25 +139,6 @@ func (cn ChainName) String() string {
 	return string(cn)
 }
 
-// FromChainContext identifies a Network using its ChainContext.
-func FromChainContext(chainContext string) (Network, error) {
-	// TODO: Remove this hardcoded value once indexer config supports multiple nodes.
-	if chainContext == "53852332637bacb61b91b6411ab4095168ba02a50be4c3f82448438826f23898" {
-		return NetworkMainnet, nil // cobalt mainnet
-	}
-	var network Network
-	for name, nw := range sdkConfig.DefaultNetworks.All {
-		if nw.ChainContext == chainContext {
-			if err := network.Set(name); err != nil {
-				return NetworkUnknown, err
-			}
-			return network, nil
-		}
-	}
-
-	return NetworkUnknown, ErrNetworkUnknown
-}
-
 // Runtime is an identifier for a runtime on the Oasis Network.
 type Runtime string
 
@@ -173,21 +152,4 @@ const (
 // String returns the string representation of a runtime.
 func (r Runtime) String() string {
 	return string(r)
-}
-
-// ID returns the ID for a Runtime on the provided network.
-func (r Runtime) ID(n Network) (string, error) {
-	for nname, nw := range sdkConfig.DefaultNetworks.All {
-		if nname == n.String() {
-			for pname, pt := range nw.ParaTimes.All {
-				if pname == r.String() {
-					return pt.ID, nil
-				}
-			}
-
-			return "", ErrRuntimeUnknown
-		}
-	}
-
-	return "", ErrRuntimeUnknown
 }

--- a/common/types.go
+++ b/common/types.go
@@ -124,17 +124,22 @@ var (
 	ErrRuntimeUnknown = errors.New("runtime unknown")
 )
 
-// Network is an instance of the Oasis Network.
-type Network uint8
+// ChainName is a name given to a sequence of networks. Used to index
+// config.DefaultChains and sdkConfig.DefaultNetworks.All.
+type ChainName string
 
 const (
-	// NetworkTestnet is the identifier for testnet.
-	NetworkTestnet Network = iota
-	// NetworkMainnet is the identifier for mainnet.
-	NetworkMainnet
-	// NetworkUnknown is the identifier for an unknown network.
-	NetworkUnknown = 255
+	// ChainNameTestnet is the identifier for testnet.
+	ChainNameTestnet ChainName = "testnet"
+	// ChainNameMainnet is the identifier for mainnet.
+	ChainNameMainnet ChainName = "mainnet"
+	// ChainNameUnknown is the identifier for an unknown network.
+	ChainNameUnknown ChainName = "unknown"
 )
+
+func (cn ChainName) String() string {
+	return string(cn)
+}
 
 // FromChainContext identifies a Network using its ChainContext.
 func FromChainContext(chainContext string) (Network, error) {
@@ -153,32 +158,6 @@ func FromChainContext(chainContext string) (Network, error) {
 	}
 
 	return NetworkUnknown, ErrNetworkUnknown
-}
-
-// Set sets the Network to the value specified by the provided string.
-func (n *Network) Set(s string) error {
-	switch strings.ToLower(s) {
-	case "mainnet":
-		*n = NetworkMainnet
-	case "testnet":
-		*n = NetworkTestnet
-	default:
-		return ErrNetworkUnknown
-	}
-
-	return nil
-}
-
-// String returns the string representation of a network.
-func (n Network) String() string {
-	switch n {
-	case NetworkTestnet:
-		return "testnet"
-	case NetworkMainnet:
-		return "mainnet"
-	default:
-		return "unknown"
-	}
 }
 
 // Runtime is an identifier for a runtime on the Oasis Network.

--- a/config/config.go
+++ b/config/config.go
@@ -263,7 +263,8 @@ func (cfg *AggregateStatsConfig) Validate() error {
 
 // ServerConfig contains the API server configuration.
 type ServerConfig struct {
-	// ChainName is the name of the chain (e.g. mainnet/testnet/local).
+	// ChainName is the name of the chain (i.e. mainnet/testnet). Custom/local nets are not supported.
+	// This is only used for the runtime status endpoint.
 	ChainName common.ChainName `koanf:"chain_name"`
 
 	// Endpoint is the service endpoint from which to serve the API.

--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ func (sc *SourceConfig) History() *History {
 
 func (sc *SourceConfig) SDKNetwork() *sdkConfig.Network {
 	if sc.ChainName != "" {
-		return sdkConfig.DefaultNetworks.All[sc.ChainName.String()]
+		return sdkConfig.DefaultNetworks.All[string(sc.ChainName)]
 	}
 	return sc.CustomChain.SDKNetwork
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/knadh/koanf/providers/file"
 	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
 )
 
@@ -122,7 +123,7 @@ type SourceConfig struct {
 
 	// ChainName is the name of the chain (e.g. mainnet/testnet). Set
 	// this to use one of the default chains.
-	ChainName string `koanf:"chain_name"`
+	ChainName common.ChainName `koanf:"chain_name"`
 	// CustomChain is information about a custom chain. Set this to use a
 	// chain other than the default chains, e.g. a local testnet.
 	CustomChain *CustomChainConfig `koanf:"custom_chain"`
@@ -147,7 +148,7 @@ func (sc *SourceConfig) History() *History {
 
 func (sc *SourceConfig) SDKNetwork() *sdkConfig.Network {
 	if sc.ChainName != "" {
-		return sdkConfig.DefaultNetworks.All[sc.ChainName]
+		return sdkConfig.DefaultNetworks.All[sc.ChainName.String()]
 	}
 	return sc.CustomChain.SDKNetwork
 }
@@ -259,7 +260,7 @@ func (cfg *AggregateStatsConfig) Validate() error {
 // ServerConfig contains the API server configuration.
 type ServerConfig struct {
 	// ChainName is the name of the chain (e.g. mainnet/testnet/local).
-	ChainName string `koanf:"chain_name"`
+	ChainName common.ChainName `koanf:"chain_name"`
 
 	// Endpoint is the service endpoint from which to serve the API.
 	Endpoint string `koanf:"endpoint"`

--- a/config/config.go
+++ b/config/config.go
@@ -153,6 +153,10 @@ func (sc *SourceConfig) SDKNetwork() *sdkConfig.Network {
 	return sc.CustomChain.SDKNetwork
 }
 
+func (sc *SourceConfig) SDKParaTime(runtime common.Runtime) *sdkConfig.ParaTime {
+	return sc.SDKNetwork().ParaTimes.All[string(runtime)]
+}
+
 func CustomSingleNetworkSourceConfig(rpc string, chainContext string) *SourceConfig {
 	return &SourceConfig{
 		CustomChain: &CustomChainConfig{

--- a/config/history.go
+++ b/config/history.go
@@ -83,8 +83,8 @@ func SingleRecordHistory(chainContext string) *History {
 	}
 }
 
-var DefaultChains = map[string]*History{
-	"mainnet": {
+var DefaultChains = map[common.ChainName]*History{
+	common.ChainNameMainnet: {
 		Records: []*Record{
 			{
 				// https://github.com/oasisprotocol/mainnet-artifacts/releases/tag/2022-04-11
@@ -126,7 +126,7 @@ var DefaultChains = map[string]*History{
 			},
 		},
 	},
-	"testnet": {
+	common.ChainNameTestnet: {
 		Records: []*Record{
 			// TODO: coalesce compatible records
 			// TODO: rename archives to match compatible API

--- a/storage/api.go
+++ b/storage/api.go
@@ -11,8 +11,9 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
-	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
+
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 type BatchItem struct {
@@ -223,11 +224,6 @@ type RuntimeSourceStorage interface {
 
 	// EVMSimulateCall gets the result of the given EVM simulate call query.
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
-
-	// StringifyDenomination returns a string representation of the given denomination.
-	// This is simply the denomination's symbol; notably, for the native denomination,
-	// this is looked up from network config.
-	StringifyDenomination(d sdkTypes.Denomination) string
 }
 
 type RuntimeAllData struct {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -48,12 +48,12 @@ type StorageClient struct {
 
 // runtimeNameToID returns the runtime ID for the given network and runtime name.
 func runtimeNameToID(chainName common.ChainName, name common.Runtime) (string, error) {
-	network, exists := oasisConfig.DefaultNetworks.All[chainName.String()]
+	network, exists := oasisConfig.DefaultNetworks.All[string(chainName)]
 	if !exists {
 		return "", fmt.Errorf("unknown network: %s", chainName)
 	}
 
-	paratime, exists := network.ParaTimes.All[name.String()]
+	paratime, exists := network.ParaTimes.All[string(name)]
 	if !exists {
 		return "", fmt.Errorf("unknown runtime: %s", name)
 	}

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -54,9 +54,8 @@ func NewConsensusClient(ctx context.Context, sourceConfig *config.SourceConfig) 
 
 // NewRuntimeClient creates a new RuntimeClient.
 func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, runtime common.Runtime) (*RuntimeClient, error) {
-	sdkPT := sourceConfig.SDKNetwork().ParaTimes.All[string(runtime)]
 	var nodeApi nodeapi.RuntimeApiLite
-	nodeApi, err := history.NewHistoryRuntimeApiLite(ctx, sourceConfig.History(), sdkPT, sourceConfig.Nodes, sourceConfig.FastStartup, runtime)
+	nodeApi, err := history.NewHistoryRuntimeApiLite(ctx, sourceConfig.History(), sourceConfig.SDKParaTime(runtime), sourceConfig.Nodes, sourceConfig.FastStartup, runtime)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating history runtime API lite: %w", err)
 	}
@@ -77,6 +76,5 @@ func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, ru
 
 	return &RuntimeClient{
 		nodeApi: nodeApi,
-		sdkPT:   sdkPT,
 	}, nil
 }

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -66,9 +66,9 @@ func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, ru
 	if sourceConfig.Cache != nil {
 		cachePath := filepath.Join(sourceConfig.Cache.CacheDir, runtime.String())
 		if sourceConfig.Cache.QueryOnCacheMiss {
-			nodeApi, err = file.NewFileRuntimeApiLite(runtime.String(), cachePath, nodeApi)
+			nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nodeApi)
 		} else {
-			nodeApi, err = file.NewFileRuntimeApiLite(runtime.String(), cachePath, nil)
+			nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nil)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("error instantiating cache-based runtimeApi: %w", err)

--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -54,7 +54,7 @@ func NewConsensusClient(ctx context.Context, sourceConfig *config.SourceConfig) 
 
 // NewRuntimeClient creates a new RuntimeClient.
 func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, runtime common.Runtime) (*RuntimeClient, error) {
-	sdkPT := sourceConfig.SDKNetwork().ParaTimes.All[runtime.String()]
+	sdkPT := sourceConfig.SDKNetwork().ParaTimes.All[string(runtime)]
 	var nodeApi nodeapi.RuntimeApiLite
 	nodeApi, err := history.NewHistoryRuntimeApiLite(ctx, sourceConfig.History(), sdkPT, sourceConfig.Nodes, sourceConfig.FastStartup, runtime)
 	if err != nil {
@@ -64,7 +64,7 @@ func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, ru
 	// todo: short circuit if using purely a file-based backend and avoid connecting
 	// to the node at all. this requires storing runtime info offline.
 	if sourceConfig.Cache != nil {
-		cachePath := filepath.Join(sourceConfig.Cache.CacheDir, runtime.String())
+		cachePath := filepath.Join(sourceConfig.Cache.CacheDir, string(runtime))
 		if sourceConfig.Cache.QueryOnCacheMiss {
 			nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nodeApi)
 		} else {

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -6,11 +6,12 @@ import (
 	"github.com/akrylysov/pogreb"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 type FileRuntimeApiLite struct {
-	runtime    string
+	runtime    common.Runtime
 	db         KVStore
 	runtimeApi nodeapi.RuntimeApiLite
 }
@@ -19,7 +20,7 @@ type RuntimeApiMethod func() (interface{}, error)
 
 var _ nodeapi.RuntimeApiLite = (*FileRuntimeApiLite)(nil)
 
-func NewFileRuntimeApiLite(runtime string, cacheDir string, runtimeApi nodeapi.RuntimeApiLite) (*FileRuntimeApiLite, error) {
+func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi nodeapi.RuntimeApiLite) (*FileRuntimeApiLite, error) {
 	db, err := pogreb.Open(cacheDir, &pogreb.Options{BackgroundSyncInterval: -1})
 	if err != nil {
 		return nil, err

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -3,9 +3,6 @@ package oasis
 import (
 	"context"
 
-	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
-	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
-
 	"github.com/oasisprotocol/oasis-indexer/storage"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
@@ -17,7 +14,6 @@ import (
 // TODO: Get rid of this struct, it hardly provides any value.
 type RuntimeClient struct {
 	nodeApi nodeapi.RuntimeApiLite
-	sdkPT   *sdkConfig.ParaTime
 }
 
 // AllData returns all relevant data to the given round.
@@ -46,16 +42,4 @@ func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.Ru
 
 func (rc *RuntimeClient) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
 	return rc.nodeApi.EVMSimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
-}
-
-func (rc *RuntimeClient) nativeTokenSymbol() string {
-	return rc.sdkPT.Denominations[sdkConfig.NativeDenominationKey].Symbol
-}
-
-func (rc *RuntimeClient) StringifyDenomination(d sdkTypes.Denomination) string {
-	if d.IsNative() {
-		return rc.nativeTokenSymbol()
-	}
-
-	return d.String()
 }

--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -5,16 +5,12 @@ import (
 	"os"
 	"testing"
 
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	common "github.com/oasisprotocol/oasis-indexer/common"
-)
-
-const (
-	EmeraldName = "emerald"
 )
 
 var RuntimeTables = []string{"runtime_sdk_balances"}
@@ -26,10 +22,10 @@ type TestRuntimeAccount struct {
 }
 
 func TestEmeraldAccounts(t *testing.T) {
-	testRuntimeAccounts(t, EmeraldName)
+	testRuntimeAccounts(t, common.RuntimeEmerald)
 }
 
-func testRuntimeAccounts(t *testing.T, runtime string) {
+func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 	if _, ok := os.LookupEnv("OASIS_INDEXER_HEALTHCHECK"); !ok {
 		t.Skip("skipping test since healthcheck tests are not enabled")
 	}
@@ -38,30 +34,19 @@ func testRuntimeAccounts(t *testing.T, runtime string) {
 
 	ctx := context.Background()
 
-	network, err := common.FromChainContext(MainnetChainContext)
-	require.Nil(t, err)
-
-	var runtimeID string
-	switch runtime {
-	case "emerald":
-		runtimeID, err = common.RuntimeEmerald.ID(network)
-	case "sapphire":
-		runtimeID, err = common.RuntimeSapphire.ID(network)
-	}
-	require.Nil(t, err)
-	t.Log("Runtime ID determined", "runtime", runtime, "runtime_id", runtimeID)
+	sdkNet := sdkConfig.DefaultNetworks.All[ChainName.String()]
+	sdkPT := sdkNet.ParaTimes.All[runtime.String()]
+	t.Log("Runtime ID determined", "runtime", runtime, "runtime_id", sdkPT.ID)
 
 	conn, err := newSdkConnection(ctx)
 	require.Nil(t, err)
-	oasisRuntimeClient := conn.Runtime(&config.ParaTime{
-		ID: runtimeID,
-	})
+	oasisRuntimeClient := conn.Runtime(sdkPT)
 
 	postgresClient, err := newTargetClient(t)
 	assert.Nil(t, err)
 
 	t.Log("Creating snapshot for runtime tables...")
-	height, err := snapshotBackends(postgresClient, runtime, RuntimeTables)
+	height, err := snapshotBackends(postgresClient, runtime.String(), RuntimeTables)
 	assert.Nil(t, err)
 
 	t.Logf("Fetching accounts information at height %d...", height)
@@ -104,7 +89,7 @@ func testRuntimeAccounts(t *testing.T, runtime string) {
 		balances, err := oasisRuntimeClient.Accounts.Balances(ctx, uint64(height), actualAddr)
 		assert.Nil(t, err)
 		for denom, amount := range balances.Balances {
-			if stringifyDenomination(denom, runtimeID) == a.Symbol {
+			if stringifyDenomination(denom, sdkPT) == a.Symbol {
 				assert.Equal(t, amount.ToBigInt(), a.Balance)
 			}
 			assert.Equal(t, amount.ToBigInt().Int64(), a.Balance)
@@ -121,28 +106,15 @@ func testRuntimeAccounts(t *testing.T, runtime string) {
 	}
 }
 
-func nativeTokenSymbol(runtimeID string) string {
-	// Iterate over all networks and find the one that contains the runtime.
-	// Any network will do; we assume that paratime IDs are unique across networks.
-	// TODO: Remove this assumption; paratime IDs are chosen by the entity that registers them,
-	// so conflicts (particularly intentional/malicious) are possible. Not that
-	// it would hurt the statecheck much, beyond generating a false alarm.
-	// https://github.com/oasisprotocol/oasis-indexer/pull/362#discussion_r1153606360
-	for _, network := range config.DefaultNetworks.All {
-		for _, paratime := range network.ParaTimes.All {
-			if paratime.ID == runtimeID {
-				return paratime.Denominations[config.NativeDenominationKey].Symbol
-			}
-		}
-	}
-	panic("Cannot find native token symbol for runtime")
+func nativeTokenSymbol(sdkPT *sdkConfig.ParaTime) string {
+	return sdkPT.Denominations[sdkConfig.NativeDenominationKey].Symbol
 }
 
 // StringifyDenomination returns a string representation denomination `d`
 // in the context of `runtimeID`. The context matters for the native denomination.
-func stringifyDenomination(d sdkTypes.Denomination, runtimeID string) string {
+func stringifyDenomination(d sdkTypes.Denomination, sdkPT *sdkConfig.ParaTime) string {
 	if d.IsNative() {
-		return nativeTokenSymbol(runtimeID)
+		return nativeTokenSymbol(sdkPT)
 	}
 
 	return d.String()

--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -34,8 +34,8 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 
 	ctx := context.Background()
 
-	sdkNet := sdkConfig.DefaultNetworks.All[ChainName.String()]
-	sdkPT := sdkNet.ParaTimes.All[runtime.String()]
+	sdkNet := sdkConfig.DefaultNetworks.All[string(ChainName)]
+	sdkPT := sdkNet.ParaTimes.All[string(runtime)]
 	t.Log("Runtime ID determined", "runtime", runtime, "runtime_id", sdkPT.ID)
 
 	conn, err := newSdkConnection(ctx)
@@ -46,7 +46,7 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 	assert.Nil(t, err)
 
 	t.Log("Creating snapshot for runtime tables...")
-	height, err := snapshotBackends(postgresClient, runtime.String(), RuntimeTables)
+	height, err := snapshotBackends(postgresClient, string(runtime), RuntimeTables)
 	assert.Nil(t, err)
 
 	t.Logf("Fetching accounts information at height %d...", height)

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -8,16 +8,18 @@ import (
 	"testing"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/oasisprotocol/oasis-indexer/log"
-	"github.com/oasisprotocol/oasis-indexer/storage"
-	"github.com/oasisprotocol/oasis-indexer/storage/postgres"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/oasisprotocol/oasis-indexer/common"
+	"github.com/oasisprotocol/oasis-indexer/log"
+	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/postgres"
 )
 
 const (
-	MainnetChainContext = "b11b369e0da5bb230b220127f5e7b242d385ef8c6f54906243f30af63c815535"
+	ChainName = common.ChainNameMainnet
 )
 
 func newTargetClient(t *testing.T) (*postgres.Client, error) {


### PR DESCRIPTION
fixes #387

- ChainID: unused, removing
- Network: we no longer talk about networks, as they're too short-lived. we're letting the SDK have that term. the indexer now talks about "chains." thus we're providing a new typed string, "ChainName" for that purpose
- "consensus" as the 'runtime' in an API request context: seems unused, and I don't remember if we had anything planned for it. removing. but let me know if we shouldn't
- `.String()`: had been carried over from when these were special uint8s, but lately we're more into types that actually are strings. removing. use `string(...)` where needed
- StringifyDenomination: we mixed that into RuntimeClient because it had conveniently had the sdkPT there. but it's configuration rather than storage, and it's the only remaining thing needing the sdkPT field, and it's the only thing structurally differentiating RuntimeClient from RuntimeLiteApi. moving it to runtime.Main. runtime.Main.cfg now has the equivalent .ParaTime field, if anyone needs it
- runtime-related analyzers (incl. token and token balance) `runtime common.Runtime` field moved to `RuntimeConfig.RuntimeName` (i.e. `.runtime` becomes `.cfg.RuntimeName`)