### PR TITLE
db: Disable/enable FK constraints on demand

### DIFF
--- a/storage/api.go
+++ b/storage/api.go
@@ -272,4 +272,15 @@ type TargetStorage interface {
 
 	// Wipe removes all contents of the target storage.
 	Wipe(ctx context.Context) error
+
+	// DisableTriggersAndFKConstraints disables all triggers and foreign key constraints
+	// in indexer tables. This is useful when inserting blockchain data out of order,
+	// so that later blocks can refer to (yet unindexed) earlier blocks without violating constraints.
+	DisableTriggersAndFKConstraints(ctx context.Context) error
+
+	// EnableTriggersAndFKConstraints enables all triggers and foreign key constraints
+	// in the given schema.
+	// WARNING: This might enable triggers not explicitly disabled by DisableTriggersAndFKConstraints.
+	// WARNING: This does not enforce/check contraints on rows that were inserted while triggers were disabled.
+	EnableTriggersAndFKConstraints(ctx context.Context) error
 }

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -322,13 +322,12 @@ func (c *Client) DisableTriggersAndFKConstraints(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	batch := &storage.QueryBatch{}
 	for _, table := range tables {
 		c.logger.Info("disabling DB triggers on table", "table", table)
-		if _, err = c.pool.Exec(ctx, fmt.Sprintf("ALTER TABLE %s DISABLE TRIGGER ALL;", table)); err != nil {
-			return err
-		}
+		batch.Queue(fmt.Sprintf("ALTER TABLE %s DISABLE TRIGGER ALL;", table))
 	}
-	return nil
+	return c.SendBatch(ctx, batch)
 }
 
 // EnableTriggersAndFKConstraints enables all triggers and foreign key constraints
@@ -340,11 +339,10 @@ func (c *Client) EnableTriggersAndFKConstraints(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	batch := &storage.QueryBatch{}
 	for _, table := range tables {
 		c.logger.Info("enabling DB triggers on table", "table", table)
-		if _, err = c.pool.Exec(ctx, fmt.Sprintf("ALTER TABLE %s ENABLE TRIGGER ALL;", table)); err != nil {
-			return err
-		}
+		batch.Queue(fmt.Sprintf("ALTER TABLE %s ENABLE TRIGGER ALL;", table))
 	}
-	return nil
+	return c.SendBatch(ctx, batch)
 }


### PR DESCRIPTION
Resolves https://app.clickup.com/t/860qer9hq

Adds methods for disabling and enabling constraints.
I do not plan to add disabling/enabling indexes; it's a little nuanced what to disable (we need some of them for inserts even during fast-sync), plus they support async updates so I hope they won't slow down inserts _that_ much. To be revisited once db insertions become the bottleneck.
I think we do not need to add disabling/enabling non-FK checks, in particular non-negativity checks for balances. In fast-sync, we won't be doing any dead reckoning, so I reckon (heh) we won't produce negative balances or other values.

Very lightly tested; I just called each method a few times and verified FKs were no longer enforced. Will be better tested once we have the calling code (= fast-sync mode in analyzers).