### PR TITLE
config: allow connecting to a special node for some things

### DIFF
--- a/analyzer/runtime/evm_test.go
+++ b/analyzer/runtime/evm_test.go
@@ -27,9 +27,11 @@ var (
 	// TODO: Would be nice to have an offline test.
 	PublicSourceConfig = &config.SourceConfig{
 		ChainName: ChainName,
-		Nodes: map[string]*config.NodeConfig{
+		Nodes: map[string]*config.ArchiveConfig{
 			CurrentArchiveName: {
-				RPC: sdkConfig.DefaultNetworks.All[string(ChainName)].RPC,
+				DefaultNode: &config.NodeConfig{
+					RPC: sdkConfig.DefaultNetworks.All[string(ChainName)].RPC,
+				},
 			},
 		},
 		FastStartup: false,

--- a/config/config.go
+++ b/config/config.go
@@ -68,6 +68,11 @@ func (cfg *AnalysisConfig) Validate() error {
 	} else if cfg.Source.ChainName != "" && cfg.Source.CustomChain != nil {
 		return fmt.Errorf("source.chain_name and source.custom_chain specified, can only use one")
 	}
+	for archiveName, archiveConfig := range cfg.Source.Nodes {
+		if archiveConfig.DefaultNode == nil && archiveConfig.ConsensusNode == nil && len(archiveConfig.RuntimeNodes) == 0 {
+			return fmt.Errorf("source.nodes[%v] has none of .default, .consensus, or .runtimes", archiveName)
+		}
+	}
 	if cfg.Analyzers.Consensus != nil {
 		if err := cfg.Analyzers.Consensus.Validate(); err != nil {
 			return err

--- a/config/docker-dev.yml
+++ b/config/docker-dev.yml
@@ -3,7 +3,8 @@ analysis:
     chain_name: mainnet
     nodes:
       damask:
-        rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
+        default:
+          rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
   analyzers:
     metadata_registry:
       interval: 1h

--- a/config/local-dev.yml
+++ b/config/local-dev.yml
@@ -3,7 +3,8 @@ analysis:
     chain_name: mainnet
     nodes:
       damask:
-        rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
+        default:
+          rpc: unix:/tmp/node.sock #unix:/node/data/internal.sock
   analyzers:
     metadata_registry:
       interval: 1h

--- a/storage/oasis/nodeapi/history/history.go
+++ b/storage/oasis/nodeapi/history/history.go
@@ -18,18 +18,18 @@ import (
 
 var _ nodeapi.ConsensusApiLite = (*HistoryConsensusApiLite)(nil)
 
-type APIConstructor func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error)
+type APIConstructor func(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error)
 
 var APIConstructors = map[string]APIConstructor{
-	"damask": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-		sdkConn, err := connections.SDKConnect(ctx, chainContext, nodeConfig, fastStartup)
+	"damask": func(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
+		sdkConn, err := connections.SDKConnect(ctx, chainContext, archiveConfig.ResolvedConsensusNode(), fastStartup)
 		if err != nil {
 			return nil, err
 		}
 		return damask.NewDamaskConsensusApiLite(sdkConn.Consensus()), nil
 	},
-	"cobalt": func(ctx context.Context, chainContext string, nodeConfig *config.NodeConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
-		rawConn, err := connections.RawConnect(nodeConfig)
+	"cobalt": func(ctx context.Context, chainContext string, archiveConfig *config.ArchiveConfig, fastStartup bool) (nodeapi.ConsensusApiLite, error) {
+		rawConn, err := connections.RawConnect(archiveConfig.ResolvedConsensusNode())
 		if err != nil {
 			return nil, fmt.Errorf("indexer RawConnect: %w", err)
 		}
@@ -44,15 +44,15 @@ type HistoryConsensusApiLite struct {
 	APIs map[string]nodeapi.ConsensusApiLite
 }
 
-func NewHistoryConsensusApiLite(ctx context.Context, history *config.History, nodes map[string]*config.NodeConfig, fastStartup bool) (*HistoryConsensusApiLite, error) {
+func NewHistoryConsensusApiLite(ctx context.Context, history *config.History, nodes map[string]*config.ArchiveConfig, fastStartup bool) (*HistoryConsensusApiLite, error) {
 	apis := map[string]nodeapi.ConsensusApiLite{}
 	for _, record := range history.Records {
-		if nodeConfig, ok := nodes[record.ArchiveName]; ok {
+		if archiveConfig, ok := nodes[record.ArchiveName]; ok {
 			apiConstructor := APIConstructors[record.ArchiveName]
 			if apiConstructor == nil {
 				return nil, fmt.Errorf("historical API for archive %s not implemented", record.ArchiveName)
 			}
-			api, err := apiConstructor(ctx, record.ChainContext, nodeConfig, fastStartup)
+			api, err := apiConstructor(ctx, record.ChainContext, archiveConfig, fastStartup)
 			if err != nil {
 				return nil, fmt.Errorf("connecting to archive %s: %w", record.ArchiveName, err)
 			}

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -20,16 +20,16 @@ type HistoryRuntimeApiLite struct {
 	APIs    map[string]nodeapi.RuntimeApiLite
 }
 
-func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkPT *sdkConfig.ParaTime, nodes map[string]*config.NodeConfig, fastStartup bool, runtime common.Runtime) (*HistoryRuntimeApiLite, error) {
+func NewHistoryRuntimeApiLite(ctx context.Context, history *config.History, sdkPT *sdkConfig.ParaTime, nodes map[string]*config.ArchiveConfig, fastStartup bool, runtime common.Runtime) (*HistoryRuntimeApiLite, error) {
 	apis := map[string]nodeapi.RuntimeApiLite{}
 	for _, record := range history.Records {
-		if nodeConfig, ok := nodes[record.ArchiveName]; ok {
-			sdkConn, err := connections.SDKConnect(ctx, record.ChainContext, nodeConfig, fastStartup)
+		if archiveConfig, ok := nodes[record.ArchiveName]; ok {
+			sdkConn, err := connections.SDKConnect(ctx, record.ChainContext, archiveConfig.ResolvedRuntimeNode(runtime), fastStartup)
 			if err != nil {
 				return nil, err
 			}
 			sdkClient := sdkConn.Runtime(sdkPT)
-			rawConn, err := connections.RawConnect(nodeConfig)
+			rawConn, err := connections.RawConnect(archiveConfig.ResolvedRuntimeNode(runtime))
 			if err != nil {
 				return nil, fmt.Errorf("indexer RawConnect: %w", err)
 			}

--- a/tests/e2e/config/e2e-dev.yml
+++ b/tests/e2e/config/e2e-dev.yml
@@ -9,7 +9,8 @@ analysis:
       sdk_network: {}
     nodes:
       damask:
-        rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
+        default:
+          rpc: unix:/testnet/net-runner/network/validator-0/internal.sock
   analyzers:
     consensus:
       from: 1


### PR DESCRIPTION
- one entry in `analysis.source.nodes` is no longer a NodeConfig, it's this new thing ArchiveConfig.
- ArchiveConfig is a struct with a .DefaultNode field, where you'd put the NodeConfig you used to have
- ArchiveConfig additionally has .ConsensusNode and .RuntimeNodes[runtime], which let you specify to connect to a different node for different purposes.

for operators, a config like this:

```yml
analysis:
  source:
    chain_name: mainnet
    nodes:
      damask:
        rpc: grpc.oasis.dev:443
```

becomes:

```yml
analysis:
  source:
    chain_name: mainnet
    nodes:
      damask:
        default:
          rpc: grpc.oasis.dev:443
```

you can then add things:

```yml
analysis:
  source:
    chain_name: mainnet
    nodes:
      damask:
        # the node to consult for most damask-network data, e.g. consensus, emerald, cipher
        default:
          rpc: grpc.oasis.dev:443
        runtimes:
          # a special node with SGX to provide sapphire data
          sapphire:
            rpc: whatever:443
```

