### PR TITLE
runtime: error message does not need to be a valid utf-8

### DIFF
--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strings"
@@ -193,6 +194,14 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			error_module = transactionData.Error.Module
 			error_code = transactionData.Error.Code
 			error_message = transactionData.Error.Message
+		}
+		if error_message != nil {
+			// Apparently the message does need to be valid UTF-8.
+			// In the rare case it's not, hex encode it.
+			// https://github.com/oasisprotocol/oasis-indexer/issues/439
+			if !storage.IsValidText(*error_message) {
+				*error_message = hex.EncodeToString([]byte(*error_message))
+			}
 		}
 		batch.Queue(
 			queries.RuntimeTransactionInsert,

--- a/storage/api.go
+++ b/storage/api.go
@@ -3,7 +3,9 @@ package storage
 
 import (
 	"context"
+	"strings"
 	"sync"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5"
 
@@ -302,4 +304,10 @@ type TargetStorage interface {
 	// WARNING: This might enable triggers not explicitly disabled by DisableTriggersAndFKConstraints.
 	// WARNING: This does not enforce/check contraints on rows that were inserted while triggers were disabled.
 	EnableTriggersAndFKConstraints(ctx context.Context) error
+}
+
+// IsValidText returns true iff the given string is valid UTF-8 and does not contain any NUL bytes.
+// Postgresql TEXT field requires valid UTF8 strings and does not allow NUL bytes.
+func IsValidText(text string) bool {
+	return utf8.ValidString(text) && !strings.ContainsRune(text, '\x00')
 }

--- a/storage/api_test.go
+++ b/storage/api_test.go
@@ -1,0 +1,67 @@
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-indexer/storage"
+	"github.com/oasisprotocol/oasis-indexer/storage/postgres/testutil"
+	"github.com/oasisprotocol/oasis-indexer/tests"
+)
+
+func TestInvalidText(t *testing.T) {
+	tests.SkipIfShort(t)
+	client := testutil.NewTestClient(t)
+	defer client.Close()
+
+	ctx := context.Background()
+
+	// Ensure database is empty before running the test.
+	require.NoError(t, client.Wipe(ctx), "failed to wipe database")
+
+	// Test that invalid text is rejected.
+	row, err := client.Query(ctx, `
+		CREATE TABLE test (
+			test TEXT
+		);
+	`)
+	require.NoError(t, err, "failed to create test table")
+	row.Close()
+
+	// Test strings.
+	for _, tc := range []struct {
+		text  string
+		valid bool
+	}{
+		{"", true},
+		{"a", true},
+		{"a\000\000b", false},
+		{"a\000", false},
+		{"\xc5z", false},
+	} {
+		switch tc.valid {
+		case true:
+			row, err = client.Query(ctx, `
+				INSERT INTO test (test) VALUES ($1);
+			`, tc.text)
+			require.NoError(t, err, "failed to execute query", "text", tc.text)
+			row.Close()
+
+			// Ensure that the text is inserted and that the IsValidText() function allows the string.
+			require.NoError(t, row.Err(), "failed to insert valid text", "text", tc.text)
+			require.True(t, storage.IsValidText(tc.text), "IsValidText() returned false for valid text", "text", tc.text)
+		case false:
+			row, err = client.Query(ctx, `
+				INSERT INTO test (test) VALUES ($1);
+			`, tc.text)
+			require.NoError(t, err, "failed to execute query", "text", tc.text)
+			row.Close()
+
+			// Ensure that the text was not inserted and that the IsValidText() function rejects the string.
+			require.Error(t, row.Err(), "didn't fail to insert invalid text", "text", tc.text)
+			require.False(t, storage.IsValidText(tc.text), "IsValidText() returned true for invalid text", "text", tc.text)
+		}
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/oasis-indexer/issues/439

An alternative would be to change the error_message field to `bytea`, but it seems that non-utf8 encodable error messages are the exception rather than the norm, so maybe it makes more sense handling it this way?

Could also prefix it with "hex-encoded" or something.