### PR TITLE
api: remove nonexistent required latest_chain_id

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1025,7 +1025,7 @@ components:
 
     Status:
       type: object
-      required: [latest_chain_id, latest_block, latest_update]
+      required: [latest_block, latest_update]
       properties:
         latest_block:
           type: integer


### PR DESCRIPTION
fixes https://github.com/oasisprotocol/oasis-indexer/pull/352#discussion_r1181784604