### PR TITLE
evmtokens: check for nil EVMTokenMutableData

### DIFF
--- a/analyzer/evmtokens/evm_tokens.go
+++ b/analyzer/evmtokens/evm_tokens.go
@@ -114,7 +114,7 @@ func (m Main) processStaleToken(ctx context.Context, batch *storage.QueryBatch, 
 		}
 		// If the returned token type is unsupported, it will have zero value token data.
 		var totalSupply *string
-		if tokenData.TotalSupply != nil {
+		if tokenData.EVMTokenMutableData != nil && tokenData.TotalSupply != nil {
 			totalSupply = common.Ptr(tokenData.TotalSupply.String())
 		}
 		batch.Queue(queries.RuntimeEVMTokenInsert,


### PR DESCRIPTION
the embedded *EVMTokenMutableData struct is nil, so it's illegal even to check if TotalSupply is nil