### PR TITLE
Ability to run analyzers in parallel

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -69,7 +69,7 @@ func (a *AggregateStatsAnalyzer) Name() string {
 	return AggregateStatsAnalyzerName
 }
 
-func NewAggregateStatsAnalyzer(cfg *config.AggregateStatsConfig, target storage.TargetStorage, logger *log.Logger) (*AggregateStatsAnalyzer, error) {
+func NewAggregateStatsAnalyzer(cfg *config.AggregateStatsConfig, target storage.TargetStorage, logger *log.Logger) (Analyzer, error) {
 	logger.Info("starting aggregate_stats analyzer")
 	return &AggregateStatsAnalyzer{
 		target:           target,

--- a/analyzer/api.go
+++ b/analyzer/api.go
@@ -54,6 +54,13 @@ type BlockRange struct {
 	To int64
 }
 
+type BlockAnalysisMode string
+
+const (
+	FastSyncMode BlockAnalysisMode = "fast-sync"
+	SlowSyncMode BlockAnalysisMode = "slow-sync"
+)
+
 // RuntimeConfig specifies configuration parameters for
 // processing the runtime layer.
 type RuntimeConfig struct {

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -67,7 +67,7 @@ type ConsensusAnalyzer struct {
 var _ analyzer.Analyzer = (*ConsensusAnalyzer)(nil)
 
 // NewConsensusAnalyzer returns a new main analyzer for the consensus layer.
-func NewConsensusAnalyzer(cfg *config.BlockBasedAnalyzerConfig, genesisChainContext string, sourceClient *source.ConsensusClient, target storage.TargetStorage, logger *log.Logger) (*ConsensusAnalyzer, error) {
+func NewConsensusAnalyzer(cfg config.BlockRange, genesisChainContext string, sourceClient *source.ConsensusClient, target storage.TargetStorage, logger *log.Logger) (*ConsensusAnalyzer, error) {
 	// Configure analyzer.
 	blockRange := analyzer.BlockRange{
 		From: cfg.From,

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -79,7 +79,6 @@ func NewConsensusAnalyzer(cfg *config.BlockBasedAnalyzerConfig, genesisChainCont
 		Source:              sourceClient,
 	}
 
-	logger.Info("Starting consensus analyzer", "config", ac)
 	return &ConsensusAnalyzer{
 		cfg:     ac,
 		target:  target,

--- a/analyzer/consensus/consensus.go
+++ b/analyzer/consensus/consensus.go
@@ -59,6 +59,7 @@ func OpenSignedTxNoVerify(signedTx *transaction.SignedTransaction) (*transaction
 // consensusAnalyzer is the main Analyzer for the consensus layer.
 type consensusAnalyzer struct {
 	cfg     analyzer.ConsensusConfig
+	mode    analyzer.BlockAnalysisMode
 	target  storage.TargetStorage
 	logger  *log.Logger
 	metrics metrics.DatabaseMetrics
@@ -67,7 +68,7 @@ type consensusAnalyzer struct {
 var _ analyzer.Analyzer = (*consensusAnalyzer)(nil)
 
 // NewConsensusAnalyzer returns a new main analyzer for the consensus layer.
-func NewConsensusAnalyzer(cfg config.BlockRange, genesisChainContext string, sourceClient *source.ConsensusClient, target storage.TargetStorage, logger *log.Logger) (analyzer.Analyzer, error) {
+func NewConsensusAnalyzer(cfg config.BlockRange, mode analyzer.BlockAnalysisMode, genesisChainContext string, sourceClient *source.ConsensusClient, target storage.TargetStorage, logger *log.Logger) (analyzer.Analyzer, error) {
 	// Configure analyzer.
 	blockRange := analyzer.BlockRange{
 		From: cfg.From,
@@ -81,6 +82,7 @@ func NewConsensusAnalyzer(cfg config.BlockRange, genesisChainContext string, sou
 
 	return &consensusAnalyzer{
 		cfg:     ac,
+		mode:    mode,
 		target:  target,
 		logger:  logger.With("analyzer", ConsensusAnalyzerName),
 		metrics: metrics.NewDefaultDatabaseMetrics(ConsensusAnalyzerName),

--- a/analyzer/metadata_registry.go
+++ b/analyzer/metadata_registry.go
@@ -29,7 +29,7 @@ func (a *MetadataRegistryAnalyzer) Name() string {
 	return MetadataRegistryAnalyzerName
 }
 
-func NewMetadataRegistryAnalyzer(cfg *config.MetadataRegistryConfig, target storage.TargetStorage, logger *log.Logger) (*MetadataRegistryAnalyzer, error) {
+func NewMetadataRegistryAnalyzer(cfg *config.MetadataRegistryConfig, target storage.TargetStorage, logger *log.Logger) (Analyzer, error) {
 	logger.Info("Starting metadata_registry analyzer")
 	return &MetadataRegistryAnalyzer{
 		interval: cfg.Interval,

--- a/analyzer/runtime/accounts.go
+++ b/analyzer/runtime/accounts.go
@@ -15,7 +15,7 @@ import (
 // It does not insert the events themselves; that is done in a
 // module-independent way. It only records effects for which an understanding of
 // the module's semantics is necessary.
-func (m *Main) queueAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
+func (m *runtimeAnalyzer) queueAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
 	for _, event := range blockData.EventData {
 		if event.WithScope.Accounts == nil {
 			continue
@@ -32,7 +32,7 @@ func (m *Main) queueAccountsEvents(batch *storage.QueryBatch, blockData *BlockDa
 	}
 }
 
-func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.MintEvent) {
+func (m *runtimeAnalyzer) queueMint(batch *storage.QueryBatch, round uint64, e accounts.MintEvent) {
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeMintInsert,
@@ -52,7 +52,7 @@ func (m *Main) queueMint(batch *storage.QueryBatch, round uint64, e accounts.Min
 	)
 }
 
-func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.BurnEvent) {
+func (m *runtimeAnalyzer) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.BurnEvent) {
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeBurnInsert,
@@ -72,7 +72,7 @@ func (m *Main) queueBurn(batch *storage.QueryBatch, round uint64, e accounts.Bur
 	)
 }
 
-func (m *Main) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts.TransferEvent) {
+func (m *runtimeAnalyzer) queueTransfer(batch *storage.QueryBatch, round uint64, e accounts.TransferEvent) {
 	// Record the event.
 	batch.Queue(
 		queries.RuntimeTransferInsert,

--- a/analyzer/runtime/consensusaccounts.go
+++ b/analyzer/runtime/consensusaccounts.go
@@ -13,7 +13,7 @@ import (
 // It does not insert the events themselves; that is done in a
 // module-independent way. It only records effects for which an understanding of
 // the module's semantics is necessary.
-func (m *Main) queueConsensusAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
+func (m *runtimeAnalyzer) queueConsensusAccountsEvents(batch *storage.QueryBatch, blockData *BlockData) {
 	for _, event := range blockData.EventData {
 		if event.WithScope.ConsensusAccounts == nil {
 			continue
@@ -27,7 +27,7 @@ func (m *Main) queueConsensusAccountsEvents(batch *storage.QueryBatch, blockData
 	}
 }
 
-func (m *Main) queueDeposit(batch *storage.QueryBatch, round uint64, e consensusaccounts.DepositEvent) {
+func (m *runtimeAnalyzer) queueDeposit(batch *storage.QueryBatch, round uint64, e consensusaccounts.DepositEvent) {
 	if !e.Amount.Denomination.IsNative() {
 		// Should never happen.
 		m.logger.Error("non-native denomination in deposit; pretending it is native",
@@ -52,7 +52,7 @@ func (m *Main) queueDeposit(batch *storage.QueryBatch, round uint64, e consensus
 	// the deposit will trigger a mint event in the runtime, and we'll update the balance then.
 }
 
-func (m *Main) queueWithdraw(batch *storage.QueryBatch, round uint64, e consensusaccounts.WithdrawEvent) {
+func (m *runtimeAnalyzer) queueWithdraw(batch *storage.QueryBatch, round uint64, e consensusaccounts.WithdrawEvent) {
 	if !e.Amount.Denomination.IsNative() {
 		// Should never happen.
 		m.logger.Error("non-native denomination in withdraw; pretending it is native",

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -41,7 +41,7 @@ var _ analyzer.Analyzer = (*Main)(nil)
 func NewRuntimeAnalyzer(
 	runtime common.Runtime,
 	runtimeMetadata *sdkConfig.ParaTime,
-	cfg *config.BlockBasedAnalyzerConfig,
+	cfg config.BlockRange,
 	sourceClient *source.RuntimeClient,
 	target storage.TargetStorage,
 	logger *log.Logger,

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -30,6 +30,7 @@ const (
 // runtimeAnalyzer is the main Analyzer for runtimes.
 type runtimeAnalyzer struct {
 	cfg     analyzer.RuntimeConfig
+	mode    analyzer.BlockAnalysisMode
 	target  storage.TargetStorage
 	logger  *log.Logger
 	metrics metrics.DatabaseMetrics
@@ -42,6 +43,7 @@ func NewRuntimeAnalyzer(
 	runtime common.Runtime,
 	runtimeMetadata *sdkConfig.ParaTime,
 	cfg config.BlockRange,
+	mode analyzer.BlockAnalysisMode,
 	sourceClient *source.RuntimeClient,
 	target storage.TargetStorage,
 	logger *log.Logger,
@@ -59,6 +61,7 @@ func NewRuntimeAnalyzer(
 
 	return &runtimeAnalyzer{
 		cfg:     ac,
+		mode:    mode,
 		target:  target,
 		logger:  logger.With("analyzer", runtime),
 		metrics: metrics.NewDefaultDatabaseMetrics(string(runtime)),

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -244,7 +244,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return consensus.NewConsensusAnalyzer(cfg.Analyzers.Consensus, genesisChainContext, sourceClient, dbClient, logger)
+			return consensus.NewConsensusAnalyzer(cfg.Analyzers.Consensus.SlowSyncRange(), genesisChainContext, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {
@@ -254,7 +254,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, runtimeMetadata, cfg.Analyzers.Emerald, sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, runtimeMetadata, cfg.Analyzers.Emerald.SlowSyncRange(), sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Sapphire != nil {
@@ -264,7 +264,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, runtimeMetadata, cfg.Analyzers.Sapphire, sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, runtimeMetadata, cfg.Analyzers.Sapphire.SlowSyncRange(), sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Cipher != nil {
@@ -274,7 +274,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, runtimeMetadata, cfg.Analyzers.Cipher, sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, runtimeMetadata, cfg.Analyzers.Cipher.SlowSyncRange(), sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokens != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -224,6 +224,7 @@ func addAnalyzer(analyzers map[string]A, errSoFar error, analyzerGenerator func(
 func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	ctx := context.Background()
 	logger := cmdCommon.Logger().WithModule(moduleName)
+	logger.Info("initializing analysis service", "config", cfg)
 
 	// Initialize source storage.
 	sources := newSourceFactory(cfg.Source)

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -136,7 +136,7 @@ func wipeStorage(cfg *config.StorageConfig) error {
 
 // Service is the Oasis Indexer's analysis service.
 type Service struct {
-	Analyzers map[string]analyzer.Analyzer
+	Analyzers []analyzer.Analyzer
 
 	sources *sourceFactory
 	target  storage.TargetStorage
@@ -208,7 +208,7 @@ type A = analyzer.Analyzer
 // should be fed into subsequent call to the function.
 // As soon as an analyzerGenerator returns an error, all subsequent calls will
 // short-circuit and return the same error, leaving `analyzers` unchanged.
-func addAnalyzer(analyzers map[string]A, errSoFar error, analyzerGenerator func() (A, error)) (map[string]A, error) {
+func addAnalyzer(analyzers []A, errSoFar error, analyzerGenerator func() (A, error)) ([]A, error) {
 	if errSoFar != nil {
 		return analyzers, errSoFar
 	}
@@ -216,7 +216,7 @@ func addAnalyzer(analyzers map[string]A, errSoFar error, analyzerGenerator func(
 	if errSoFar != nil {
 		return analyzers, errSoFar
 	}
-	analyzers[a.Name()] = a
+	analyzers = append(analyzers, a)
 	return analyzers, nil
 }
 
@@ -236,7 +236,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	}
 
 	// Initialize analyzers.
-	analyzers := map[string]A{}
+	analyzers := []A{}
 	if cfg.Analyzers.Consensus != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
 			genesisChainContext := cfg.Source.History().CurrentRecord().ChainContext

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -243,7 +243,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return consensus.NewMain(cfg.Analyzers.Consensus, genesisChainContext, sourceClient, dbClient, logger)
+			return consensus.NewConsensusAnalyzer(cfg.Analyzers.Consensus, genesisChainContext, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -343,7 +343,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokens.NewMain(common.RuntimeEmerald, sourceClient, dbClient, logger)
+			return evmtokens.NewEvmTokensAnalyzer(common.RuntimeEmerald, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokens != nil {
@@ -352,7 +352,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokens.NewMain(common.RuntimeSapphire, sourceClient, dbClient, logger)
+			return evmtokens.NewEvmTokensAnalyzer(common.RuntimeSapphire, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokenBalances != nil {
@@ -361,7 +361,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeEmerald, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewEvmTokenBalancesAnalyzer(common.RuntimeEmerald, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokenBalances != nil {
@@ -370,7 +370,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeSapphire, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewEvmTokenBalancesAnalyzer(common.RuntimeSapphire, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -247,7 +247,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return consensus.NewConsensusAnalyzer(*fastRange, chainContext, sourceClient, dbClient, logger)
+					return consensus.NewConsensusAnalyzer(*fastRange, analyzer.FastSyncMode, chainContext, sourceClient, dbClient, logger)
 				})
 			}
 		}
@@ -261,7 +261,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, sdkPT, *fastRange, sourceClient, dbClient, logger)
+					return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, sdkPT, *fastRange, analyzer.FastSyncMode, sourceClient, dbClient, logger)
 				})
 			}
 		}
@@ -275,7 +275,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, sdkPT, *fastRange, sourceClient, dbClient, logger)
+					return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, sdkPT, *fastRange, analyzer.FastSyncMode, sourceClient, dbClient, logger)
 				})
 			}
 		}
@@ -289,7 +289,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 					if err1 != nil {
 						return nil, err1
 					}
-					return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, sdkPT, *fastRange, sourceClient, dbClient, logger)
+					return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, sdkPT, *fastRange, analyzer.FastSyncMode, sourceClient, dbClient, logger)
 				})
 			}
 		}
@@ -304,7 +304,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return consensus.NewConsensusAnalyzer(cfg.Analyzers.Consensus.SlowSyncRange(), genesisChainContext, sourceClient, dbClient, logger)
+			return consensus.NewConsensusAnalyzer(cfg.Analyzers.Consensus.SlowSyncRange(), analyzer.SlowSyncMode, genesisChainContext, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Emerald != nil {
@@ -314,7 +314,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, runtimeMetadata, cfg.Analyzers.Emerald.SlowSyncRange(), sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, runtimeMetadata, cfg.Analyzers.Emerald.SlowSyncRange(), analyzer.SlowSyncMode, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Sapphire != nil {
@@ -324,7 +324,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, runtimeMetadata, cfg.Analyzers.Sapphire.SlowSyncRange(), sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, runtimeMetadata, cfg.Analyzers.Sapphire.SlowSyncRange(), analyzer.SlowSyncMode, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.Cipher != nil {
@@ -334,7 +334,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 			if err1 != nil {
 				return nil, err1
 			}
-			return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, runtimeMetadata, cfg.Analyzers.Cipher.SlowSyncRange(), sourceClient, dbClient, logger)
+			return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, runtimeMetadata, cfg.Analyzers.Cipher.SlowSyncRange(), analyzer.SlowSyncMode, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokens != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -136,7 +136,8 @@ func wipeStorage(cfg *config.StorageConfig) error {
 
 // Service is the Oasis Indexer's analysis service.
 type Service struct {
-	Analyzers []analyzer.Analyzer
+	analyzers         []analyzer.Analyzer
+	fastSyncAnalyzers []analyzer.Analyzer
 
 	sources *sourceFactory
 	target  storage.TargetStorage
@@ -221,7 +222,7 @@ func addAnalyzer(analyzers []A, errSoFar error, analyzerGenerator func() (A, err
 }
 
 // NewService creates new Service.
-func NewService(cfg *config.AnalysisConfig) (*Service, error) {
+func NewService(cfg *config.AnalysisConfig) (*Service, error) { //nolint:gocyclo
 	ctx := context.Background()
 	logger := cmdCommon.Logger().WithModule(moduleName)
 	logger.Info("initializing analysis service", "config", cfg)
@@ -235,7 +236,66 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 		return nil, err
 	}
 
-	// Initialize analyzers.
+	// Initialize fast-sync analyzers.
+	fastSyncAnalyzers := []A{}
+	if cfg.Analyzers.Consensus != nil {
+		if fastRange := cfg.Analyzers.Consensus.FastSyncRange(); fastRange != nil {
+			for i := 0; i < cfg.Analyzers.Consensus.FastSync.Parallelism; i++ {
+				fastSyncAnalyzers, err = addAnalyzer(fastSyncAnalyzers, err, func() (A, error) {
+					chainContext := cfg.Source.History().CurrentRecord().ChainContext
+					sourceClient, err1 := sources.Consensus(ctx)
+					if err1 != nil {
+						return nil, err1
+					}
+					return consensus.NewConsensusAnalyzer(*fastRange, chainContext, sourceClient, dbClient, logger)
+				})
+			}
+		}
+	}
+	if cfg.Analyzers.Emerald != nil {
+		if fastRange := cfg.Analyzers.Emerald.FastSyncRange(); fastRange != nil {
+			for i := 0; i < cfg.Analyzers.Emerald.FastSync.Parallelism; i++ {
+				fastSyncAnalyzers, err = addAnalyzer(fastSyncAnalyzers, err, func() (A, error) {
+					sdkPT := cfg.Source.SDKParaTime(common.RuntimeEmerald)
+					sourceClient, err1 := sources.Runtime(ctx, common.RuntimeEmerald)
+					if err1 != nil {
+						return nil, err1
+					}
+					return runtime.NewRuntimeAnalyzer(common.RuntimeEmerald, sdkPT, *fastRange, sourceClient, dbClient, logger)
+				})
+			}
+		}
+	}
+	if cfg.Analyzers.Sapphire != nil {
+		if fastRange := cfg.Analyzers.Sapphire.FastSyncRange(); fastRange != nil {
+			for i := 0; i < cfg.Analyzers.Sapphire.FastSync.Parallelism; i++ {
+				fastSyncAnalyzers, err = addAnalyzer(fastSyncAnalyzers, err, func() (A, error) {
+					sdkPT := cfg.Source.SDKParaTime(common.RuntimeSapphire)
+					sourceClient, err1 := sources.Runtime(ctx, common.RuntimeSapphire)
+					if err1 != nil {
+						return nil, err1
+					}
+					return runtime.NewRuntimeAnalyzer(common.RuntimeSapphire, sdkPT, *fastRange, sourceClient, dbClient, logger)
+				})
+			}
+		}
+	}
+	if cfg.Analyzers.Cipher != nil {
+		if fastRange := cfg.Analyzers.Cipher.FastSyncRange(); fastRange != nil {
+			for i := 0; i < cfg.Analyzers.Cipher.FastSync.Parallelism; i++ {
+				fastSyncAnalyzers, err = addAnalyzer(fastSyncAnalyzers, err, func() (A, error) {
+					sdkPT := cfg.Source.SDKParaTime(common.RuntimeCipher)
+					sourceClient, err1 := sources.Runtime(ctx, common.RuntimeCipher)
+					if err1 != nil {
+						return nil, err1
+					}
+					return runtime.NewRuntimeAnalyzer(common.RuntimeCipher, sdkPT, *fastRange, sourceClient, dbClient, logger)
+				})
+			}
+		}
+	}
+
+	// Initialize slow-sync analyzers.
 	analyzers := []A{}
 	if cfg.Analyzers.Consensus != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
@@ -330,12 +390,23 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	logger.Info("initialized all analyzers")
 
 	return &Service{
-		Analyzers: analyzers,
+		fastSyncAnalyzers: fastSyncAnalyzers,
+		analyzers:         analyzers,
 
 		sources: sources,
 		target:  dbClient,
 		logger:  logger,
 	}, nil
+}
+
+// closingChannel returns a channel that closes when the wait group `wg` is done.
+func closingChannel(wg *sync.WaitGroup) <-chan struct{} {
+	c := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(c)
+	}()
+	return c
 }
 
 // Start starts the analysis service.
@@ -346,22 +417,34 @@ func (a *Service) Start() {
 	ctx, cancelAnalyzers := context.WithCancel(context.Background())
 	defer cancelAnalyzers() // Start() only returns when analyzers are done, so this should be a no-op, but it makes the compiler happier.
 
-	// Start all analyzers.
-	var wg sync.WaitGroup
-	for _, an := range a.Analyzers {
-		wg.Add(1)
+	// Start fast-sync analyzers.
+	var fastSyncWg sync.WaitGroup
+	for _, an := range a.fastSyncAnalyzers {
+		fastSyncWg.Add(1)
 		go func(an analyzer.Analyzer) {
-			defer wg.Done()
+			defer fastSyncWg.Done()
 			an.Start(ctx)
 		}(an)
 	}
+	fastSyncAnalyzersDone := closingChannel(&fastSyncWg)
 
-	// Create a channel that will close when all analyzers have completed.
-	analyzersDone := make(chan struct{})
-	go func() {
-		wg.Wait()
-		close(analyzersDone)
-	}()
+	// Prepare slow-sync analyzers (to be started after fast-sync analyzers are done).
+	var wg sync.WaitGroup
+	for _, an := range a.analyzers {
+		wg.Add(1)
+		go func(an analyzer.Analyzer) {
+			defer wg.Done()
+			// Start the analyzer after fast-sync analyzers,
+			// unless the context is canceled first (e.g. by ctrl+C during fast-sync).
+			select {
+			case <-ctx.Done():
+				return
+			case <-fastSyncAnalyzersDone:
+				an.Start(ctx)
+			}
+		}(an)
+	}
+	analyzersDone := closingChannel(&wg)
 
 	// Trap Ctrl+C and SIGTERM; the latter is issued by Kubernetes to request a shutdown.
 	signalChan := make(chan os.Signal, 1)

--- a/config/config.go
+++ b/config/config.go
@@ -247,6 +247,7 @@ type BlockBasedAnalyzerConfig struct {
 
 	// If present, the analyzer will run in fast sync mode for
 	// an initial range of blocks, and then switch to slow sync.
+	// If absent, the analyzer will only run in "slow", sequential mode.
 	//
 	// If fast sync mode is enabled:
 	// - DB checks and foreign keys are disabled.
@@ -269,10 +270,7 @@ type BlockBasedAnalyzerConfig struct {
 type FastSyncConfig struct {
 	// To is the block (inclusive) to which the analyzer
 	// will run in fast sync mode. From this block onwards (exclusive),
-	// the analyzer will run in slow mode. If absent, the analyzer will
-	// only run in slow mode.
-	// Omitting this parameter or setting it to 0 means to use the latest
-	// block height at the time of starting the indexer.
+	// the analyzer will run in slow mode.
 	To int64 `koanf:"to"`
 
 	// The number of parallel analyzers to run in fast sync mode.

--- a/config/config.go
+++ b/config/config.go
@@ -245,11 +245,94 @@ type BlockBasedAnalyzerConfig struct {
 	// From is the (inclusive) starting block for this analyzer.
 	From int64 `koanf:"from"`
 
+	// If present, the analyzer will run in fast sync mode for
+	// an initial range of blocks, and then switch to slow sync.
+	//
+	// If fast sync mode is enabled:
+	// - DB checks and foreign keys are disabled.
+	// - Multiple analyzers run in parallel and process blocks out of order.
+	// - Analyzers do not perform dead reckoning on state (notably, transfers).
+	// After all analyzers finish the fast sync range:
+	// - DB checks and foreign keys are re-enabled.
+	// - State that would normally be dead-reckoned is fetched directly from
+	//	 the node via the StateToGenesis() RPC.
+	// - A single "slow mode" analyzer (per runtime/consensus) is started, and resumes
+	//   to process blocks sequentially, with dead reckoning enabled.
+	FastSync *FastSyncConfig `koanf:"fast_sync"`
+
 	// To is the (inclusive) ending block for this analyzer.
-	// Omitting this parameter means this analyzer will
-	// continue processing new blocks until the next breaking
-	// upgrade.
+	// Omitting this parameter or setting it to 0 means this analyzer will
+	// continue processing new blocks forever.
 	To int64 `koanf:"to"`
+}
+
+type FastSyncConfig struct {
+	// To is the block (inclusive) to which the analyzer
+	// will run in fast sync mode. From this block onwards (exclusive),
+	// the analyzer will run in slow mode. If absent, the analyzer will
+	// only run in slow mode.
+	// Omitting this parameter or setting it to 0 means to use the latest
+	// block height at the time of starting the indexer.
+	To int64 `koanf:"to"`
+
+	// The number of parallel analyzers to run in fast sync mode.
+	Parallelism int `koanf:"parallelism"`
+}
+
+func (blockCfg BlockBasedAnalyzerConfig) FastSyncRange() *BlockRange {
+	if blockCfg.FastSync == nil {
+		return nil
+	}
+	return &BlockRange{
+		From: blockCfg.From,
+		To:   blockCfg.FastSync.To,
+	}
+}
+
+func (blockCfg BlockBasedAnalyzerConfig) SlowSyncRange() BlockRange {
+	if blockCfg.FastSync == nil {
+		return BlockRange{
+			From: blockCfg.From,
+			To:   blockCfg.To,
+		}
+	}
+	return BlockRange{
+		From: blockCfg.FastSync.To + 1,
+		To:   blockCfg.To,
+	}
+}
+
+func (blockCfg BlockBasedAnalyzerConfig) Validate() error {
+	// Check non-range constraints.
+	if blockCfg.FastSync != nil && blockCfg.FastSync.To == 0 {
+		return fmt.Errorf("invalid block range: .fast_sync.to must be > 0")
+	}
+	if blockCfg.FastSync != nil && blockCfg.FastSync.Parallelism <= 0 {
+		return fmt.Errorf("invalid parallelism level: must be > 0")
+	}
+
+	// Check that the slow sync range and fast sync range are valid.
+	if err := blockCfg.SlowSyncRange().Validate(); err != nil {
+		return err
+	}
+	if f := blockCfg.FastSyncRange(); f != nil {
+		if err := f.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type BlockRange struct {
+	From int64 // Inclusive.
+	To   int64 // Inclusive.
+}
+
+func (r BlockRange) Validate() error {
+	if (r.To != 0 && r.From > r.To) || r.To < 0 || r.From < 0 {
+		return fmt.Errorf("invalid block range from %d to %d", r.From, r.To)
+	}
+	return nil
 }
 
 type IntervalBasedAnalyzerConfig struct {
@@ -258,14 +341,6 @@ type IntervalBasedAnalyzerConfig struct {
 }
 
 type EvmTokensAnalyzerConfig struct{}
-
-// Validate validates the range configuration.
-func (cfg *BlockBasedAnalyzerConfig) Validate() error {
-	if (cfg.To != 0 && cfg.From > cfg.To) || cfg.To < 0 || cfg.From < 0 {
-		return fmt.Errorf("malformed analysis range from %d to %d", cfg.From, cfg.To)
-	}
-	return nil
-}
 
 // MetadataRegistryConfig is the configuration for the metadata registry analyzer.
 type MetadataRegistryConfig struct {


### PR DESCRIPTION
Resolves https://app.clickup.com/t/8669qdzbh

This PR
- adds a `fast_sync` key to each block analyzer's config, wherein the block range and parallelism can be specified
- runs those fast-sync analyzers first
- (TODO) changes "slow-sync" consensus analyzer (now at most one) so it first processes the genesis _right before the first block it will analyze_. If that happens to be the chain genesis document, it grabs that; otherwise, it uses StateToGenesis at an appropriate height. If it notices that at least one block _after_ the beginning of the configured "slow" range has already been processed, it assumes genesis was already processed also, and skips genesis processing. This is different from how we've been processing genesis so far (analyze the newest chain's genesis document at most once, regardless of the configured range), but I think the new way makes more sense. It also allows the slow analyzer to do the right thing wrt genesis in any of the three scenarios:
  - it runs after fast-sync analyzers that have processed some range of blocks
  - it runs after a slow-sync analyzer (after k8s redeployment)
  - it is starting from scratch 

This PR does NOT implement fast-sync behavior (= disabling dead reckoning) or parallelism tolerance inside the analyzers themselves; that happens in other PRs. So the only way to test this config in the very short term is to run "fast-sync" analyzers (that are no different from slow ones) with a parallelism level of 1.