### PR TITLE
analyzer: fix evm.Create result type cutting

### DIFF
--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -369,9 +369,9 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 				EVMCreate: func(body *evm.Create, ok *[]byte) error {
 					blockTransactionData.Body = body
 					amount = uncategorized.QuantityFromBytes(body.Value)
-					if !txr.Result.IsUnknown() && txr.Result.IsSuccess() && len(*ok) == 32 {
+					if !txr.Result.IsUnknown() && txr.Result.IsSuccess() && len(*ok) == 20 {
 						// todo: is this rigorous enough?
-						if to, err = registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, uncategorized.SliceEthAddress(*ok)); err != nil {
+						if to, err = registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, *ok); err != nil {
 							return fmt.Errorf("created contract: %w", err)
 						}
 					}


### PR DESCRIPTION
the result is the address, not the address embedded in a 256-bit thing. just the address. don't look for 32 bytes, don't cut it.

tested on a recent evm.Create transaction that occurred on mainnet Emerald, verified that the `to` column in the runtime_transactions table was populated, verified eth addresses displayed in API against another block explorer