### PR TITLE
evm: only store log signatures for parsed events

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -342,8 +342,8 @@ var (
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)`
 
 	RuntimeEventInsert = `
-    INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, evm_log_name, evm_log_params, related_accounts)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+    INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, related_accounts, evm_log_name, evm_log_params, evm_log_signature)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
 
 	RuntimeMintInsert = `
     INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -76,6 +76,7 @@ type EventData struct {
 	Body             EventBody
 	WithScope        ScopedSdkEvent
 	EvmLogName       string
+	EvmLogSignature  ethCommon.Hash
 	EvmLogParams     []*apiTypes.EvmEventParam
 	RelatedAddresses map[apiTypes.Address]bool
 }
@@ -645,6 +646,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 						blockData.PossibleTokens[eventAddr].Mutated = true
 					}
 					eventData.EvmLogName = apiTypes.Erc20Transfer
+					eventData.EvmLogSignature = ethCommon.BytesToHash(event.Topics[0])
 					eventData.EvmLogParams = []*apiTypes.EvmEventParam{
 						{
 							Name:    "from",
@@ -687,6 +689,7 @@ func extractEvents(blockData *BlockData, relatedAccountAddresses map[apiTypes.Ad
 					amount := &big.Int{}
 					amount.SetBytes(amountU256)
 					eventData.EvmLogName = apiTypes.Erc20Approval
+					eventData.EvmLogSignature = ethCommon.BytesToHash(event.Topics[0])
 					eventData.EvmLogParams = []*apiTypes.EvmEventParam{
 						{
 							Name:    "owner",

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -234,9 +234,10 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			eventData.TxHash,
 			eventData.Type,
 			eventData.Body,
+			eventRelatedAddresses,
 			eventData.EvmLogName,
 			eventData.EvmLogParams,
-			eventRelatedAddresses,
+			eventData.EvmLogSignature,
 		)
 	}
 

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -957,11 +957,9 @@ paths:
           schema:
             type: string
           description: |
-            A filter on the first of `topics` in the EVM log structure, which typically contains the
-            event _signature_, i.e. the keccak256 hash of the event name and parameter types.
-            Note: The filter will match on `topics[0]` even in the rare case of anonymous events
-            when that field does not actually contain the signature.
-          example: '0x27f12abfe35860a9a927b465bb3d4a9c23c8428174b83f278fe45ed7b4da2662'
+            A filter on the evm log signatures.
+            Note: The filter will only match on parsed (verified) EVM events.
+          example: '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'
       responses:
         '200':
           description: |

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1242,6 +1242,12 @@ func (c *StorageClient) RuntimeTransactions(ctx context.Context, p apiTypes.GetR
 
 // RuntimeEvents returns a list of runtime events.
 func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntimeEventsParams) (*RuntimeEventList, error) {
+	var evmLogSignature *ethCommon.Hash
+	if p.EvmLogSignature != nil {
+		h := ethCommon.HexToHash(*p.EvmLogSignature)
+		evmLogSignature = &h
+	}
+
 	res, err := c.withTotalCount(
 		ctx,
 		queries.RuntimeEvents,
@@ -1250,7 +1256,7 @@ func (c *StorageClient) RuntimeEvents(ctx context.Context, p apiTypes.GetRuntime
 		p.TxIndex,
 		p.TxHash,
 		p.Type,
-		p.EvmLogSignature,
+		evmLogSignature,
 		p.Rel,
 		p.Limit,
 		p.Offset,

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -397,7 +397,7 @@ const (
 					($3::integer IS NULL OR evs.tx_index = $3::integer) AND
 					($4::text IS NULL OR evs.tx_hash = $4::text OR txs.tx_eth_hash = $4::text) AND
 					($5::text IS NULL OR evs.type = $5::text) AND
-					($6::text IS NULL OR evs.evm_log_signature = $6::text) AND
+					($6::bytea IS NULL OR evs.evm_log_signature = $6::bytea) AND
 					($7::text IS NULL OR evs.related_accounts @> ARRAY[$7::text])
 			ORDER BY evs.round DESC, evs.tx_index, evs.type, evs.body::text
 			LIMIT $8::bigint

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -113,15 +113,16 @@ CREATE TABLE chain.runtime_events
   -- TODO: add link to openapi spec section with runtime event types.
   type TEXT NOT NULL,
   -- The raw event, as returned by the oasis-sdk runtime client.
-  -- `evm.log` events are further parsed into known event types,
-  -- e.g. (ERC20) Transfer, to populate the `evm_log_name` and
-  -- `evm_log_params` fields below.
   body JSONB NOT NULL,
+  related_accounts TEXT[],
+
+  -- The events of type `evm.log` are further parsed into known event types, e.g. (ERC20) Transfer,
+  -- to populate the `evm_log_name`, `evm_log_params`, and `evm_log_signature` fields.
+  -- These fields are populated only when the ABI for the event is known. Typically, this is the
+  -- case for events emitted by verified contracts.
   evm_log_name TEXT,
-  -- The event signature, if it exists, will be the first topic.
-  evm_log_signature TEXT GENERATED ALWAYS AS (body->'topics'->>0) STORED,
   evm_log_params JSONB,
-  related_accounts TEXT[]
+  evm_log_signature BYTEA CHECK (octet_length(evm_log_signature) = 32)
 );
 CREATE INDEX ix_runtime_events_round ON chain.runtime_events(runtime, round);  -- for sorting by round, when there are no filters applied
 CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events(tx_hash);


### PR DESCRIPTION
Log signatures are now stored only for parsed events. This is because only in case of parsed events, we can be sure that the thing in `topic[0]` is actually the event signature (otherwise it could be random data inserted by an anonymous event).

This makes the field a bit less useful until more EVM events will be parsed (once contract verification is supported). If the use-case for filtering arbitrary EVM events by topic is needed (regardless if verified or not), support for filtering by `topic[0]` value directly could be added to API.

Side-note:
In old code, the `evm_log_signature` was actually stored base64 encoded in the DB, which was probably unexpected. The API filtering by `evm_log_signature` did not work as described in the API docs (where hex string is used in the example). 

Testing:
```
select distinct(evm_log_signature) from chain.runtime_events where evm_log_signature != '';
                         evm_log_signature
