### PR TITLE
show us the encrypted data

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -254,8 +254,8 @@ const (
       VALUES ($1, $2, $3, $4)`
 
 	RuntimeTransactionInsert = `
-    INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, fee, gas_limit, gas_used, size, timestamp, method, body, "to", amount, success, error_module, error_code, error_message)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`
+    INSERT INTO chain.runtime_transactions (runtime, round, tx_index, tx_hash, tx_eth_hash, fee, gas_limit, gas_used, size, timestamp, method, body, "to", amount, evm_encrypted_format, evm_encrypted_public_key, evm_encrypted_data_nonce, evm_encrypted_data_data, evm_encrypted_result_nonce, evm_encrypted_result_data, success, error_module, error_code, error_message)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)`
 
 	RuntimeEventInsert = `
     INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)

--- a/analyzer/runtime/evm.go
+++ b/analyzer/runtime/evm.go
@@ -13,6 +13,7 @@ import (
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer/evmabi"
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 )
@@ -53,7 +54,7 @@ type EVMTokenBalanceData struct {
 }
 
 type EVMEncryptedData struct {
-	Format      int
+	Format      common.CallFormat
 	PublicKey   []byte
 	DataNonce   []byte
 	DataData    []byte
@@ -313,7 +314,7 @@ func EVMMaybeUnmarshalEncryptedData(data []byte, result *[]byte) (*EVMEncryptedD
 		// https://github.com/oasisprotocol/oasis-sdk/blob/runtime-sdk/v0.3.0/runtime-sdk/modules/evm/src/lib.rs#L626
 		return nil, nil
 	}
-	encryptedData.Format = int(call.Format)
+	encryptedData.Format = common.CallFormat(call.Format.String())
 	switch call.Format {
 	case sdkTypes.CallFormatEncryptedX25519DeoxysII:
 		var callEnvelope sdkTypes.CallEnvelopeX25519DeoxysII
@@ -323,6 +324,8 @@ func EVMMaybeUnmarshalEncryptedData(data []byte, result *[]byte) (*EVMEncryptedD
 		encryptedData.PublicKey = callEnvelope.Pk[:]
 		encryptedData.DataNonce = callEnvelope.Nonce[:]
 		encryptedData.DataData = callEnvelope.Data
+	// If you are adding new call formats, remember to add them to the
+	// database call_format enum too.
 	default:
 		return nil, fmt.Errorf("outer call format %s (%d) not supported", call.Format, call.Format)
 	}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -376,16 +376,14 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 							return fmt.Errorf("created contract: %w", err)
 						}
 					}
-					var evmEncrypted *EVMEncryptedData
-					evmEncrypted, err = EVMMaybeUnmarshalEncryptedData(body.InitCode, ok)
-					if err == nil {
+					if evmEncrypted, err2 := EVMMaybeUnmarshalEncryptedData(body.InitCode, ok); err2 == nil {
 						blockTransactionData.EVMEncrypted = evmEncrypted
 					} else {
 						logger.Error("error unmarshalling encrypted init code and result, omitting encrypted fields",
 							"round", blockHeader.Round,
 							"tx_index", txIndex,
 							"tx_hash", txr.Tx.Hash(),
-							"err", err,
+							"err", err2,
 						)
 					}
 					return nil
@@ -396,16 +394,14 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					if to, err = registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, body.Address); err != nil {
 						return fmt.Errorf("address: %w", err)
 					}
-					var evmEncrypted *EVMEncryptedData
-					evmEncrypted, err = EVMMaybeUnmarshalEncryptedData(body.Data, ok)
-					if err == nil {
+					if evmEncrypted, err2 := EVMMaybeUnmarshalEncryptedData(body.Data, ok); err2 == nil {
 						blockTransactionData.EVMEncrypted = evmEncrypted
 					} else {
 						logger.Error("error unmarshalling encrypted data and result, omitting encrypted fields",
 							"round", blockHeader.Round,
 							"tx_index", txIndex,
 							"tx_hash", txr.Tx.Hash(),
-							"err", err,
+							"err", err2,
 						)
 					}
 					// todo: maybe parse known token methods

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -276,6 +276,22 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 		for addr := range transactionData.RelatedAccountAddresses {
 			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.cfg.RuntimeName, addr, data.Header.Round, transactionData.Index)
 		}
+		var (
+			evmEncryptedFormat      *int
+			evmEncryptedPublicKey   *[]byte
+			evmEncryptedDataNonce   *[]byte
+			evmEncryptedDataData    *[]byte
+			evmEncryptedResultNonce *[]byte
+			evmEncryptedResultData  *[]byte
+		)
+		if transactionData.EVMEncrypted != nil {
+			evmEncryptedFormat = &transactionData.EVMEncrypted.Format
+			evmEncryptedPublicKey = &transactionData.EVMEncrypted.PublicKey
+			evmEncryptedDataNonce = &transactionData.EVMEncrypted.DataNonce
+			evmEncryptedDataData = &transactionData.EVMEncrypted.DataData
+			evmEncryptedResultNonce = &transactionData.EVMEncrypted.ResultNonce
+			evmEncryptedResultData = &transactionData.EVMEncrypted.ResultData
+		}
 		var error_module string
 		var error_code uint32
 		var error_message *string
@@ -300,6 +316,12 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			transactionData.Body,
 			transactionData.To,
 			transactionData.Amount,
+			evmEncryptedFormat,
+			evmEncryptedPublicKey,
+			evmEncryptedDataNonce,
+			evmEncryptedDataData,
+			evmEncryptedResultNonce,
+			evmEncryptedResultData,
 			transactionData.Success,
 			error_module,
 			error_code,

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -277,7 +277,7 @@ func (m *Main) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			batch.Queue(queries.RuntimeRelatedTransactionInsert, m.cfg.RuntimeName, addr, data.Header.Round, transactionData.Index)
 		}
 		var (
-			evmEncryptedFormat      *int
+			evmEncryptedFormat      *common.CallFormat
 			evmEncryptedPublicKey   *[]byte
 			evmEncryptedDataNonce   *[]byte
 			evmEncryptedDataData    *[]byte

--- a/common/types.go
+++ b/common/types.go
@@ -144,3 +144,5 @@ const (
 	RuntimeSapphire Runtime = "sapphire"
 	RuntimeUnknown  Runtime = "unknown"
 )
+
+type CallFormat string

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -53,6 +53,14 @@ CREATE TABLE chain.runtime_transactions
   "to"        oasis_addr,   -- Exact semantics depend on method. Extracted from body; for convenience only.
   amount      UINT_NUMERIC, -- Exact semantics depend on method. Extracted from body; for convenience only.
 
+  -- Encrypted data in encrypted Ethereum-format transactions.
+  evm_encrypted_format INTEGER,
+  evm_encrypted_public_key BYTEA,
+  evm_encrypted_data_nonce BYTEA,
+  evm_encrypted_data_data BYTEA,
+  evm_encrypted_result_nonce BYTEA,
+  evm_encrypted_result_data BYTEA,
+
   -- Error information.
   success       BOOLEAN,  -- NULL means success is unknown (can happen in confidential runtimes)
   error_module  TEXT,

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -48,7 +48,7 @@ CREATE TABLE chain.runtime_transactions
   size UINT31 NOT NULL,
 
   -- Transaction contents.
-  method      TEXT,         -- accounts.Transter, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call. NULL for malformed and encrypted txs.
+  method      TEXT,         -- accounts.Transfer, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call. NULL for malformed and encrypted txs.
   body        JSONB,        -- For EVM txs, the EVM method and args are encoded in here. NULL for malformed and encrypted txs.
   "to"        oasis_addr,   -- Exact semantics depend on method. Extracted from body; for convenience only.
   amount      UINT_NUMERIC, -- Exact semantics depend on method. Extracted from body; for convenience only.

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -3,6 +3,7 @@
 BEGIN;
 
 CREATE TYPE runtime AS ENUM ('emerald', 'sapphire', 'cipher');
+CREATE TYPE call_format AS ENUM ('encrypted/x25519-deoxysii');
 
 CREATE TABLE chain.runtime_blocks
 (
@@ -54,7 +55,7 @@ CREATE TABLE chain.runtime_transactions
   amount      UINT_NUMERIC, -- Exact semantics depend on method. Extracted from body; for convenience only.
 
   -- Encrypted data in encrypted Ethereum-format transactions.
-  evm_encrypted_format INTEGER,
+  evm_encrypted_format call_format,
   evm_encrypted_public_key BYTEA,
   evm_encrypted_data_nonce BYTEA,
   evm_encrypted_data_data BYTEA,


### PR DESCRIPTION
alright, if you really want to look :shrug: 

no api

philosophy:
- collapse all callformat variants into a looser type with variable size nonce+data fields.
- same for public key, there's just a variable size slot for it.
- store the format alongside, in case anyone wants to make sense of the keys+nonces+data
- the "public key" in the tx is the one provided by the caller. I'm not aware of us capturing the runtime's public key.
- if anything goes wrong, log and leave it nil. the drawback is that NULL in the db could mean either plain or something failed during analysis (e.g. new callformat that we don't support)
- kinda oddly asymmetric, we don't store the data+result when it's unencrypted