### PR TITLE
evm_tokens: Explicitly tracks unsupported tokens in the DB

### DIFF
--- a/analyzer/runtime/evm.go
+++ b/analyzer/runtime/evm.go
@@ -21,7 +21,8 @@ import (
 type EVMTokenType int
 
 const (
-	EVMTokenTypeERC20 EVMTokenType = 20
+	EVMTokenTypeUnsupported EVMTokenType = 0 // A smart contract for which we're confident it's not a supported token kind.
+	EVMTokenTypeERC20       EVMTokenType = 20
 )
 
 type EVMPossibleToken struct {
@@ -214,8 +215,8 @@ func evmDownloadTokenERC20(ctx context.Context, logger *log.Logger, source stora
 
 // EVMDownloadNewToken tries to download the data of a given token. If it
 // transiently fails to download the data, it returns with a non-nil error. If
-// it deterministically cannot download the data, it returns nil with nil
-// error as well. Note that this latter case is not considered an error!
+// it deterministically cannot download the data, it returns a struct
+// with the `Type` field set to `EVMTokenTypeUnsupported`.
 func EVMDownloadNewToken(ctx context.Context, logger *log.Logger, source storage.RuntimeSourceStorage, round uint64, tokenEthAddr []byte) (*EVMTokenData, error) {
 	// todo: check ERC-165 0xffffffff compliance
 	// todo: try other token standards based on ERC-165
@@ -234,7 +235,7 @@ func EVMDownloadNewToken(ctx context.Context, logger *log.Logger, source storage
 	// see https://github.com/oasisprotocol/oasis-indexer/issues/225
 
 	// No applicable token discovered.
-	return nil, nil
+	return &EVMTokenData{Type: EVMTokenTypeUnsupported}, nil
 }
 
 // EVMDownloadMutatedToken tries to download the mutable data of a given

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -174,7 +174,7 @@ CREATE TABLE chain.evm_tokens
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
-  token_type INTEGER, -- From https://github.com/oasisprotocol/oasis-indexer/blob/v0.0.7/analyzer/modules/evm.go#L21
+  token_type INTEGER NOT NULL, -- 0 = unsupported, X = ERC-X; full spec at https://github.com/oasisprotocol/oasis-indexer/blob/v0.0.16/analyzer/runtime/evm.go#L21
   token_name TEXT,
   symbol TEXT,
   decimals INTEGER,


### PR DESCRIPTION
After this PR, every smart contract we encounter has an entry in the `evm_tokens` table, with the `type` column explicitly set to `0` (signifyin "not a token") when appropriate.

**Background:**
Previously, "tokens" (smart contracts, really) that were found to not be a known/supported token type were tracked in the `evm_token_analysis` table, in that their `last_dowload_round` was nonzero ... but they were not inserted into the `evm_tokens` table, because that table only stored "true" tokens.

This led to a the `evm_token_balances` (a separate analyzer) needing access to the `evm_token_analysis` table.

In https://app.clickup.com/t/861mn3n0e, we're extending `evm_token_balances` to also query native balances. This will require some special-casing of the native token. This PR makes it so that the special-casing stays limited to just the `evm_token_balances` analyzer, and does not spill over into `evm_tokens`.

**Testing**:
Dumped the evm_* tables (`docker exec -it indexer-postgres pg_dump -U rwuser indexer --table chain.evm_token_balance_analysis --table chain.evm_token_analysis --table chain.evm_tokens --table chain.evm_token_balances`) after indexing the first 1000 emerald blocks in Damask, both before and after the PR. There were no differences. To be fair, also no (!) new entries in `evm_token_balances`, I guess because the smart contracts that we heuristically determine _might_ be tokens (= we see a Transfer log coming from them) end up being actual ERC-20 tokens. So for a complete test, I should run with (potentially many) more rounds.