### PR TITLE
evm_token_balances: Refresh balance of native tokens

### DIFF
--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oasisprotocol/oasis-indexer/storage"
 	"github.com/oasisprotocol/oasis-indexer/storage/client"
 	source "github.com/oasisprotocol/oasis-indexer/storage/oasis"
+	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
 // Imagine a timeline starting from a `balanceOf` output `v0` followed by
@@ -121,7 +122,10 @@ type StaleTokenBalance struct {
 
 func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTokenBalance, error) {
 	var staleTokenBalances []*StaleTokenBalance
-	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokenBalanceAnalysisStale, m.runtime, limit)
+	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokenBalanceAnalysisStale,
+		m.runtime,
+		nativeTokenSymbol(&m.runtimeMetadata),
+		limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying stale token balances: %w", err)
 	}
@@ -151,17 +155,49 @@ func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTok
 }
 
 func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.QueryBatch, staleTokenBalance *StaleTokenBalance) error {
-	m.logger.Info("downloading", "stale_token_balance", staleTokenBalance)
-	// todo: assert that token addr and account addr contexts are secp256k1
-	tokenEthAddr, err := client.EVMEthAddrFromPreimage(staleTokenBalance.TokenAddrContextIdentifier, staleTokenBalance.TokenAddrContextVersion, staleTokenBalance.TokenAddrData)
-	if err != nil {
-		return fmt.Errorf("token address: %w", err)
-	}
 	accountEthAddr, err := client.EVMEthAddrFromPreimage(staleTokenBalance.AccountAddrContextIdentifier, staleTokenBalance.AccountAddrContextVersion, staleTokenBalance.AccountAddrData)
 	if err != nil {
 		return fmt.Errorf("account address: %w", err)
 	}
-	if staleTokenBalance.Type != nil {
+	switch *staleTokenBalance.Type {
+	case evm.EVMTokenTypeUnsupported:
+		// Do nothing; we'll just mark this token as processed so we remove it from the queue.
+	case evm.EVMTokenTypeNative:
+		// Query native balance.
+		addr := nodeapi.Address{}
+		if err := addr.UnmarshalText([]byte(staleTokenBalance.AccountAddr)); err != nil {
+			m.logger.Error("invalid account address bech32 '%s': %w", staleTokenBalance.AccountAddr, err)
+			break
+		}
+		balance, err := m.source.GetNativeBalance(ctx, staleTokenBalance.DownloadRound, addr)
+		if err != nil || balance == nil {
+			return fmt.Errorf("getting native runtime balance: %w", err)
+		}
+		if balance.Cmp(staleTokenBalance.Balance) != 0 {
+			correction := (&common.BigInt{}).Sub(&balance.Int, staleTokenBalance.Balance)
+			// Native token balance changes do not produce events, so our dead reckoning
+			// is expected to often be off. Log discrepancies at Info level only.
+			m.logger.Info("correcting reckoned native runtime balance to downloaded balance",
+				"account_addr", staleTokenBalance.AccountAddr,
+				"download_round", staleTokenBalance.DownloadRound,
+				"reckoned_balance", staleTokenBalance.Balance.String(),
+				"downloaded_balance", balance.String(),
+			)
+			batch.Queue(queries.RuntimeNativeBalanceUpdate,
+				m.runtime,
+				staleTokenBalance.AccountAddr,
+				nativeTokenSymbol(&m.runtimeMetadata),
+				correction,
+			)
+		} else {
+			m.logger.Debug("native balance: nothing to correct", "account_addr", staleTokenBalance.AccountAddr, "balance", balance)
+		}
+	default:
+		// All other ERC-X tokens. Query the token contract.
+		tokenEthAddr, err := client.EVMEthAddrFromPreimage(staleTokenBalance.TokenAddrContextIdentifier, staleTokenBalance.TokenAddrContextVersion, staleTokenBalance.TokenAddrData)
+		if err != nil {
+			return fmt.Errorf("token address: %w", err)
+		}
 		balanceData, err := evm.EVMDownloadTokenBalance(
 			ctx,
 			m.logger,
@@ -178,15 +214,12 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 			if balanceData.Balance.Cmp(staleTokenBalance.Balance) != 0 {
 				correction := &big.Int{}
 				correction.Sub(balanceData.Balance, staleTokenBalance.Balance)
-				// Note: This will happen because we currently don't scan
-				// before the beginning of the Dasmask upgrade, so the
-				// reckoning will be wrong about any balances from before
-				// then. It can also happen when contracts misbehave.
+				// Can happen when contracts misbehave, or if we haven't indexed all the runtime blocks from the very first one on.
 				m.logger.Warn("correcting reckoned balance of token to downloaded balance",
 					"token_addr", staleTokenBalance.TokenAddr,
 					"account_addr", staleTokenBalance.AccountAddr,
 					"download_round", staleTokenBalance.DownloadRound,
-					"reckoned_balance", staleTokenBalance.Balance,
+					"reckoned_balance", staleTokenBalance.Balance.String(),
 					"downloaded_balance", balanceData,
 					"correction", correction,
 				)
@@ -197,6 +230,8 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 					correction.String(),
 				)
 			}
+		} else {
+			m.logger.Debug("EVM token balance: nothing to correct", "token_addr", staleTokenBalance.TokenAddr, "account_addr", staleTokenBalance.AccountAddr, "balance", balanceData.Balance)
 		}
 	}
 	batch.Queue(queries.RuntimeEVMTokenBalanceAnalysisUpdate,

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -171,7 +171,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 			break
 		}
 		balance, err := m.source.GetNativeBalance(ctx, staleTokenBalance.DownloadRound, addr)
-		if err != nil || balance == nil {
+		if err != nil {
 			return fmt.Errorf("getting native runtime balance: %w", err)
 		}
 		if balance.Cmp(staleTokenBalance.Balance) != 0 {

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -109,7 +109,7 @@ func NewMain(
 type StaleTokenBalance struct {
 	TokenAddr                    string
 	AccountAddr                  string
-	Type                         *evm.EVMTokenType
+	Type                         evm.EVMTokenType
 	Balance                      *big.Int
 	TokenAddrContextIdentifier   string
 	TokenAddrContextVersion      int
@@ -159,7 +159,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 	if err != nil {
 		return fmt.Errorf("account address: %w", err)
 	}
-	switch *staleTokenBalance.Type {
+	switch staleTokenBalance.Type {
 	case evm.EVMTokenTypeUnsupported:
 		// Do nothing; we'll just mark this token as processed so we remove it from the queue.
 	case evm.EVMTokenTypeNative:
@@ -205,7 +205,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 			staleTokenBalance.DownloadRound,
 			tokenEthAddr,
 			accountEthAddr,
-			*staleTokenBalance.Type,
+			staleTokenBalance.Type,
 		)
 		if err != nil {
 			return fmt.Errorf("downloading token balance %s %s: %w", staleTokenBalance.TokenAddr, staleTokenBalance.AccountAddr, err)

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -167,6 +167,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 		addr := nodeapi.Address{}
 		if err := addr.UnmarshalText([]byte(staleTokenBalance.AccountAddr)); err != nil {
 			m.logger.Error("invalid account address bech32 '%s': %w", staleTokenBalance.AccountAddr, err)
+			// Do not return; mark this token as processed later on in the func, so we remove it from the DB queue.
 			break
 		}
 		balance, err := m.source.GetNativeBalance(ctx, staleTokenBalance.DownloadRound, addr)

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
-	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime/evm"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -103,7 +103,7 @@ func NewMain(
 type StaleTokenBalance struct {
 	TokenAddr                    string
 	AccountAddr                  string
-	Type                         *runtime.EVMTokenType
+	Type                         *evm.EVMTokenType
 	Balance                      *big.Int
 	TokenAddrContextIdentifier   string
 	TokenAddrContextVersion      int
@@ -157,7 +157,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 		return fmt.Errorf("account address: %w", err)
 	}
 	if staleTokenBalance.Type != nil {
-		balanceData, err := runtime.EVMDownloadTokenBalance(
+		balanceData, err := evm.EVMDownloadTokenBalance(
 			ctx,
 			m.logger,
 			m.source,

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -82,7 +82,7 @@ const (
 
 type Main struct {
 	runtime         common.Runtime
-	runtimeMetadata sdkConfig.ParaTime
+	runtimeMetadata *sdkConfig.ParaTime
 	source          storage.RuntimeSourceStorage
 	target          storage.TargetStorage
 	logger          *log.Logger
@@ -92,7 +92,7 @@ var _ analyzer.Analyzer = (*Main)(nil)
 
 func NewMain(
 	runtime common.Runtime,
-	runtimeMetadata sdkConfig.ParaTime,
+	runtimeMetadata *sdkConfig.ParaTime,
 	sourceClient *source.RuntimeClient,
 	target storage.TargetStorage,
 	logger *log.Logger,
@@ -124,7 +124,7 @@ func (m Main) getStaleTokenBalances(ctx context.Context, limit int) ([]*StaleTok
 	var staleTokenBalances []*StaleTokenBalance
 	rows, err := m.target.Query(ctx, queries.RuntimeEVMTokenBalanceAnalysisStale,
 		m.runtime,
-		nativeTokenSymbol(&m.runtimeMetadata),
+		nativeTokenSymbol(m.runtimeMetadata),
 		limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying stale token balances: %w", err)
@@ -186,7 +186,7 @@ func (m Main) processStaleTokenBalance(ctx context.Context, batch *storage.Query
 			batch.Queue(queries.RuntimeNativeBalanceUpdate,
 				m.runtime,
 				staleTokenBalance.AccountAddr,
-				nativeTokenSymbol(&m.runtimeMetadata),
+				nativeTokenSymbol(m.runtimeMetadata),
 				correction,
 			)
 		} else {

--- a/analyzer/evmtokenbalances/evm_token_balances.go
+++ b/analyzer/evmtokenbalances/evm_token_balances.go
@@ -8,6 +8,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	sdkConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
+
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime/evm"
@@ -78,25 +80,28 @@ const (
 )
 
 type Main struct {
-	runtime common.Runtime
-	source  storage.RuntimeSourceStorage
-	target  storage.TargetStorage
-	logger  *log.Logger
+	runtime         common.Runtime
+	runtimeMetadata sdkConfig.ParaTime
+	source          storage.RuntimeSourceStorage
+	target          storage.TargetStorage
+	logger          *log.Logger
 }
 
 var _ analyzer.Analyzer = (*Main)(nil)
 
 func NewMain(
 	runtime common.Runtime,
+	runtimeMetadata sdkConfig.ParaTime,
 	sourceClient *source.RuntimeClient,
 	target storage.TargetStorage,
 	logger *log.Logger,
 ) (*Main, error) {
 	return &Main{
-		runtime: runtime,
-		source:  sourceClient,
-		target:  target,
-		logger:  logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime),
+		runtime:         runtime,
+		runtimeMetadata: runtimeMetadata,
+		source:          sourceClient,
+		target:          target,
+		logger:          logger.With("analyzer", EvmTokenBalancesAnalyzerPrefix+runtime),
 	}, nil
 }
 
@@ -285,4 +290,8 @@ func (m Main) Start(ctx context.Context) {
 
 func (m Main) Name() string {
 	return EvmTokenBalancesAnalyzerPrefix + string(m.runtime)
+}
+
+func nativeTokenSymbol(sdkPT *sdkConfig.ParaTime) string {
+	return sdkPT.Denominations[sdkConfig.NativeDenominationKey].Symbol
 }

--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/oasisprotocol/oasis-indexer/analyzer"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/queries"
-	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime"
+	"github.com/oasisprotocol/oasis-indexer/analyzer/runtime/evm"
 	"github.com/oasisprotocol/oasis-indexer/analyzer/util"
 	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -60,7 +60,7 @@ func NewMain(
 type StaleToken struct {
 	Addr                  string
 	LastDownloadRound     *uint64
-	Type                  *runtime.EVMTokenType
+	Type                  *evm.EVMTokenType
 	AddrContextIdentifier string
 	AddrContextVersion    int
 	AddrData              []byte
@@ -102,7 +102,7 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 	// can have a nil type, because downloading a token always sets the type.
 	// We check both just in case, because we later dereference the .Type pointer.
 	if staleToken.LastDownloadRound == nil || staleToken.Type == nil {
-		tokenData, err := runtime.EVMDownloadNewToken(
+		tokenData, err := evm.EVMDownloadNewToken(
 			ctx,
 			m.logger,
 			m.source,
@@ -121,8 +121,8 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 			tokenData.Decimals,
 			tokenData.TotalSupply.String(),
 		)
-	} else if *staleToken.Type != runtime.EVMTokenTypeUnsupported {
-		mutable, err := runtime.EVMDownloadMutatedToken(
+	} else if *staleToken.Type != evm.EVMTokenTypeUnsupported {
+		mutable, err := evm.EVMDownloadMutatedToken(
 			ctx,
 			m.logger,
 			m.source,

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -511,7 +511,7 @@ var (
       SELECT * FROM stale_native_tokens
     ) foo LIMIT $3`,
 		evm.EVMTokenTypeNative,
-		evm.NativeEVMTokenAddress,
+		evm.NativeRuntimeTokenAddress,
 	)
 
 	RuntimeEVMTokenBalanceAnalysisUpdate = `

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -1,4 +1,4 @@
-package runtime
+package evm
 
 import (
 	"context"
@@ -21,9 +21,14 @@ import (
 type EVMTokenType int
 
 const (
-	EVMTokenTypeUnsupported EVMTokenType = 0 // A smart contract for which we're confident it's not a supported token kind.
+	EVMTokenTypeNative      EVMTokenType = -1 // A placeholder type to represent the runtime's native token. No contract should be assigned this type.
+	EVMTokenTypeUnsupported EVMTokenType = 0  // A smart contract for which we're confident it's not a supported token kind.
 	EVMTokenTypeERC20       EVMTokenType = 20
 )
+
+// A fake address that is used to represent the native runtime token in contexts
+// that are primarily intended for tracking EVM tokens (= contract-based tokens).
+const NativeEVMTokenAddress = "oasis1runt1menat1vet0ken0000000000000000000000"
 
 type EVMPossibleToken struct {
 	Mutated bool

--- a/analyzer/runtime/evm/client.go
+++ b/analyzer/runtime/evm/client.go
@@ -28,7 +28,7 @@ const (
 
 // A fake address that is used to represent the native runtime token in contexts
 // that are primarily intended for tracking EVM tokens (= contract-based tokens).
-const NativeEVMTokenAddress = "oasis1runt1menat1vet0ken0000000000000000000000"
+const NativeRuntimeTokenAddress = "oasis1runt1menat1vet0ken0000000000000000000000"
 
 type EVMPossibleToken struct {
 	Mutated bool

--- a/analyzer/runtime/evm/client_test.go
+++ b/analyzer/runtime/evm/client_test.go
@@ -1,4 +1,4 @@
-package runtime
+package evm
 
 import (
 	"context"

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -20,7 +20,7 @@ import (
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/consensusaccounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/core"
-	evm_sdk "github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
+	sdkEVM "github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
 	evm "github.com/oasisprotocol/oasis-indexer/analyzer/runtime/evm"
@@ -85,7 +85,7 @@ type ScopedSdkEvent struct {
 	Core              *core.Event
 	Accounts          *accounts.Event
 	ConsensusAccounts *consensusaccounts.Event
-	EVM               *evm_sdk.Event
+	EVM               *sdkEVM.Event
 }
 
 type AddressPreimageData struct {
@@ -368,7 +368,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					}
 					return nil
 				},
-				EVMCreate: func(body *evm_sdk.Create, ok *[]byte) error {
+				EVMCreate: func(body *sdkEVM.Create, ok *[]byte) error {
 					blockTransactionData.Body = body
 					amount = uncategorized.QuantityFromBytes(body.Value)
 					if !txr.Result.IsUnknown() && txr.Result.IsSuccess() && len(*ok) == 20 {
@@ -389,7 +389,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 					}
 					return nil
 				},
-				EVMCall: func(body *evm_sdk.Call, ok *[]byte) error {
+				EVMCall: func(body *sdkEVM.Call, ok *[]byte) error {
 					blockTransactionData.Body = body
 					amount = uncategorized.QuantityFromBytes(body.Value)
 					if to, err = registerRelatedEthAddress(blockData.AddressPreimages, blockTransactionData.RelatedAccountAddresses, body.Address); err != nil {
@@ -589,7 +589,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 			}
 			return nil
 		},
-		EVM: func(event *evm_sdk.Event) error {
+		EVM: func(event *sdkEVM.Event) error {
 			eventAddr, err1 := registerRelatedEthAddress(blockData.AddressPreimages, relatedAccountAddresses, event.Address)
 			if err1 != nil {
 				return fmt.Errorf("event address: %w", err1)

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -406,21 +406,23 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 						)
 					}
 
-					// Dead-reckon native token balances.
-					// Native token transfers do not generate events. Theoretically, any call can change the balance of any account,
-					// and we do not have a good way of tracking them; we just query them with the evm_token_balances analyzer.
-					// Heuristically, a call is most likely to change the balances of the sender and the receiver, so we create
-					// a (quite possibly incorrect) dead-reckoned change of 0 for those accounts, which will cause the evm_token_balances analyzer
-					// to re-query their real balance.
-					reckonedAmount := amount.ToBigInt() // Calls with an empty body represent a transfer of the native token.
-					if len(body.Data) != 0 || len(blockTransactionData.SignerData) > 1 {
-						// Calls with a non-empty body have no standard impact on native balance. Better to dead-reckon a 0 change (and keep stale balances)
-						// than to reckon a wrong change (and have a "random" incorrect balance until it is re-queried).
-						reckonedAmount = big.NewInt(0)
-					}
-					registerTokenIncrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, to, reckonedAmount)
-					for _, signer := range blockTransactionData.SignerData {
-						registerTokenDecrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, signer.Address, reckonedAmount)
+					if txr.Result.Ok != nil {
+						// Dead-reckon native token balances.
+						// Native token transfers do not generate events. Theoretically, any call can change the balance of any account,
+						// and we do not have a good way of tracking them; we just query them with the evm_token_balances analyzer.
+						// But heuristically, a call is most likely to change the balances of the sender and the receiver, so we create
+						// a (quite possibly incorrect) dead-reckoned change of 0 for those accounts, which will cause the evm_token_balances analyzer
+						// to re-query their real balance.
+						reckonedAmount := amount.ToBigInt() // Calls with an empty body represent a transfer of the native token.
+						if len(body.Data) != 0 || len(blockTransactionData.SignerData) > 1 {
+							// Calls with a non-empty body have no standard impact on native balance. Better to dead-reckon a 0 change (and keep stale balances)
+							// than to reckon a wrong change (and have a "random" incorrect balance until it is re-queried).
+							reckonedAmount = big.NewInt(0)
+						}
+						registerTokenIncrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, to, reckonedAmount)
+						for _, signer := range blockTransactionData.SignerData {
+							registerTokenDecrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, signer.Address, reckonedAmount)
+						}
 					}
 
 					// TODO: maybe parse known token methods (ERC-20 etc)

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -453,7 +453,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 			// Early versions of runtimes didn't emit a GasUsed event.
 			if (txr.Result.IsUnknown() || txr.Result.IsSuccess()) && tx != nil {
 				// Treat as if it used all the gas.
-				logger.Info("tx didn't emit a core.GasUsed event, assuming it used max allowed gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", tx.AuthInfo.Fee.Gas)
+				logger.Debug("tx didn't emit a core.GasUsed event, assuming it used max allowed gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", tx.AuthInfo.Fee.Gas)
 				txGasUsed = tx.AuthInfo.Fee.Gas
 			} else {
 				// Very rough heuristic: Treat as not using any gas.
@@ -464,7 +464,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 				//
 				// Beware that some failed txs have an enormous (e.g. MAX_INT64) gas
 				// limit.
-				logger.Info("tx didn't emit a core.GasUsed event and failed, assuming it used no gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", 0)
+				logger.Debug("tx didn't emit a core.GasUsed event and failed, assuming it used no gas", "tx_hash", txr.Tx.Hash(), "assumed_gas_used", 0)
 				txGasUsed = 0
 			}
 		}

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -418,9 +418,9 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 						// than to reckon a wrong change (and have a "random" incorrect balance until it is re-queried).
 						reckonedAmount = big.NewInt(0)
 					}
-					registerTokenIncrease(blockData.TokenBalanceChanges, evm.NativeEVMTokenAddress, to, reckonedAmount)
+					registerTokenIncrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, to, reckonedAmount)
 					for _, signer := range blockTransactionData.SignerData {
-						registerTokenDecrease(blockData.TokenBalanceChanges, evm.NativeEVMTokenAddress, signer.Address, reckonedAmount)
+						registerTokenDecrease(blockData.TokenBalanceChanges, evm.NativeRuntimeTokenAddress, signer.Address, reckonedAmount)
 					}
 
 					// TODO: maybe parse known token methods (ERC-20 etc)

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -258,7 +258,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 	for key, change := range data.TokenBalanceChanges {
 		// Update the DB balance only if it's actually changed.
 		if change != big.NewInt(0) {
-			if key.TokenAddress == evm.NativeEVMTokenAddress {
+			if key.TokenAddress == evm.NativeRuntimeTokenAddress {
 				batch.Queue(queries.RuntimeNativeBalanceUpdate, m.runtime, key.AccountAddress, m.nativeTokenSymbol(), change.String())
 			} else {
 				batch.Queue(queries.RuntimeEVMTokenBalanceUpdate, m.runtime, key.TokenAddress, key.AccountAddress, change.String())

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -294,21 +294,23 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 		})
 	}
 	if cfg.Analyzers.EmeraldEvmTokenBalances != nil {
+		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimeEmerald)
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
 			sourceClient, err1 := sources.Runtime(ctx, common.RuntimeEmerald)
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeEmerald, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewMain(common.RuntimeEmerald, *runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokenBalances != nil {
+		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimeEmerald)
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
 			sourceClient, err1 := sources.Runtime(ctx, common.RuntimeSapphire)
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeSapphire, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewMain(common.RuntimeSapphire, *runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -304,7 +304,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokenBalances != nil {
-		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimeEmerald)
+		runtimeMetadata := cfg.Source.SDKParaTime(common.RuntimeSapphire)
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
 			sourceClient, err1 := sources.Runtime(ctx, common.RuntimeSapphire)
 			if err1 != nil {

--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -300,7 +300,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeEmerald, *runtimeMetadata, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewMain(common.RuntimeEmerald, runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.SapphireEvmTokenBalances != nil {
@@ -310,7 +310,7 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 			if err1 != nil {
 				return nil, err1
 			}
-			return evmtokenbalances.NewMain(common.RuntimeSapphire, *runtimeMetadata, sourceClient, dbClient, logger)
+			return evmtokenbalances.NewMain(common.RuntimeSapphire, runtimeMetadata, sourceClient, dbClient, logger)
 		})
 	}
 	if cfg.Analyzers.MetadataRegistry != nil {

--- a/go.sum
+++ b/go.sum
@@ -880,6 +880,8 @@ github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd/go.mod h1:CT
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
+github.com/kisielk/godepgraph v0.0.0-20221115040737-2d0831789458 h1:QHffewzTTAhdV2FQ0X6hxp/tHpRYXE3STwzaD94N1qw=
+github.com/kisielk/godepgraph v0.0.0-20221115040737-2d0831789458/go.mod h1:Gb5YEgxqiSSVrXKWQxDcKoCM94NO5QAwOwTaVmIUAMI=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.9.5/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/storage/api.go
+++ b/storage/api.go
@@ -228,7 +228,7 @@ type GovernanceData struct {
 }
 
 // RuntimeSourceStorage defines an interface for retrieving raw block data
-// from the runtime layer.
+// from a specific runtime.
 type RuntimeSourceStorage interface {
 	// AllData returns all data tied to a specific round.
 	AllData(ctx context.Context, round uint64) (*RuntimeAllData, error)

--- a/storage/api.go
+++ b/storage/api.go
@@ -8,11 +8,12 @@ import (
 	"github.com/jackc/pgx/v5"
 
 	beacon "github.com/oasisprotocol/oasis-core/go/beacon/api"
-	"github.com/oasisprotocol/oasis-core/go/common"
+	coreCommon "github.com/oasisprotocol/oasis-core/go/common"
 	consensus "github.com/oasisprotocol/oasis-core/go/consensus/api"
 	genesisAPI "github.com/oasisprotocol/oasis-core/go/genesis/api"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
 
@@ -209,7 +210,7 @@ type SchedulerData struct {
 	Height int64
 
 	Validators []nodeapi.Validator
-	Committees map[common.Namespace][]nodeapi.Committee
+	Committees map[coreCommon.Namespace][]nodeapi.Committee
 }
 
 // GovernanceData represents governance data for proposals at a given height.
@@ -237,6 +238,9 @@ type RuntimeSourceStorage interface {
 
 	// EVMSimulateCall gets the result of the given EVM simulate call query.
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
+
+	// GetNativeBalance gets the native balance of the given account at the given round.
+	GetNativeBalance(ctx context.Context, round uint64, addr nodeapi.Address) (*common.BigInt, error)
 
 	// Close instructs the source storage to clean up resources. Calling other
 	// methods after this one results in undefined behavior.

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -175,35 +175,37 @@ CREATE TABLE chain.evm_tokens
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
+  PRIMARY KEY (runtime, token_address),
   token_type INTEGER NOT NULL, -- 0 = unsupported, X = ERC-X; full spec at https://github.com/oasisprotocol/oasis-indexer/blob/v0.0.16/analyzer/runtime/evm.go#L21
   token_name TEXT,
   symbol TEXT,
   decimals INTEGER,
-  total_supply uint_numeric,
-  PRIMARY KEY (runtime, token_address)
+  total_supply uint_numeric
 );
 
 CREATE TABLE chain.evm_token_analysis
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
+  PRIMARY KEY (runtime, token_address),
   -- Block analyzer bumps this when it sees the mutable fields of the token
   -- change (e.g. total supply) based on dead reckoning.
   last_mutate_round UINT63 NOT NULL,
   -- Token analyzer bumps this when it downloads info about the token.
-  last_download_round UINT63,
-  PRIMARY KEY (runtime, token_address)
+  last_download_round UINT63
 );
 CREATE INDEX ix_evm_token_analysis_stale ON chain.evm_token_analysis (runtime, token_address) WHERE last_download_round IS NULL OR last_mutate_round > last_download_round;
 
 CREATE TABLE chain.evm_token_balance_analysis
 (
   runtime runtime NOT NULL,
+  -- This table is used to track balance querying primarily for EVM tokens (ERC-20, ERC-271, etc), but also for
+  -- the runtime-native token; the latter is represented with a special addr: oasis1runt1menat1vet0ken0000000000000000000000
   token_address oasis_addr NOT NULL,
   account_address oasis_addr NOT NULL,
+  PRIMARY KEY (runtime, token_address, account_address),
   last_mutate_round UINT63 NOT NULL,
-  last_download_round UINT63,
-  PRIMARY KEY (runtime, token_address, account_address)
+  last_download_round UINT63
 );
 CREATE INDEX ix_evm_token_balance_analysis_stale ON chain.evm_token_balance_analysis (runtime, token_address, account_address) WHERE last_download_round IS NULL OR last_mutate_round > last_download_round;
 

--- a/storage/oasis/nodeapi/api.go
+++ b/storage/oasis/nodeapi/api.go
@@ -20,6 +20,7 @@ import (
 	staking "github.com/oasisprotocol/oasis-core/go/staking/api"
 
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
+	common "github.com/oasisprotocol/oasis-indexer/common"
 	sdkClient "github.com/oasisprotocol/oasis-sdk/client-sdk/go/client"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
@@ -74,6 +75,8 @@ func (r *TxResult) IsSuccess() bool {
 }
 
 type TxError consensusResults.Error
+
+type Address = staking.Address
 
 // A lightweight version of "consensus/api/transactions/results".Event.
 //
@@ -203,6 +206,7 @@ type RuntimeApiLite interface {
 	EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error)
 	GetBlockHeader(ctx context.Context, round uint64) (*RuntimeBlockHeader, error)
 	GetTransactionsWithResults(ctx context.Context, round uint64) ([]RuntimeTransactionWithResults, error)
+	GetNativeBalance(ctx context.Context, round uint64, addr Address) (*common.BigInt, error)
 	Close() error
 }
 

--- a/storage/oasis/nodeapi/file/runtime.go
+++ b/storage/oasis/nodeapi/file/runtime.go
@@ -73,6 +73,14 @@ func (r *FileRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint64) ([]
 	)
 }
 
+func (r *FileRuntimeApiLite) GetNativeBalance(ctx context.Context, round uint64, addr nodeapi.Address) (*common.BigInt, error) {
+	return GetFromCacheOrCall(
+		r.db, round == roothash.RoundLatest,
+		generateCacheKey("GetNativeBalance", r.runtime, round, addr),
+		func() (*common.BigInt, error) { return r.runtimeApi.GetNativeBalance(ctx, round, addr) },
+	)
+}
+
 func (r *FileRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
 	return GetSliceFromCacheOrCall(
 		r.db, round == roothash.RoundLatest,

--- a/storage/oasis/nodeapi/history/runtime.go
+++ b/storage/oasis/nodeapi/history/runtime.go
@@ -93,6 +93,14 @@ func (rc *HistoryRuntimeApiLite) GetBlockHeader(ctx context.Context, round uint6
 	return api.GetBlockHeader(ctx, round)
 }
 
+func (rc *HistoryRuntimeApiLite) GetNativeBalance(ctx context.Context, round uint64, addr nodeapi.Address) (*common.BigInt, error) {
+	api, err := rc.APIForRound(round)
+	if err != nil {
+		return nil, fmt.Errorf("getting api for runtime %s round %d: %w", rc.Runtime, round, err)
+	}
+	return api.GetNativeBalance(ctx, round, addr)
+}
+
 func (rc *HistoryRuntimeApiLite) GetTransactionsWithResults(ctx context.Context, round uint64) ([]nodeapi.RuntimeTransactionWithResults, error) {
 	api, err := rc.APIForRound(round)
 	if err != nil {

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -15,8 +15,6 @@ import (
 	common "github.com/oasisprotocol/oasis-indexer/common"
 	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
-	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
 	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
@@ -137,11 +135,11 @@ func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint6
 }
 
 func (rc *UniversalRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
-	return evm.NewV1(rc.sdkClient).SimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
+	return rc.sdkClient.Evm.SimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
 }
 
 func (rc *UniversalRuntimeApiLite) GetNativeBalance(ctx context.Context, round uint64, addr Address) (*common.BigInt, error) {
-	balances, err := accounts.NewV1(rc.sdkClient).Balances(ctx, round, sdkTypes.Address(addr))
+	balances, err := rc.sdkClient.Accounts.Balances(ctx, round, sdkTypes.Address(addr))
 	if err != nil {
 		return nil, err
 	}

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -12,9 +12,13 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/crypto/hash"
 	roothash "github.com/oasisprotocol/oasis-core/go/roothash/api/block"
 	coreRuntimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
+	common "github.com/oasisprotocol/oasis-indexer/common"
 	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
+	"github.com/oasisprotocol/oasis-indexer/log"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
+	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
+	sdkTypes "github.com/oasisprotocol/oasis-sdk/client-sdk/go/types"
 )
 
 // Implementation of `RuntimeApiLite` that supports all versions of the node ABI
@@ -135,4 +139,17 @@ func (rc *UniversalRuntimeApiLite) GetEventsRaw(ctx context.Context, round uint6
 
 func (rc *UniversalRuntimeApiLite) EVMSimulateCall(ctx context.Context, round uint64, gasPrice []byte, gasLimit uint64, caller []byte, address []byte, value []byte, data []byte) ([]byte, error) {
 	return evm.NewV1(rc.sdkClient).SimulateCall(ctx, round, gasPrice, gasLimit, caller, address, value, data)
+}
+
+func (rc *UniversalRuntimeApiLite) GetNativeBalance(ctx context.Context, round uint64, addr Address) (*common.BigInt, error) {
+	balances, err := accounts.NewV1(rc.sdkClient).Balances(ctx, round, sdkTypes.Address(addr))
+	if err != nil {
+		return nil, err
+	}
+	nativeBalance, ok := balances.Balances[sdkTypes.NativeDenomination]
+	if !ok {
+		log.NewDefaultLogger("nodeapi").Warn("native runtime balance not found", "address", addr)
+		return common.Ptr(common.NewBigInt(0)), nil
+	}
+	return common.Ptr(common.BigIntFromQuantity(nativeBalance)), nil
 }

--- a/storage/oasis/nodeapi/universal_runtime.go
+++ b/storage/oasis/nodeapi/universal_runtime.go
@@ -14,7 +14,6 @@ import (
 	coreRuntimeClient "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
 	common "github.com/oasisprotocol/oasis-indexer/common"
 	cobaltRoothash "github.com/oasisprotocol/oasis-indexer/coreapi/v21.1.1/roothash/api/block"
-	"github.com/oasisprotocol/oasis-indexer/log"
 	connection "github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/accounts"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/modules/evm"
@@ -148,7 +147,8 @@ func (rc *UniversalRuntimeApiLite) GetNativeBalance(ctx context.Context, round u
 	}
 	nativeBalance, ok := balances.Balances[sdkTypes.NativeDenomination]
 	if !ok {
-		log.NewDefaultLogger("nodeapi").Warn("native runtime balance not found", "address", addr)
+		// This is normal for accounts that have had no balance activity;
+		// the node returns an empty map.
 		return common.Ptr(common.NewBigInt(0)), nil
 	}
 	return common.Ptr(common.BigIntFromQuantity(nativeBalance)), nil

--- a/storage/oasis/runtime.go
+++ b/storage/oasis/runtime.go
@@ -5,6 +5,7 @@ import (
 
 	clientAPI "github.com/oasisprotocol/oasis-core/go/runtime/client/api"
 
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/storage"
 	"github.com/oasisprotocol/oasis-indexer/storage/oasis/nodeapi"
 )
@@ -53,6 +54,10 @@ func (rc *RuntimeClient) LatestBlockHeight(ctx context.Context) (uint64, error) 
 		return 0, err
 	}
 	return header.Round, nil
+}
+
+func (rc *RuntimeClient) GetNativeBalance(ctx context.Context, round uint64, addr nodeapi.Address) (*common.BigInt, error) {
+	return rc.nodeApi.GetNativeBalance(ctx, round, addr)
 }
 
 // Implements RuntimeSourceStorage interface.

--- a/tests/e2e_regression/e2e_config.yml
+++ b/tests/e2e_regression/e2e_config.yml
@@ -6,8 +6,7 @@ analysis:
     chain_name: mainnet
     nodes:
       damask:
-        default:
-          rpc: unix:/tmp/node.sock
+        default: { rpc: unix:/tmp/node.sock }
     fast_startup: true
   analyzers:
     # metadata_registry:
@@ -16,7 +15,7 @@ analysis:
     #   tx_volume_interval: 5m
     consensus:
       from: 8_048_956  # Damask genesis
-      to: 8_049_056 # 100 blocks; fast enough for early testing
+      to: 8_049_056    # 100 blocks; fast enough for early testing
     emerald:
       from: 1_003_298  # round at Damask genesis
       to: 1_003_398


### PR DESCRIPTION
Closes https://app.clickup.com/t/861mn3n0e

I don't like how a lot of logic for native tokens is very similar to EVM tokens, so it feels like we're duplicating code, but it's just different enough that when I try to reuse snippets (or here, the whole analyzer), it ends up having a lot of parallel codepaths internally, one for EVM tokens and one for natives. Oh well. This PR is one possible balance to strike.

**Testing: **
Indexed the first 10k blocks of emerald, then ran `evm_tokens` and `evm_token_balances` analyzers. Did this both pre- and post- PR and diffed the DBs. No changes except for the new entries in `evm_token_balances_analysis` table for the native tokens.