### PR TITLE
storage: expose test postgres client and add migrations test

### DIFF
--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -34,7 +34,7 @@ jobs:
         ports:
           - 5432:5432
     env:
-      CI_TEST_CONN_STRING: "postgresql://postgres:postgres@127.0.0.1:5432/postgres"
+      CI_TEST_CONN_STRING: "postgresql://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/cmd/analyzer/analyzer_test.go
+++ b/cmd/analyzer/analyzer_test.go
@@ -1,0 +1,31 @@
+package analyzer_test
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-indexer/cmd/analyzer"
+	"github.com/oasisprotocol/oasis-indexer/storage/postgres/testutil"
+	"github.com/oasisprotocol/oasis-indexer/tests"
+)
+
+// Relative path to the migrations directory when running tests in this file.
+// When running go tests, the working directory is always set to the package directory of the test being run.
+const migrationsPath = "file://../../storage/migrations"
+
+func TestMigrations(t *testing.T) {
+	tests.SkipIfShort(t)
+	client := testutil.NewTestClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Ensure database is empty before running migrations.
+	require.NoError(t, client.Wipe(ctx), "failed to wipe database")
+
+	// Run migrations.
+	require.NoError(t, analyzer.RunMigrations(migrationsPath, os.Getenv("CI_TEST_CONN_STRING")), "failed to run migrations")
+}

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -46,7 +46,7 @@ CREATE TABLE chain.runtime_transactions
   gas_used    UINT63 NOT NULL,
 
   size UINT31 NOT NULL,
-  
+
   -- Transaction contents.
   method      TEXT,         -- accounts.Transter, consensus.Deposit, consensus.Withdraw, evm.Create, evm.Call. NULL for malformed and encrypted txs.
   body        JSONB,        -- For EVM txs, the EVM method and args are encoded in here. NULL for malformed and encrypted txs.

--- a/storage/postgres/client.go
+++ b/storage/postgres/client.go
@@ -247,10 +247,10 @@ func (c *Client) Wipe(ctx context.Context) error {
 	// List, then drop all custom types.
 	// Query from https://stackoverflow.com/questions/3660787/how-to-list-custom-types-using-postgres-information-schema
 	rows, err := c.Query(ctx, `
-		SELECT      n.nspname as schema, t.typname as type 
-		FROM        pg_type t 
-		LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace 
-		WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid)) 
+		SELECT      n.nspname as schema, t.typname as type
+		FROM        pg_type t
+		LEFT JOIN   pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+		WHERE       (t.typrelid = 0 OR (SELECT c.relkind = 'c' FROM pg_catalog.pg_class c WHERE c.oid = t.typrelid))
 		AND     NOT EXISTS(SELECT 1 FROM pg_catalog.pg_type el WHERE el.oid = t.typelem AND el.typarray = t.oid)
 		AND     n.nspname != 'information_schema' AND n.nspname NOT LIKE 'pg_%';
 	`)

--- a/storage/postgres/testutil/testutil.go
+++ b/storage/postgres/testutil/testutil.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-indexer/log"
+	"github.com/oasisprotocol/oasis-indexer/storage/postgres"
+)
+
+// NewTestClient returns a postgres client used in CI tests.
+func NewTestClient(t *testing.T) *postgres.Client {
+	connString := os.Getenv("CI_TEST_CONN_STRING")
+	logger, err := log.NewLogger("postgres-test", io.Discard, log.FmtJSON, log.LevelInfo)
+	require.Nil(t, err, "log.NewLogger")
+
+	client, err := postgres.NewClient(connString, logger)
+	require.Nil(t, err, "postgres.NewClient")
+	return client
+}


### PR DESCRIPTION
This introduces a postgres `testutils` package, which allows connecting to the test database from other tests in the codebase. An analyzer test that executes the migrations is also included as an example of usage (the test ensures migrations are applied without errors).

This was needed/useful in https://github.com/oasisprotocol/oasis-indexer/pull/389 and was extracted into a separate PR.