### PR TITLE
file: don't crash on cleanup with query_on_cache_miss: no

### DIFF
--- a/storage/oasis/nodeapi/file/consensus.go
+++ b/storage/oasis/nodeapi/file/consensus.go
@@ -39,7 +39,10 @@ func NewFileConsensusApiLite(cacheDir string, consensusApi nodeapi.ConsensusApiL
 
 func (c *FileConsensusApiLite) Close() error {
 	// Close all resources and return the first encountered error, if any.
-	firstErr := c.consensusApi.Close()
+	var firstErr error
+	if c.consensusApi != nil {
+		firstErr = c.consensusApi.Close()
+	}
 	if err := c.db.Close(); err != nil && firstErr == nil {
 		firstErr = err
 	}

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -37,7 +37,10 @@ func NewFileRuntimeApiLite(runtime common.Runtime, cacheDir string, runtimeApi n
 
 func (r *FileRuntimeApiLite) Close() error {
 	// Close all resources and return the first encountered error, if any.
-	firstErr := r.runtimeApi.Close()
+	var firstErr error
+	if r.runtimeApi != nil {
+		firstErr = r.runtimeApi.Close()
+	}
 	if err := r.db.Close(); err != nil && firstErr == nil {
 		firstErr = err
 	}


### PR DESCRIPTION
we leave the delegate api nil in that case. don't try to close it