### PR TITLE
analyzers, cache: Allow to shut down gracefully

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -79,11 +79,7 @@ func NewAggregateStatsAnalyzer(cfg *config.AggregateStatsConfig, target storage.
 	}, nil
 }
 
-func (a *AggregateStatsAnalyzer) Start() {
-	// TODO: ideally analyzers would get a top level context passed in.
-	// That way the analyzers can gracefully shutdown on application termination.
-	ctx := context.Background()
-
+func (a *AggregateStatsAnalyzer) Start(ctx context.Context) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -121,7 +117,7 @@ func (a *AggregateStatsAnalyzer) txVolumeWorker(ctx context.Context) {
 		case <-time.After(a.txVolumeInterval):
 			// Update stats.
 		case <-ctx.Done():
-			a.logger.Error("shutting down tx volume worker", "err", ctx.Err())
+			a.logger.Error("shutting down tx volume worker", "reason", ctx.Err())
 			return
 		}
 	}
@@ -240,9 +236,10 @@ func (a *AggregateStatsAnalyzer) dailyActiveAccountsWorker(ctx context.Context) 
 
 		select {
 		case <-time.After(dailyActiveAccountsInterval):
-			// Update stats.
+			// Update stats again.
 		case <-ctx.Done():
-			a.logger.Error("shutting down daily active accounts worker", "err", ctx.Err())
+			a.logger.Error("shutting down daily active accounts worker", "reason", ctx.Err())
+			// No cleanup needed.
 			return
 		}
 	}

--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -239,7 +239,6 @@ func (a *AggregateStatsAnalyzer) dailyActiveAccountsWorker(ctx context.Context) 
 			// Update stats again.
 		case <-ctx.Done():
 			a.logger.Error("shutting down daily active accounts worker", "reason", ctx.Err())
-			// No cleanup needed.
 			return
 		}
 	}

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"errors"
 
 	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
