### PR TITLE
analyzer: runtime_events evm-tx hash query optimisation

### DIFF
--- a/analyzer/queries/queries.go
+++ b/analyzer/queries/queries.go
@@ -342,8 +342,8 @@ var (
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)`
 
 	RuntimeEventInsert = `
-    INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, type, body, related_accounts, evm_log_name, evm_log_params, evm_log_signature)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+    INSERT INTO chain.runtime_events (runtime, round, tx_index, tx_hash, tx_eth_hash, type, body, related_accounts, evm_log_name, evm_log_params, evm_log_signature)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`
 
 	RuntimeMintInsert = `
     INSERT INTO chain.runtime_transfers (runtime, round, sender, receiver, symbol, amount)
@@ -486,7 +486,7 @@ var (
           analysis.last_mutate_round > analysis.last_download_round
         )
     ),
-    
+
     stale_native_tokens AS (
       SELECT
         analysis.token_address,

--- a/analyzer/runtime/extract.go
+++ b/analyzer/runtime/extract.go
@@ -73,6 +73,7 @@ type EventBody interface{}
 type EventData struct {
 	TxIndex          *int    // nil for non-tx events
 	TxHash           *string // nil for non-tx events
+	TxEthHash        *string // nil for non-evm-tx events
 	Type             apiTypes.RuntimeEventType
 	Body             EventBody
 	WithScope        ScopedSdkEvent
@@ -470,6 +471,7 @@ func ExtractRound(blockHeader nodeapi.RuntimeBlockHeader, txrs []nodeapi.Runtime
 			txIndex := txIndex // const local copy of loop variable
 			eventData.TxIndex = &txIndex
 			eventData.TxHash = &blockTransactionData.Hash
+			eventData.TxEthHash = blockTransactionData.EthHash
 		}
 		if !foundGasUsedEvent {
 			// Early versions of runtimes didn't emit a GasUsed event.

--- a/analyzer/runtime/runtime.go
+++ b/analyzer/runtime/runtime.go
@@ -251,6 +251,7 @@ func (m *processor) queueDbUpdates(batch *storage.QueryBatch, data *BlockData) {
 			data.Header.Round,
 			eventData.TxIndex,
 			eventData.TxHash,
+			eventData.TxEthHash,
 			eventData.Type,
 			eventData.Body,
 			eventRelatedAddresses,

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -389,13 +389,12 @@ const (
 		`
 
 	RuntimeEvents = `
-		SELECT evs.round, evs.tx_index, evs.tx_hash, txs.tx_eth_hash, evs.type, evs.body, evs.evm_log_name, evs.evm_log_params
+		SELECT evs.round, evs.tx_index, evs.tx_hash, evs.tx_eth_hash, evs.type, evs.body, evs.evm_log_name, evs.evm_log_params
 			FROM chain.runtime_events as evs
-			LEFT JOIN chain.runtime_transactions as txs USING (runtime, tx_index, round)
 			WHERE (evs.runtime = $1) AND
 					($2::bigint IS NULL OR evs.round = $2::bigint) AND
 					($3::integer IS NULL OR evs.tx_index = $3::integer) AND
-					($4::text IS NULL OR evs.tx_hash = $4::text OR txs.tx_eth_hash = $4::text) AND
+					($4::text IS NULL OR evs.tx_hash = $4::text OR evs.tx_eth_hash = $4::text) AND
 					($5::text IS NULL OR evs.type = $5::text) AND
 					($6::bytea IS NULL OR evs.evm_log_signature = $6::bytea) AND
 					($7::text IS NULL OR evs.related_accounts @> ARRAY[$7::text])

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -110,6 +110,7 @@ CREATE TABLE chain.runtime_events
   FOREIGN KEY (runtime, round, tx_index) REFERENCES chain.runtime_transactions(runtime, round, tx_index) DEFERRABLE INITIALLY DEFERRED,
 
   tx_hash HEX64,
+  tx_eth_hash HEX64,
   -- TODO: add link to openapi spec section with runtime event types.
   type TEXT NOT NULL,
   -- The raw event, as returned by the oasis-sdk runtime client.
@@ -126,6 +127,7 @@ CREATE TABLE chain.runtime_events
 );
 CREATE INDEX ix_runtime_events_round ON chain.runtime_events(runtime, round);  -- for sorting by round, when there are no filters applied
 CREATE INDEX ix_runtime_events_tx_hash ON chain.runtime_events(tx_hash);
+CREATE INDEX ix_runtime_events_tx_eth_hash ON chain.runtime_events(tx_eth_hash);
 CREATE INDEX ix_runtime_events_related_accounts ON chain.runtime_events USING gin(related_accounts);
 CREATE INDEX ix_runtime_events_evm_log_signature ON chain.runtime_events(evm_log_signature);
 CREATE INDEX ix_runtime_events_evm_log_params ON chain.runtime_events USING gin(evm_log_params);


### PR DESCRIPTION
Filtering runtime events by `eth_tx_hash` (included in: https://github.com/oasisprotocol/oasis-indexer/pull/419)

Caused a regression in get events API call performance: e.g.: https://index.oasislabs.com/v1/emerald/events?tx_hash=14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d59622b7dc8&limit=100 gets stuck.

This is the query plan for the query made by the above requests:
```
 Aggregate  (cost=9283853.87..9283853.88 rows=1 width=8)
   ->  Limit  (cost=9283828.81..9283851.44 rows=194 width=212)
         ->  Gather Merge  (cost=9283828.81..9283851.44 rows=194 width=212)
               Workers Planned: 2
               ->  Sort  (cost=9282828.79..9282829.03 rows=97 width=212)
                     Sort Key: evs.round DESC, evs.tx_index, evs.type, ((evs.body)::text)
                     ->  Parallel Hash Left Join  (cost=6858208.35..9282825.59 rows=97 width=212)
                           Hash Cond: ((evs.runtime = txs.runtime) AND ((evs.tx_index)::integer = (txs.tx_index)::integer) AND ((evs.round)::bigint = (txs.round)::bigint))
                           Filter: (((evs.tx_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d59622b7dc8'::text) OR ((txs.tx_eth_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1
bbc6d59622b7dc8'::text))
                           ->  Parallel Seq Scan on runtime_events evs  (cost=0.00..1538650.90 rows=6316675 width=353)
                                 Filter: (runtime = 'emerald'::indexer.runtime)
                           ->  Parallel Hash  (cost=6301815.86..6301815.86 rows=17849171 width=81)
                                 ->  Parallel Seq Scan on runtime_transactions txs  (cost=0.00..6301815.86 rows=17849171 width=81)
                                       Filter: (runtime = 'emerald'::indexer.runtime)
```

With the added `OR txs.tx_eth_hash = $4::text` the query runner cannot just filter the runtime_events anymore and then join into matching runtime_transactions, but it also needs to consider runtime_transactions that match the eth_hash, and it ends up with the above monstrosity that apparently ends up in scanning runtime_transactions and runtime_events tables.

TODO: 
- [x] localhost sanity-check response:
```
curl "localhost:8008/v1/emerald/events?tx_hash=fbb0bda05fea2b40434c624457b3e1529d953f8240644139ed78ad2db271ca29&limit=1"
{"events":[{"body":{"amount":259136},"eth_tx_hash":"fbb0bda05fea2b40434c624457b3e1529d953f8240644139ed78ad2db271ca29","evm_log_name":"","round":1004759,"tx_hash":"5496282c666039bfbfccd13234327ce6c1a267afdb8b926801ccb48c9c1e32e1","tx_index":0,"type":"core.gas_used"}],"is_total_count_clipped":false,"total_count":13}
```
- [x] Query plan (on a small db) with `set enable_seqscan=false`
```
 Aggregate  (cost=129.02..129.03 rows=1 width=8)
   ->  Limit  (cost=128.57..128.65 rows=30 width=213)
         ->  Sort  (cost=128.57..128.65 rows=30 width=213)
               Sort Key: evs.round DESC, evs.tx_index, evs.type, ((evs.body)::text)
               ->  Bitmap Heap Scan on runtime_events evs  (cost=9.09..127.84 rows=30 width=213)
                     Recheck Cond: (((tx_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d59622b7dc8'::text) OR ((evm_tx_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d596
22b7dc8'::text))
                     Filter: (runtime = 'emerald'::runtime)
                     ->  BitmapOr  (cost=9.09..9.09 rows=30 width=0)
                           ->  Bitmap Index Scan on ix_runtime_events_tx_hash  (cost=0.00..4.54 rows=15 width=0)
                                 Index Cond: ((tx_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d59622b7dc8'::text)
                           ->  Bitmap Index Scan on ix_runtime_events_evm_tx_hash  (cost=0.00..4.54 rows=15 width=0)
                                 Index Cond: ((evm_tx_hash)::text = '14674280e2b569122ff350f6cede43ad340d698dc9796f9d1bbc6d59622b7dc8'::text)
```
---


Possible alternative fixes:
- Technically #419 never asked to support filtering by eth_tx_hash (only to include it in the response), so could just drop the support for filtering, however the runtime_transactions endpoints does support this, so it kinda makes sense supporting this filtering in runtime_events as well
- Rewrite the runtime_events query into subqueries, something like this should work, but it might be quite complex and not the easiest to reason about (or maybe not?):
```sql
		-- Loads transactions that match the given filters.
		WITH txs as (
			SELECT runtime, tx_index, round, tx_eth_hash
			FROM chain.runtime_transactions
			WHERE (runtime = $1) AND
					($2::bigint IS NULL OR round = $2::bigint) AND
					($3::integer IS NULL OR tx_index = $3::integer) AND
					($4::text IS NULL OR txs_hash = $4::text OR tx_eth_hash = $4::text)
		),
		-- Loads transaction events that match the given filters.
		tx_evs as (
			SELECT evs.round, evs.tx_index, evs.tx_hash, txs.tx_eth_hash, evs.type, evs.body, evs.evm_log_name, evs.evm_log_params
			FROM chain.runtime_events AS evs INNER JOIN txs USING (runtime, tx_index, round)
			WHERE ($5::text IS NULL OR evs.type = $5::text) AND
			 		($6::bytea IS NULL OR evs.evm_log_signature = $6::bytea) AND
					($7::text IS NULL OR evs.related_accounts @> ARRAY[$7::text])
		),
		-- Loads block events that are not related to any transaction and match the given filters.
		block_evs as (
			SELECT round, NUL, NUL, NUL, type, body, evm_log_name, evm_log_params
			FROM chain.runtime_events
			WHERE (runtime = $1) AND
					($2::bigint IS NULL OR round = $2::bigint) AND
					($3::integer IS NULL AND tx_index IS NULL) AND
					($4::text IS NULL AND tx_hash = IS NULL) AND
					($5::text IS NULL OR evs.type = $5::text) AND
					($6::bytea IS NULL OR evs.evm_log_signature = $6::bytea) AND
					($7::text IS NULL OR evs.related_accounts @> ARRAY[$7::text])
		)
		-- Combine the two sets of events and sort them.
		SELECT * FROM tx_evs
		UNION ALL
		SELECT * FROM block_evs
		ORDER BY round DESC, tx_index, type, body::text
		LIMIT $8::bigint
		OFFSET $9::bigint
```