### PR TITLE
cmd: let 'from' height choose genesis doc

### DIFF
--- a/cmd/analyzer/analyzer.go
+++ b/cmd/analyzer/analyzer.go
@@ -237,7 +237,12 @@ func NewService(cfg *config.AnalysisConfig) (*Service, error) {
 	analyzers := map[string]A{}
 	if cfg.Analyzers.Consensus != nil {
 		analyzers, err = addAnalyzer(analyzers, err, func() (A, error) {
-			genesisChainContext := cfg.Source.History().CurrentRecord().ChainContext
+			startHeight := int64(cfg.Analyzers.Consensus.From)
+			startRecord, err1 := cfg.Source.History().RecordForHeight(startHeight)
+			if err1 != nil {
+				return nil, fmt.Errorf("getting history record for consensus starting block %d: %w", startHeight, err1)
+			}
+			genesisChainContext := startRecord.ChainContext
 			sourceClient, err1 := sources.Consensus(ctx)
 			if err1 != nil {
 				return nil, err1


### PR DESCRIPTION
fixes #432 

second part, use the consensus 'from' block, i.e. the height at which to start indexing, decide which genesis document to use

we'll probably have to adjust this logic later when more of the fast sync functionality is ready. 