### PR TITLE
cleanup: enable offline cache-based runtimeClient

### DIFF
--- a/storage/oasis/client.go
+++ b/storage/oasis/client.go
@@ -54,21 +54,27 @@ func NewConsensusClient(ctx context.Context, sourceConfig *config.SourceConfig) 
 
 // NewRuntimeClient creates a new RuntimeClient.
 func NewRuntimeClient(ctx context.Context, sourceConfig *config.SourceConfig, runtime common.Runtime) (*RuntimeClient, error) {
+	// If we are using purely file-backed indexer, do not connect to the node.
+	if sourceConfig.Cache != nil && !sourceConfig.Cache.QueryOnCacheMiss {
+		cachePath := filepath.Join(sourceConfig.Cache.CacheDir, string(runtime))
+		nodeApi, err := file.NewFileRuntimeApiLite(runtime, cachePath, nil)
+		if err != nil {
+			return nil, fmt.Errorf("error instantiating cache-based runtimeApi: %w", err)
+		}
+		return &RuntimeClient{
+			nodeApi: nodeApi,
+		}, nil
+	}
+
+	// Create an API that connects to the real node, then wrap it in a caching layer.
 	var nodeApi nodeapi.RuntimeApiLite
 	nodeApi, err := history.NewHistoryRuntimeApiLite(ctx, sourceConfig.History(), sourceConfig.SDKParaTime(runtime), sourceConfig.Nodes, sourceConfig.FastStartup, runtime)
 	if err != nil {
 		return nil, fmt.Errorf("instantiating history runtime API lite: %w", err)
 	}
-
-	// todo: short circuit if using purely a file-based backend and avoid connecting
-	// to the node at all. this requires storing runtime info offline.
 	if sourceConfig.Cache != nil {
 		cachePath := filepath.Join(sourceConfig.Cache.CacheDir, string(runtime))
-		if sourceConfig.Cache.QueryOnCacheMiss {
-			nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nodeApi)
-		} else {
-			nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nil)
-		}
+		nodeApi, err = file.NewFileRuntimeApiLite(runtime, cachePath, nodeApi)
 		if err != nil {
 			return nil, fmt.Errorf("error instantiating cache-based runtimeApi: %w", err)
 		}


### PR DESCRIPTION
After #390 the clunky `runtimeInfo`/`sdkPT` config was removed, which allows us to easily instantiate a cache-based runtimeClient without attempting to connect to a node (eg in CI).