### PR TITLE
Cobalt core API: Support DebondingStartEscrowEvent

### DIFF
--- a/coreapi/v21.1.1/staking/api/api.go
+++ b/coreapi/v21.1.1/staking/api/api.go
@@ -59,9 +59,10 @@ type BurnEvent struct {
 
 // EscrowEvent is an escrow event.
 type EscrowEvent struct {
-	Add     *AddEscrowEvent     `json:"add,omitempty"`
-	Take    *TakeEscrowEvent    `json:"take,omitempty"`
-	Reclaim *ReclaimEscrowEvent `json:"reclaim,omitempty"`
+	Add            *AddEscrowEvent            `json:"add,omitempty"`
+	Take           *TakeEscrowEvent           `json:"take,omitempty"`
+	DebondingStart *DebondingStartEscrowEvent `json:"debonding_start,omitempty"` // Only emitted at _some_ heights; introduced in oasis-core v21.3.0 mid-Cobalt.
+	Reclaim        *ReclaimEscrowEvent        `json:"reclaim,omitempty"`
 }
 
 // Event signifies a staking event, returned via GetEvents.
@@ -89,6 +90,21 @@ type AddEscrowEvent struct {
 type TakeEscrowEvent struct {
 	Owner  Address           `json:"owner"`
 	Amount quantity.Quantity `json:"amount"`
+}
+
+// DebondingStartEvent is the event emitted when the debonding process has
+// started and the given number of active shares have been moved into the
+// debonding pool and started debonding.
+//
+// Note that the given amount is valid at the time of debonding start and
+// may not correspond to the final debonded amount in case any escrowed
+// stake is subject to slashing.
+type DebondingStartEscrowEvent struct {
+	Owner           Address           `json:"owner"`
+	Escrow          Address           `json:"escrow"`
+	Amount          quantity.Quantity `json:"amount"`
+	ActiveShares    quantity.Quantity `json:"active_shares"`
+	DebondingShares quantity.Quantity `json:"debonding_shares"`
 }
 
 // ReclaimEscrowEvent is the event emitted when stake is reclaimed from an

--- a/storage/oasis/nodeapi/cobalt/convert.go
+++ b/storage/oasis/nodeapi/cobalt/convert.go
@@ -200,7 +200,19 @@ func convertEvent(e txResultsCobalt.Event) nodeapi.Event {
 					RawBody:              common.TryAsJSON(e.Staking.Escrow.Reclaim),
 					Type:                 apiTypes.ConsensusEventTypeStakingEscrowReclaim,
 				}
-				// NOTE: There is no Staking.Escrow.DebondingStart event in Cobalt.
+			case e.Staking.Escrow.DebondingStart != nil: // Note: Event started appearing mid-Cobalt.
+				ret = nodeapi.Event{
+					StakingDebondingStart: &nodeapi.DebondingStartEscrowEvent{
+						Owner:           e.Staking.Escrow.DebondingStart.Owner,
+						Escrow:          e.Staking.Escrow.DebondingStart.Escrow,
+						Amount:          e.Staking.Escrow.DebondingStart.Amount,
+						ActiveShares:    e.Staking.Escrow.DebondingStart.ActiveShares,
+						DebondingShares: e.Staking.Escrow.DebondingStart.DebondingShares,
+						DebondEndTime:   0, // Not provided in Cobalt; added in core v22.0, i.e. the testnet-only Damask precursor.
+					},
+					RawBody: common.TryAsJSON(e.Staking.Escrow.DebondingStart),
+					Type:    apiTypes.ConsensusEventTypeStakingEscrowDebondingStart,
+				}
 			}
 		case e.Staking.AllowanceChange != nil:
 			ret = nodeapi.Event{

--- a/storage/oasis/nodeapi/cobalt/node.go
+++ b/storage/oasis/nodeapi/cobalt/node.go
@@ -52,7 +52,7 @@ func (c *CobaltConsensusApiLite) Close() error {
 func (c *CobaltConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
 	var rsp genesisCobalt.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetGenesisDocument", nil, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetGenesisDocument(cobalt): %w", err)
 	}
 	return ConvertGenesis(rsp), nil
 }
@@ -60,7 +60,7 @@ func (c *CobaltConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genes
 func (c *CobaltConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
 	var rsp genesisCobalt.Document
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/StateToGenesis", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
 	}
 	return ConvertGenesis(rsp), nil
 }
@@ -68,7 +68,7 @@ func (c *CobaltConsensusApiLite) StateToGenesis(ctx context.Context, height int6
 func (c *CobaltConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
 	var rsp consensusCobalt.Block
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetBlock", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
 	}
 	return convertBlock(rsp), nil
 }
@@ -76,7 +76,7 @@ func (c *CobaltConsensusApiLite) GetBlock(ctx context.Context, height int64) (*c
 func (c *CobaltConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
 	var rsp consensusCobalt.TransactionsWithResults
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Consensus/GetTransactionsWithResults", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
 	}
 	txrs := make([]nodeapi.TransactionWithResults, len(rsp.Transactions))
 
@@ -84,10 +84,10 @@ func (c *CobaltConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("GetTransactionsWithResults(%d): transaction %d (%x): %w", height, i, txBytes, err)
 		}
 		if rsp.Results[i] == nil {
-			return nil, fmt.Errorf("transaction %d (%s) has no result", i, tx.Hash())
+			return nil, fmt.Errorf("GetTransactionsWithResults(%d): transaction %d (%x): has no result", height, i, txBytes)
 		}
 		txrs[i] = nodeapi.TransactionWithResults{
 			Transaction: tx,
@@ -100,7 +100,7 @@ func (c *CobaltConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 func (c *CobaltConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
 	var rsp beaconCobalt.EpochTime
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Beacon/GetEpoch", height, &rsp); err != nil {
-		return beacon.EpochInvalid, err
+		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
 	}
 	return rsp, nil
 }
@@ -108,7 +108,7 @@ func (c *CobaltConsensusApiLite) GetEpoch(ctx context.Context, height int64) (be
 func (c *CobaltConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*registryCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Registry/GetEvents", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -120,7 +120,7 @@ func (c *CobaltConsensusApiLite) RegistryEvents(ctx context.Context, height int6
 func (c *CobaltConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*stakingCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Staking/GetEvents", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -132,7 +132,7 @@ func (c *CobaltConsensusApiLite) StakingEvents(ctx context.Context, height int64
 func (c *CobaltConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*governanceCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Governance/GetEvents", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -144,7 +144,7 @@ func (c *CobaltConsensusApiLite) GovernanceEvents(ctx context.Context, height in
 func (c *CobaltConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	var rsp []*roothashCobalt.Event
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.RootHash/GetEvents", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -156,7 +156,7 @@ func (c *CobaltConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 func (c *CobaltConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	var rsp []*schedulerCobalt.Validator
 	if err := c.grpcConn.Invoke(ctx, "/oasis-core.Scheduler/GetValidators", height, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
 	}
 	validators := make([]nodeapi.Validator, len(rsp))
 	for i, v := range rsp {
@@ -171,7 +171,7 @@ func (c *CobaltConsensusApiLite) GetCommittees(ctx context.Context, height int64
 		Height:    height,
 		RuntimeID: runtimeID,
 	}, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetCommittees(%d): %w", height, err)
 	}
 	committees := make([]nodeapi.Committee, len(rsp))
 	for i, c := range rsp {
@@ -186,7 +186,7 @@ func (c *CobaltConsensusApiLite) GetProposal(ctx context.Context, height int64, 
 		Height:     height,
 		ProposalID: proposalID,
 	}, &rsp); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetProposal(%d, %d): %w", height, proposalID, err)
 	}
 	return (*nodeapi.Proposal)(convertProposal(rsp)), nil
 }

--- a/storage/oasis/nodeapi/damask/node.go
+++ b/storage/oasis/nodeapi/damask/node.go
@@ -41,21 +41,33 @@ func (c *DamaskConsensusApiLite) Close() error {
 }
 
 func (c *DamaskConsensusApiLite) GetGenesisDocument(ctx context.Context) (*genesis.Document, error) {
-	return c.client.GetGenesisDocument(ctx)
+	rsp, err := c.client.GetGenesisDocument(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("GetGenesisDocument(damask): %w", err)
+	}
+	return rsp, nil
 }
 
 func (c *DamaskConsensusApiLite) StateToGenesis(ctx context.Context, height int64) (*genesis.Document, error) {
-	return c.client.StateToGenesis(ctx, height)
+	rsp, err := c.client.StateToGenesis(ctx, height)
+	if err != nil {
+		return nil, fmt.Errorf("StateToGenesis(%d): %w", height, err)
+	}
+	return rsp, nil
 }
 
 func (c *DamaskConsensusApiLite) GetBlock(ctx context.Context, height int64) (*consensus.Block, error) {
-	return c.client.GetBlock(ctx, height)
+	rsp, err := c.client.GetBlock(ctx, height)
+	if err != nil {
+		return nil, fmt.Errorf("GetBlock(%d): %w", height, err)
+	}
+	return rsp, nil
 }
 
 func (c *DamaskConsensusApiLite) GetTransactionsWithResults(ctx context.Context, height int64) ([]nodeapi.TransactionWithResults, error) {
 	rsp, err := c.client.GetTransactionsWithResults(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetTransactionsWithResults(%d): %w", height, err)
 	}
 	txrs := make([]nodeapi.TransactionWithResults, len(rsp.Transactions))
 
@@ -63,10 +75,10 @@ func (c *DamaskConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 	for i, txBytes := range rsp.Transactions {
 		var tx consensusTx.SignedTransaction
 		if err := cbor.Unmarshal(txBytes, &tx); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("GetTransactionsWithResults(%d): transaction %d (%x): %w", height, i, txBytes, err)
 		}
 		if rsp.Results[i] == nil {
-			return nil, fmt.Errorf("transaction %d (%s) has no result", i, tx.Hash())
+			return nil, fmt.Errorf("GetTransactionsWithResults(%d): transaction %d (%x): has no result", height, i, txBytes)
 		}
 		txrs[i] = nodeapi.TransactionWithResults{
 			Transaction: tx,
@@ -77,13 +89,17 @@ func (c *DamaskConsensusApiLite) GetTransactionsWithResults(ctx context.Context,
 }
 
 func (c *DamaskConsensusApiLite) GetEpoch(ctx context.Context, height int64) (beacon.EpochTime, error) {
-	return c.client.Beacon().GetEpoch(ctx, height)
+	rsp, err := c.client.Beacon().GetEpoch(ctx, height)
+	if err != nil {
+		return beacon.EpochInvalid, fmt.Errorf("GetEpoch(%d): %w", height, err)
+	}
+	return rsp, nil
 }
 
 func (c *DamaskConsensusApiLite) RegistryEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	rsp, err := c.client.Registry().GetEvents(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RegistryEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -95,7 +111,7 @@ func (c *DamaskConsensusApiLite) RegistryEvents(ctx context.Context, height int6
 func (c *DamaskConsensusApiLite) StakingEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	rsp, err := c.client.Staking().GetEvents(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("StakingEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -107,7 +123,7 @@ func (c *DamaskConsensusApiLite) StakingEvents(ctx context.Context, height int64
 func (c *DamaskConsensusApiLite) GovernanceEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	rsp, err := c.client.Governance().GetEvents(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GovernanceEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -119,7 +135,7 @@ func (c *DamaskConsensusApiLite) GovernanceEvents(ctx context.Context, height in
 func (c *DamaskConsensusApiLite) RoothashEvents(ctx context.Context, height int64) ([]nodeapi.Event, error) {
 	rsp, err := c.client.RootHash().GetEvents(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("RoothashEvents(%d): %w", height, err)
 	}
 	events := make([]nodeapi.Event, len(rsp))
 	for i, e := range rsp {
@@ -131,7 +147,7 @@ func (c *DamaskConsensusApiLite) RoothashEvents(ctx context.Context, height int6
 func (c *DamaskConsensusApiLite) GetValidators(ctx context.Context, height int64) ([]nodeapi.Validator, error) {
 	rsp, err := c.client.Scheduler().GetValidators(ctx, height)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetValidators(%d): %w", height, err)
 	}
 	validators := make([]nodeapi.Validator, len(rsp))
 	for i, v := range rsp {
@@ -146,7 +162,7 @@ func (c *DamaskConsensusApiLite) GetCommittees(ctx context.Context, height int64
 		RuntimeID: runtimeID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetCommittees(%d): %w", height, err)
 	}
 	committees := make([]nodeapi.Committee, len(rsp))
 	for i, c := range rsp {
@@ -161,7 +177,7 @@ func (c *DamaskConsensusApiLite) GetProposal(ctx context.Context, height int64, 
 		ProposalID: proposalID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("GetProposal(%d, %d): %w", height, proposalID, err)
 	}
 	return (*nodeapi.Proposal)(rsp), nil
 }

--- a/storage/oasis/nodeapi/file/common.go
+++ b/storage/oasis/nodeapi/file/common.go
@@ -13,8 +13,11 @@ type NodeApiMethod func() (interface{}, error)
 
 var ErrUnstableRPCMethod = errors.New("this method is not cacheable because the RPC return value is not constant")
 
-func generateCacheKey(methodName string, params ...interface{}) []byte {
-	return cbor.Marshal([]interface{}{methodName, params})
+// A key in the KVStore.
+type CacheKey []byte
+
+func generateCacheKey(methodName string, params ...interface{}) CacheKey {
+	return CacheKey(cbor.Marshal([]interface{}{methodName, params}))
 }
 
 type KVStore struct {
@@ -40,45 +43,65 @@ func OpenKVStore(logger *log.Logger, path string) (*KVStore, error) {
 	return &KVStore{DB: db, logger: logger, path: path}, nil
 }
 
+// Pretty() returns a pretty-printed, human-readable version of the cache key.
+// It tries to interpret it as CBOR and returns the pretty-printed struct, otherwise
+// it returns the key's raw bytes as hex.
+func (cacheKey CacheKey) Pretty() string {
+	var pretty string
+	var parsed interface{}
+	err := cbor.Unmarshal(cacheKey, &parsed)
+	if err != nil {
+		pretty = fmt.Sprintf("%+v", parsed)
+	} else {
+		pretty = fmt.Sprintf("%x", cacheKey)
+	}
+	if len(pretty) > 100 {
+		pretty = pretty[:95] + "[...]"
+	}
+	return pretty
+}
+
 // getFromCacheOrCall fetches the value of `cacheKey` from the cache if it exists,
 // interpreted as a `Value`. If it does not exist, it calls `valueFunc` to get the
 // value, and caches it before returning it.
 // If `volatile` is true, `valueFunc` is always called, and the result is not cached.
-func GetFromCacheOrCall[Value any](cache KVStore, volatile bool, cacheKey []byte, valueFunc func() (*Value, error)) (*Value, error) {
+func GetFromCacheOrCall[Value any](cache KVStore, volatile bool, key CacheKey, valueFunc func() (*Value, error)) (*Value, error) {
 	// If the latest height was requested, the response is not cacheable, so we have to hit the backing API.
 	if volatile {
 		return valueFunc()
 	}
 
 	// If the value is cached, return it.
-	isCached, err := cache.Has(cacheKey)
+	isCached, err := cache.Has(key)
 	if err != nil {
 		return nil, err
 	}
 	if isCached {
-		raw, err2 := cache.Get(cacheKey)
+		raw, err2 := cache.Get(key)
 		if err2 != nil {
-			return nil, err2
+			cache.logger.Warn(fmt.Sprintf("failed to fetch key %s from cache: %v", key.Pretty(), err2))
 		}
 		var result *Value
 		err2 = cbor.Unmarshal(raw, &result)
-		return result, err2
+		if err2 != nil {
+			cache.logger.Warn(fmt.Sprintf("failed to unmarshal key %s from cache into %T: %v", key.Pretty(), result, err2))
+		}
 	}
 
-	// Otherwise, the value is not cached. Call the backing API to get it.
+	// Otherwise, the value is not cached or couldn't be restored from the cache. Call the backing API to get it.
 	result, err := valueFunc()
 	if err != nil {
 		return nil, err
 	}
 
 	// Store value in cache for later use.
-	return result, cache.Put(cacheKey, cbor.Marshal(result))
+	return result, cache.Put(key, cbor.Marshal(result))
 }
 
 // Like getFromCacheOrCall, but for slice-typed return values.
-func GetSliceFromCacheOrCall[Response any](cache KVStore, volatile bool, cacheKey []byte, valueFunc func() ([]Response, error)) ([]Response, error) {
+func GetSliceFromCacheOrCall[Response any](cache KVStore, volatile bool, key CacheKey, valueFunc func() ([]Response, error)) ([]Response, error) {
 	// Use `getFromCacheOrCall()` to avoid duplicating the cache update logic.
-	responsePtr, err := GetFromCacheOrCall(cache, volatile, cacheKey, func() (*[]Response, error) {
+	responsePtr, err := GetFromCacheOrCall(cache, volatile, key, func() (*[]Response, error) {
 		response, err := valueFunc()
 		if response == nil {
 			return nil, err


### PR DESCRIPTION
This PR allows our cobalt RPC client to parse the DebondingStartEscrowEvent that was introduced mid-Cobalt.
The PR also includes some additional error message details to make this error (and similar ones) easier to pinpoint.

Prompted by https://app.clickup.com/t/866a7412t, and closes that ticket.

We've had a similar problem before: https://github.com/oasisprotocol/oasis-indexer/blob/82e29b83591b75432467ed2303a713a6d3128bc6/coreapi/v21.1.1/staking/api/api.go#L84

I believe the original sin was that when we vendored the cobalt APIs into the indexer, we took v21.1.0, which was the earliest compatible API. We should have instead gone with 21.3.9, the latest compatible one. I was wondering about it at the time but got different recommendations on slack. 
Anyway, I re-vendored v21.3.9 locally and compared it with the manually-updated v21.1.1 that we have in indexer, and it looks like this missing field is the last meaningful difference. So hopefully we can index the rest of Cobalt with no further changes.

**Testing:** Indexed block 4741442 (which was the problematic one in the ticket). Indexed some early blocks to make sure the old format still works well. This also led to ...

**... Change 2:** If the KVStore cache caches a value but then fails to fetch it (e.g. because the definition of the value's type has changed between runs), we should revert to re-fetching the value from the node, rather than sticking with hte cached value and failing the round. This PR implements this change.