--------------------------------------------------------------------
 0x8c5be1e5ebec7d5bd14f71427d1e84f3dd0314c0f7b2291e5b200ac8c7c3b925  # ERC-20 Approval
 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef # ERC-20 Transfer
(2 rows)

```

API test:
```
curl "localhost:8008/v1/emerald/events?evm_log_signature=0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef&limit=1"
{"events":[{"body":{"address":"I4OW1NAbpWIeZolKAij2s2UfFWY=","data":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=","topics":["3fJSrRviyJtpwrBo/DeNqpUrp/FjxKEWKPVaTfUjs+8=","AAAAAAAAAAAAAAAAjZzJ7hGq+GWRPe7JOe6y3Hg4q3s=","AAAAAAAAAAAAAAAARUyUgag32PmIFkKUTpoi1aP3kl0="]},"eth_tx_hash":"5cb3deb32fd4e3ca66c7af4dbb0b986e9b516b8ed06e4bbced34cc1b7911ca5e","evm_log_name":"Transfer","evm_log_params":[{"evm_type":"address","name":"from","value":"0x8d9cc9ee11aaf865913deec939eeb2dc7838ab7b"},{"evm_type":"address","name":"to","value":"0x454c9481a837d8f9881642944e9a22d5a3f7925d"},{"evm_type":"uint256","name":"value","value":"0"}],"round":1019379,"tx_hash":"dea14048b683bca15863465aafbecdfdd09c4aed8910635643ad9c7f4278311e","tx_index":0,"type":"evm.log"}],"is_total_count_clipped":true,"total_count":1000}
```