### PR TITLE
Andrew7234/epoch tracking

### DIFF
--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -373,19 +373,10 @@ func (m *Main) queueBlockInserts(batch *storage.QueryBatch, data *storage.Consen
 
 func (m *Main) queueEpochInserts(batch *storage.QueryBatch, data *storage.ConsensusBlockData) error {
 	batch.Queue(
-		queries.ConsensusEpochInsert,
+		queries.ConsensusEpochUpsert,
 		data.Epoch,
 		data.BlockHeader.Height,
 	)
-
-	// Conclude previous epoch. Epochs start at index 0.
-	if data.Epoch > 0 {
-		batch.Queue(
-			queries.ConsensusEpochUpdate,
-			data.Epoch-1,
-			data.BlockHeader.Height,
-		)
-	}
 
 	return nil
 }

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -180,7 +180,8 @@ const (
 		OFFSET $3::bigint`
 
 	Epochs = `
-		SELECT id, start_height, end_height
+		SELECT id, start_height, 
+			(CASE id WHEN (SELECT max(id) FROM chain.epochs) THEN NULL ELSE end_height END) AS end_height
 			FROM chain.epochs
 		ORDER BY id DESC
 		LIMIT $1::bigint

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -84,10 +84,13 @@ CREATE INDEX ix_events_type ON chain.events (type, tx_block);  -- tx_block is fo
 CREATE TABLE chain.epochs
 (
   id           UINT63 PRIMARY KEY,
+  -- Earliest known height that belongs to the epoch.
   start_height UINT63 NOT NULL,
-  end_height   UINT63 CHECK (end_height IS NULL OR end_height >= start_height),
+  -- Max known height that belongs to the epoch.
+  end_height   UINT63 NOT NULL CHECK (end_height >= start_height),
   UNIQUE (start_height, end_height)
 );
+CREATE INDEX ix_epochs_id ON chain.epochs (id);
 
 -- Registry Backend Data
 CREATE TABLE chain.entities


### PR DESCRIPTION
https://app.clickup.com/t/860qer8y5

Note: I believe the prior epoch tracking logic was slightly incorrect. Our openapi spec [states that](https://github.com/oasisprotocol/oasis-indexer/blob/main/api/spec/v1.yaml#L1705) the `end_height` is ```description: The (inclusive) height at which this epoch ended. Omitted if the epoch is still active.```

However, the prior code set the db end_height as the _exclusive_ upper bound. This PR will now set the `end_height to be the inclusive upper bound as described. Eg, 
```
  id   | start_height | end_height
-------+--------------+------------
 13402 |      10 |  19
 13403 |      20 |  29
```

I'm not quite sure which is more idiomatic, comments are welcome.

Test plan: light testing ran locally with e2e_regression tests over 601 blocks. Further verification is needed once we are able to run multiple parallel consensus analyzers.

Todo: ~~investigate if/how we use epoch end_height in the rest of the indexer logic.~~