### PR TITLE
tests: assert.Nil -> require.Nil in some places

### DIFF
--- a/storage/oasis/client_test.go
+++ b/storage/oasis/client_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-indexer/config"
@@ -61,7 +60,7 @@ func TestGenesisDocument(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.GenesisDocument(ctx)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestBlockData(t *testing.T) {

--- a/tests/statecheck/consensus_test.go
+++ b/tests/statecheck/consensus_test.go
@@ -142,11 +142,11 @@ func TestGenesisFull(t *testing.T) {
 	oasisClient := conn.Consensus()
 
 	postgresClient, err := newTargetClient(t)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	t.Log("Creating snapshot...")
 	height, err := snapshotBackends(postgresClient, ConsensusName, ConsensusTables)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	t.Logf("Fetching genesis at height %d...", height)
 	genesis := &genesisAPI.Document{}

--- a/tests/statecheck/runtime_test.go
+++ b/tests/statecheck/runtime_test.go
@@ -43,15 +43,15 @@ func testRuntimeAccounts(t *testing.T, runtime common.Runtime) {
 	oasisRuntimeClient := conn.Runtime(sdkPT)
 
 	postgresClient, err := newTargetClient(t)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	t.Log("Creating snapshot for runtime tables...")
 	height, err := snapshotBackends(postgresClient, string(runtime), RuntimeTables)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	t.Logf("Fetching accounts information at height %d...", height)
 	addresses, err := oasisRuntimeClient.Accounts.Addresses(ctx, uint64(height), sdkTypes.NativeDenomination)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	expectedAccts := make(map[sdkTypes.Address]bool)
 	for _, addr := range addresses {
 		expectedAccts[addr] = true

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	oasisConfig "github.com/oasisprotocol/oasis-sdk/client-sdk/go/config"
 	"github.com/oasisprotocol/oasis-sdk/client-sdk/go/connection"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
@@ -25,7 +25,7 @@ const (
 func newTargetClient(t *testing.T) (*postgres.Client, error) {
 	connString := os.Getenv("HEALTHCHECK_TEST_CONN_STRING")
 	logger, err := log.NewLogger("db-test", io.Discard, log.FmtJSON, log.LevelInfo)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	return postgres.NewClient(connString, logger)
 }


### PR DESCRIPTION
Use `require` instead of `assert` in places where continuing with tests does not make sense due to the failure (e.g. connecting to the db, querying the node etc...).  `require` is similar to `assert` but it also stops the execution of the test case, while `assert` continues.


This makes `statecheck` output a bit more readable (and meaningful) in case it fails early. 

Concrete example: if `oasisRuntimeClient.Accounts.Addresses`  failed, the `statecheck` reported a discrepancy for every account found in the postgresql db, which masked the actual error - loading the state in the first place.