@@ -22,7 +23,7 @@ var (
 // Analyzer is a worker that analyzes a subset of the Oasis Network.
 type Analyzer interface {
 	// Start starts the analyzer.
-	Start()
+	Start(ctx context.Context)
 
 	// Name returns the name of the analyzer.
 	Name() string

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -258,6 +258,8 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 }
 
 func (m Main) Start(ctx context.Context) {
+	defer m.cleanup()
+
 	backoff, err := util.NewBackoff(
 		100*time.Millisecond,
 		// Cap the timeout at the expected round time. All runtimes currently have the same round time.

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -301,7 +301,9 @@ func (m Main) Start(ctx context.Context) {
 }
 
 func (m *Main) cleanup() {
-	m.cfg.Source.Close()
+	if err := m.cfg.Source.Close(); err != nil {
+		m.logger.Error("error closing data source", "err", err)
+	}
 }
 
 func (m Main) Name() string {

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -200,6 +200,8 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 }
 
 func (m Main) Start(ctx context.Context) {
+	defer m.cleanup()
+
 	backoff, err := util.NewBackoff(
 		100*time.Millisecond,
 		// Cap the timeout at the expected round time. All runtimes currently have the same round time.
@@ -218,7 +220,6 @@ func (m Main) Start(ctx context.Context) {
 			// Process next block.
 		case <-ctx.Done():
 			m.logger.Warn("shutting down evm_tokens analyzer", "reason", ctx.Err())
-			m.cleanup()
 			return
 		}
 

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -199,9 +199,7 @@ func (m Main) processBatch(ctx context.Context) (int, error) {
 	return len(staleTokens), nil
 }
 
-func (m Main) Start() {
-	ctx := context.Background()
-
+func (m Main) Start(ctx context.Context) {
 	backoff, err := util.NewBackoff(
 		100*time.Millisecond,
 		// Cap the timeout at the expected round time. All runtimes currently have the same round time.
@@ -215,7 +213,14 @@ func (m Main) Start() {
 	}
 
 	for {
-		backoff.Wait()
+		select {
+		case <-time.After(backoff.Timeout()):
+			// Process next block.
+		case <-ctx.Done():
+			m.logger.Warn("shutting down evm_tokens analyzer", "reason", ctx.Err())
+			m.cleanup()
+			return
+		}
 
 		numProcessed, err := m.processBatch(ctx)
 		if err != nil {
@@ -233,6 +238,10 @@ func (m Main) Start() {
 
 		backoff.Success()
 	}
+}
+
+func (m *Main) cleanup() {
+	m.cfg.Source.Close()
 }
 
 func (m Main) Name() string {

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -242,7 +242,9 @@ func (m Main) Start(ctx context.Context) {
 }
 
 func (m *Main) cleanup() {
-	m.cfg.Source.Close()
+	if err := m.cfg.Source.Close(); err != nil {
+		m.logger.Error("error closing data source", "err", err)
+	}
 }
 
 func (m Main) Name() string {

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -57,7 +57,6 @@ func (a *MetadataRegistryAnalyzer) Start(ctx context.Context) {
 			// Fetch data again.
 		case <-ctx.Done():
 			a.logger.Warn("shutting down metadata analyzer", "reason", ctx.Err())
-			// No clean-up needed.
 			return
 		}
 	}

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -77,7 +77,7 @@ func NewRuntimeAnalyzer(
 func (m *Main) Start(ctx context.Context) {
 	defer m.cleanup()
 
-	if err := m.prework(); err != nil {
+	if err := m.prework(ctx); err != nil {
 		m.logger.Error("error doing prework",
 			"err", err,
 		)
@@ -193,9 +193,8 @@ func (m *Main) latestRound(ctx context.Context) (uint64, error) {
 }
 
 // prework performs tasks that need to be done before the main loop starts.
-func (m *Main) prework() error {
+func (m *Main) prework(ctx context.Context) error {
 	batch := &storage.QueryBatch{}
-	ctx := context.Background()
 
 	// Register special addresses.
 	batch.Queue(

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -75,6 +75,8 @@ func NewRuntimeAnalyzer(
 }
 
 func (m *Main) Start(ctx context.Context) {
+	defer m.cleanup()
+
 	if err := m.prework(); err != nil {
 		m.logger.Error("error doing prework",
 			"err", err,
@@ -118,7 +120,6 @@ func (m *Main) Start(ctx context.Context) {
 			// Process next block.
 		case <-ctx.Done():
 			m.logger.Warn("shutting down runtime analyzer", "reason", ctx.Err())
-			m.cleanup()
 			return
 		}
 		m.logger.Info("attempting block", "round", round)
@@ -149,7 +150,11 @@ func (m *Main) Start(ctx context.Context) {
 }
 
 func (m *Main) cleanup() {
-	m.cfg.Source.Close()
+	if err := m.cfg.Source.Close(); err != nil {
+		m.logger.Error("failed to cleanly close consensus data source",
+			"err", err.Error(),
+		)
+	}
 }
 
 // Name returns the name of the Main.

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -274,14 +274,10 @@ func (a *Service) Start() {
 		a.logger.Info("received interrupt, shutting down")
 		// Cancel the analyzers' context and wait for them to exit cleanly.
 		cancelAnalyzers()
-		select {
-		case <-analyzersDone:
-			a.logger.Info("all analyzers have exited cleanly")
-			return
-		case <-signalChan:
-			a.logger.Info("received second interrupt, forcing exit")
-			return
-		}
+		signal.Stop(signalChan) // Let the default handler handle ctrl+C so people can kill the process in a hurry.
+		<-analyzersDone
+		a.logger.Info("all analyzers have exited cleanly")
+		return
 	}
 }
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -64,7 +64,7 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		os.Exit(1)
 	}
-	defer service.Shutdown()
+	defer service.cleanup()
 
 	service.Start()
 }
@@ -113,6 +113,7 @@ func NewService(cfg *config.ServerConfig) (*Service, error) {
 
 // Start starts the API service.
 func (s *Service) Start() {
+	defer s.cleanup()
 	s.logger.Info("starting api service at " + s.address)
 
 	// Routes to static files (openapi spec).
@@ -169,8 +170,8 @@ func (s *Service) Start() {
 	)
 }
 
-// Shutdown gracefully shuts down the service.
-func (s *Service) Shutdown() {
+// cleanup gracefully shuts down the service.
+func (s *Service) cleanup() {
 	s.target.Shutdown()
 }
 

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -64,7 +64,6 @@ func runServer(cmd *cobra.Command, args []string) {
 	if err != nil {
 		os.Exit(1)
 	}
-	defer service.cleanup()
 
 	service.Start()
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,9 +30,6 @@ var (
 type Service interface {
 	// Start starts the service.
 	Start()
-
-	// Shutdown shuts down the service.
-	Shutdown()
 }
 
 func rootMain(cmd *cobra.Command, args []string) {
@@ -60,7 +57,6 @@ func rootMain(cmd *cobra.Command, args []string) {
 		wg.Add(1)
 		go func(s Service) {
 			defer wg.Done()
-			defer s.Shutdown()
 			s.Start()
 		}(s)
 	}

--- a/storage/api.go
+++ b/storage/api.go
@@ -126,6 +126,10 @@ type ConsensusSourceStorage interface {
 
 	// Name returns the name of the source storage.
 	Name() string
+
+	// Close instructs the source storage to clean up resources. Calling other
+	// methods after this one results in undefined behavior.
+	Close() error
 }
 
 type ConsensusAllData struct {
@@ -224,6 +228,10 @@ type RuntimeSourceStorage interface {
 
 	// EVMSimulateCall gets the result of the given EVM simulate call query.
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
+
+	// Close instructs the source storage to clean up resources. Calling other
+	// methods after this one results in undefined behavior.
+	Close() error
 }
 
 type RuntimeAllData struct {

--- a/storage/api.go
+++ b/storage/api.go
@@ -264,8 +264,8 @@ type TargetStorage interface {
 	// QueryRow submits a query to fetch a single row of data from target storage.
 	QueryRow(ctx context.Context, sql string, args ...interface{}) QueryResult
 
-	// Shutdown shuts down the target storage client.
-	Shutdown()
+	// Close shuts down the target storage client.
+	Close()
 
 	// Name returns the name of the target storage.
 	Name() string

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -113,7 +113,7 @@ func NewStorageClient(chainName common.ChainName, db storage.TargetStorage, l *l
 
 // Shutdown closes the backing TargetStorage.
 func (c *StorageClient) Shutdown() {
-	c.db.Shutdown()
+	c.db.Close()
 }
 
 // Wraps an error into one of the error types defined by the `common` package, if applicable.

--- a/storage/oasis/consensus.go
+++ b/storage/oasis/consensus.go
@@ -27,6 +27,10 @@ type ConsensusClient struct {
 	network *sdkConfig.Network
 }
 
+func (cc *ConsensusClient) Close() error {
+	return cc.nodeApi.Close()
+}
+
 // GenesisDocument returns the original genesis document.
 func (cc *ConsensusClient) GenesisDocument(ctx context.Context) (*genesisAPI.Document, error) {
 	return cc.nodeApi.GetGenesisDocument(ctx)

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -54,6 +54,7 @@ type ConsensusApiLite interface {
 	GetValidators(ctx context.Context, height int64) ([]Validator, error)
 	GetCommittees(ctx context.Context, height int64, runtimeID coreCommon.Namespace) ([]Committee, error)
 	GetProposal(ctx context.Context, height int64, proposalID uint64) (*Proposal, error)
+	Close() error
 }
 
 // A lightweight subset of `consensus.TransactionsWithResults`.
@@ -202,6 +203,7 @@ type RuntimeApiLite interface {
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
 	GetTransactionsWithResults(ctx context.Context, round uint64) ([]RuntimeTransactionWithResults, error)
+	Close() error
 }
 
 type (

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -45,6 +45,10 @@ func NewCobaltConsensusApiLite(grpcConn *grpc.ClientConn) *CobaltConsensusApiLit
 	}
 }
 
+func (c *CobaltConsensusApiLite) Close() error {
+	return c.grpcConn.Close()
+}
+
 func (c *CobaltConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
 	var rsp genesisCobalt.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -36,6 +36,10 @@ func NewDamaskConsensusApiLite(client consensus.ClientBackend) *DamaskConsensusA
 	}
 }
 
+func (c *DamaskConsensusApiLite) Close() error {
+	return nil // Nothing to do; c.client does not expose a Close() method despite containing a gRPC connection.
+}
+
 func (c *DamaskConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
 	return c.client.GetGenesisDocument(ctx)
 }

--- a/storage/oasis/nodeapi/file/common.go
+++ b/storage/oasis/nodeapi/file/common.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/akrylysov/pogreb"
 	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+	"github.com/oasisprotocol/oasis-indexer/log"
 )
 
 type NodeApiMethod func() (interface{}, error)
@@ -30,6 +31,11 @@ func generateCacheKey(methodName string, params ...interface{}) []byte {
 }
 
 type KVStore struct{ *pogreb.DB }
+
+func (s KVStore) Close() error {
+	log.NewDefaultLogger("kvstore").Info("closing KVStore")
+	return s.DB.Close()
+}
 
 // getFromCacheOrCall fetches the value of `cacheKey` from the cache if it exists,
 // interpreted as a `Value`. If it does not exist, it calls `valueFunc` to get the

--- a/storage/oasis/nodeapi/file/common.go
+++ b/storage/oasis/nodeapi/file/common.go
@@ -1,8 +1,6 @@
 package file
 
 import (
-	"bytes"
-	"encoding/gob"
 	"errors"
 
 	"github.com/akrylysov/pogreb"
@@ -15,19 +13,7 @@ type NodeApiMethod func() (interface{}, error)
 var ErrUnstableRPCMethod = errors.New("this method is not cacheable because the RPC return value is not constant")
 
 func generateCacheKey(methodName string, params ...interface{}) []byte {
-	var buf bytes.Buffer
-	enc := gob.NewEncoder(&buf)
-	err := enc.Encode(methodName)
-	if err != nil {
-		panic(err)
-	}
-	for _, p := range params {
-		err = enc.Encode(p)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return buf.Bytes()
+	return cbor.Marshal([]interface{}{methodName, params})
 }
 
 type KVStore struct{ *pogreb.DB }

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -38,7 +38,12 @@ func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiL
 }
 
 func (c *FileConsensusApiLite) Close() error {
-	return c.db.Close()
+	// Close all resources and return the first encountered error, if any.
+	firstErr := c.consensusApi.Close()
+	if err := c.db.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 func (c *FileConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -3,12 +3,12 @@ package file
 import (
 	"context"
 
-	"github.com/akrylysov/pogreb"
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
 	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesis "github.com/oasisprotocol/oasis-core/go/genesis/api"
 
+	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
@@ -24,12 +24,15 @@ type FileConsensusApiLite struct {
 var _ nodeapi.ConsensusApiLite = (*FileConsensusApiLite)(nil)
 
 func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiLite) (*FileConsensusApiLite, error) {
-	db, err := pogreb.Open(cacheDir, &pogreb.Options{BackgroundSyncInterval: -1})
+	db, err := OpenKVStore(
+		log.NewDefaultLogger("cached-node-api").With("runtime", "consensus"),
+		cacheDir,
+	)
 	if err != nil {
 		return nil, err
 	}
 	return &FileConsensusApiLite{
-		db:           KVStore{db},
+		db:           *db,
 		consensusApi: consensusApi,
 	}, nil
 }

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -34,6 +34,10 @@ func NewFileConsensusApiLite(filename string, consensusApi nodeapi.ConsensusApiL
 	}, nil
 }
 
+func (c *FileConsensusApiLite) Close() error {
+	return c.db.Close()
+}
+
 func (c *FileConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
 	return GetFromCacheOrCall(
 		c.db, false,

--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -23,8 +23,8 @@ type FileConsensusApiLite struct {
 
 var _ nodeapi.ConsensusApiLite = (*FileConsensusApiLite)(nil)
 
-func NewFileConsensusApiLite(filename string, consensusApi nodeapi.ConsensusApiLite) (*FileConsensusApiLite, error) {
-	db, err := pogreb.Open(filename, &pogreb.Options{BackgroundSyncInterval: -1})
+func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiLite) (*FileConsensusApiLite, error) {
+	db, err := pogreb.Open(cacheDir, &pogreb.Options{BackgroundSyncInterval: -1})
 	if err != nil {
 		return nil, err
 	}

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -3,10 +3,10 @@ package file
 import (
 	"context"
 
-	"github.com/akrylysov/pogreb"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api"
 
 	"github.com/oasisprotocol/oasis-indexer/common"
+	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
@@ -21,13 +21,16 @@ type RuntimeApiMethod func() (interface{}, error)
 var _ nodeapi.RuntimeApiLite = (*FileRuntimeApiLite)(nil)
 
 func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi nodeapi.RuntimeApiLite) (*FileRuntimeApiLite, error) {
-	db, err := pogreb.Open(cacheDir, &pogreb.Options{BackgroundSyncInterval: -1})
+	db, err := OpenKVStore(
+		log.NewDefaultLogger("cached-node-api").With("runtime", runtime),
+		cacheDir,
+	)
 	if err != nil {
 		return nil, err
 	}
 	return &FileRuntimeApiLite{
 		runtime:    runtime,
-		db:         KVStore{db},
+		db:         *db,
 		runtimeApi: runtimeApi,
 	}, nil
 }

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -32,6 +32,10 @@ func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi n
 	}, nil
 }
 
+func (r *FileRuntimeApiLite) Close() error {
+	return r.db.Close()
+}
+
 func (r *FileRuntimeApiLite) GetBlockHeader(ctx context.Context, round uint64) (*nodeapi.RuntimeBlockHeader, error) {
 	return GetFromCacheOrCall(
 		r.db, round == roothash.RoundLatest,

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -36,7 +36,12 @@ func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi n
 }
 
 func (r *FileRuntimeApiLite) Close() error {
-	return r.db.Close()
+	// Close all resources and return the first encountered error, if any.
+	firstErr := r.runtimeApi.Close()
+	if err := r.db.Close(); err != nil && firstErr == nil {
+		firstErr = err
+	}
+	return firstErr
 }
 
 func (r *FileRuntimeApiLite) GetBlockHeader(ctx context.Context, round uint64) (*nodeapi.RuntimeBlockHeader, error) {

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -68,12 +68,15 @@ func NewHistoryConsensusApiLite(ctx context.Context, history *config.History, no
 func (c *HistoryConsensusApiLite) Close() error {
 	var firstErr error
 	for _, api := range c.APIs {
-		if err := api.Close(); err != nil {
+		if err := api.Close(); err != nil && firstErr == nil {
 			firstErr = err
 			// Do not return yet; keep closing others.
 		}
 	}
-	return firstErr
+	if firstErr != nil {
+		return fmt.Errorf("closing apis failed, first encountered error was: %w", firstErr)
+	}
+	return nil
 }
 
 func (c *HistoryConsensusApiLite) APIForHeight(height int64) (nodeapi.ConsensusApiLite, error) {

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -65,6 +65,17 @@ func NewHistoryConsensusApiLite(ctx context.Context, history *config.History, no
 	}, nil
 }
 
+func (c *HistoryConsensusApiLite) Close() error {
+	var firstErr error
+	for _, api := range c.APIs {
+		if err := api.Close(); err != nil {
+			firstErr = err
+			// Do not return yet; keep closing others.
+		}
+	}
+	return firstErr
+}
+
 func (c *HistoryConsensusApiLite) APIForHeight(height int64) (nodeapi.ConsensusApiLite, error) {
 	record, err := c.History.RecordForHeight(height)
 	if err != nil {

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -43,6 +43,15 @@ func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkP
 	}, nil
 }
 
+func (rc *HistoryRuntimeApiLite) Close() error {
+	for _, api := range rc.APIs {
+		if err := api.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (rc *HistoryRuntimeApiLite) APIForRound(round uint64) (nodeapi.RuntimeApiLite, error) {
 	record, err := rc.History.RecordForRuntimeRound(rc.Runtime, round)
 	if err != nil {

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -44,10 +44,15 @@ func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkP
 }
 
 func (rc *HistoryRuntimeApiLite) Close() error {
+	var firstErr error
 	for _, api := range rc.APIs {
-		if err := api.Close(); err != nil {
-			return err
+		if err := api.Close(); err != nil && firstErr == nil {
+			firstErr = err
+			// Do not return yet; keep closing others.
 		}
+	}
+	if firstErr != nil {
+		return fmt.Errorf("closing apis failed, first encountered error was: %w", firstErr)
 	}
 	return nil
 }

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -51,6 +51,10 @@ func NewUniversalRuntimeApiLite(runtimeID coreCommon.Namespace, grpcConn *grpc.C
 	}
 }
 
+func (rc *UniversalRuntimeApiLite) Close() error {
+	return rc.grpcConn.Close()
+}
+
 func (rc *UniversalRuntimeApiLite) GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error) {
 	// Fetch the raw CBOR first, decode later.
 	var rsp cbor.RawMessage

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -16,6 +16,10 @@ type RuntimeClient struct {
 	nodeApi nodeapi.RuntimeApiLite
 }
 
+func (rc *RuntimeClient) Close() error {
+	return rc.nodeApi.Close()
+}
+
 // AllData returns all relevant data to the given round.
 func (rc *RuntimeClient) AllData(ctx context.Context, round uint64) (*storage.RuntimeAllData, error) {
 	blockHeader, err := rc.nodeApi.GetBlockHeader(ctx, round)

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -198,8 +198,8 @@ func (c *Client) QueryRow(ctx context.Context, sql string, args ...interface{}) 
 	return c.pool.QueryRow(ctx, sql, args...)
 }
 
-// Shutdown implements the storage.TargetStorage interface for Client.
-func (c *Client) Shutdown() {
+// Close implements the storage.TargetStorage interface for Client.
+func (c *Client) Close() {
 	c.pool.Close()
 }
 

--- a/storage/postgres/client_test.go
+++ b/storage/postgres/client_test.go
@@ -30,7 +30,7 @@ func TestConnect(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	client.Shutdown()
+	client.Close()
 }
 
 func TestInvalidConnect(t *testing.T) {
@@ -49,7 +49,7 @@ func TestQuery(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	rows, err := client.Query(context.Background(), `
 		SELECT * FROM ( VALUES (0),(1),(2) ) AS q;
@@ -73,7 +73,7 @@ func TestInvalidQuery(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	_, err = client.Query(context.Background(), `
 		an invalid query
@@ -86,7 +86,7 @@ func TestQueryRow(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	var result int
 	err = client.QueryRow(context.Background(), `
@@ -101,7 +101,7 @@ func TestInvalidQueryRow(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	var result int
 	err = client.QueryRow(context.Background(), `
@@ -115,7 +115,7 @@ func TestSendBatch(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	defer func() {
 		destroy := &storage.QueryBatch{}
@@ -185,7 +185,7 @@ func TestInvalidSendBatch(t *testing.T) {
 
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	invalid := &storage.QueryBatch{}
 	invalid.Queue(`
@@ -198,7 +198,7 @@ func TestInvalidSendBatch(t *testing.T) {
 func TestNumeric(t *testing.T) {
 	client, err := newClient(t)
 	require.Nil(t, err)
-	defer client.Shutdown()
+	defer client.Close()
 
 	// Create custom type, derived from NUMERIC.
 	_, err = client.pool.Exec(context.Background(), `CREATE DOMAIN mynumeric NUMERIC(1000,0) CHECK(VALUE >= 0)`)


### PR DESCRIPTION
This PR was motivated by #360 which introduces an on-disk cache (KV store), but does not close it cleanly when exiting. This PR adds a cleanup mechanism to the cache, and (partly by necessity, partly for code hygiene) extends the cleanup mechanism to all the analyzers.

At a high level, all analyzers are now provided with an external `context.Context` in their `Start()` method, and they are on the lookout for the `ctx.Done()` channel closing. The top-level code closes the channel on regular program termination and on SIGINT (Ctrl+C).

There is an additional change piggybacking on this PR:
- The recently-added KVStore (cache) now uses `cbor` to serialize its keys. It previously used `gob`, which in my testing complained for certain keys. (I think null pointers? I didn't investigate further, as I think it's preferable to not introduce new serialization formats (here, gob) into the project anyway.)

**Testing:** Ran in three different scenarios, verified that KV store (which is the furthest down the stack of cleanup methods) closes correctly:
- analyzers with a limited range in config; allow them to finish "on their own"
- kill analyzers with a single ctrl+C
- kill analyzers with a double ctrl+C (by introducing an artificial delay into cleanup); verify that the program is killable at the cost of incomplete cleanup