### PR TITLE
stats: Update materialized views concurrently

### DIFF
--- a/analyzer/aggregate_stats.go
+++ b/analyzer/aggregate_stats.go
@@ -98,7 +98,7 @@ func (a *AggregateStatsAnalyzer) Start(ctx context.Context) {
 // txVolumeWorker periodically updates the tx volume stats.
 func (a *AggregateStatsAnalyzer) txVolumeWorker(ctx context.Context) {
 	for {
-		a.logger.Info("updating tx volume stats")
+		a.logger.Info("updating tx volume stats (5-min and daily)")
 
 		// Note: The order matters here! Daily tx volume is a materialized view
 		// that's instantiated from 5 minute tx volume.

--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -477,11 +477,11 @@ const (
       account_address = $3`
 
 	RefreshDailyTxVolume = `
-    REFRESH MATERIALIZED VIEW stats.daily_tx_volume
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stats.daily_tx_volume
   `
 
 	RefreshMin5TxVolume = `
-    REFRESH MATERIALIZED VIEW stats.min5_tx_volume
+    REFRESH MATERIALIZED VIEW CONCURRENTLY stats.min5_tx_volume
   `
 
 	// LatestDailyAccountStats is the query to get the timestamp of the latest daily active accounts stat.

--- a/storage/migrations/03_agg_stats.up.sql
+++ b/storage/migrations/03_agg_stats.up.sql
@@ -34,6 +34,7 @@ CREATE MATERIALIZED VIEW stats.min5_tx_volume AS
   FROM chain.runtime_blocks AS b
   JOIN chain.runtime_transactions AS t ON (b.round = t.round AND b.runtime = t.runtime)
   GROUP BY 1, 2;
+CREATE UNIQUE INDEX ix_stats_min5_tx_volume_window_start ON stats.min5_tx_volume (layer, window_start); -- A unique index is required for CONCURRENTLY refreshing the view.
 
 -- daily_tx_volume stores the number of transactions per day
 -- at the consensus layer.
@@ -44,6 +45,7 @@ CREATE MATERIALIZED VIEW stats.daily_tx_volume AS
     SUM(sub.tx_volume) AS tx_volume
   FROM stats.min5_tx_volume AS sub
   GROUP BY 1, 2;
+CREATE UNIQUE INDEX ix_stats_daily_tx_volume_window_start ON stats.daily_tx_volume (layer, window_start); -- A unique index is required for CONCURRENTLY refreshing the view.
 
 -- daily_active_accounts stores the sliding widnow for the number of unique accounts per day
 -- that were involved in transactions.


### PR DESCRIPTION
Refreshing the materialized view takes ~5 min. Before this PR, the view was locked (even for read queries) during the refresh, making the related `/stats/tx_volume` endpoint unavailable for ~5min every ~1h, 1h being the refresh interval.

The changes (CREATE INDEX) have been applied to mainnet prod + staging indexers already.

Testing: Locally.