### PR TITLE
api: EVM tokens: output only tokesn of supported types; fix error generation

### DIFF
--- a/api/errors.go
+++ b/api/errors.go
@@ -27,7 +27,13 @@ var (
 
 type ErrStorageError struct{ Err error }
 
-func (e ErrStorageError) Error() string { return fmt.Sprintf("storage error: %s", e.Err.Error()) }
+func (e ErrStorageError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("storage error: %s", e.Err.Error())
+	}
+	// ErrStorageError shouldn't be constructed with a nil Err, but format it just in case.
+	return "storage error: internal bug, incorrectly instantiated error object with nil"
+}
 
 func HttpCodeForError(err error) int {
 	errVal := reflect.ValueOf(err)

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1686,7 +1686,7 @@ components:
     RuntimeEvmBalance:
       description: Balance of an account for a specific runtime and EVM token.
       type: object
-      required: [balance, token_contract_addr, token_decimals]
+      required: [balance, token_contract_addr, token_decimals, token_type]
       properties:
         balance:
           <<: *BigIntType

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2335,9 +2335,9 @@ components:
       type: string
       enum:
         - ERC20
-        - ERC721
-        - ERC1155
-        - OasisSdk
+        # Desired support in the future, among others:
+        # - ERC721
+        # - ERC1155
       description: |
         The type of a EVM token.
 

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -627,7 +627,7 @@ func (c *StorageClient) Account(ctx context.Context, address staking.Address) (*
 		address.String(),
 	)
 	if queryErr != nil {
-		return nil, wrapError(err)
+		return nil, wrapError(queryErr)
 	}
 	defer allowanceRows.Close()
 
@@ -1451,7 +1451,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 			&t.Type,
 			&t.NumHolders,
 		); err2 != nil {
-			return nil, wrapError(err)
+			return nil, wrapError(err2)
 		}
 
 		ts.EvmTokens = append(ts.EvmTokens, t)


### PR DESCRIPTION
**Bugfix:** The /{runtime}/evm_tokens endpoint had the token `type` as a required field for each token. However for some tokens, we cannot heuristically determine the type (or it's a currently unsupported type; currently, only ERC-20 is supported), and the field will be null there.
This PR changes how we fetch the tokens so that unknown-type tokens are suppressed.

The PR applies the same fix to `/{runtime}/accounts/{address}`, field `evm_balances`, which used to include unsupported-type tokens.

I noticed the error when https://testnet-index.oasislabs.com/v1/sapphire/evm_tokens produced an error:
`can't scan into dest[6]: cannot scan NULL into *string`, with a SQL statement `SELECT ... FROM chain.evm_tokens` where `dest[6]` is the type.

**Bonus bugfix:**
The actual error above was hidden in the server logs and behind a HTTP 504 (Bad Gateway) because the server crashed with nil pointer dereference panic. The dereference happened during error reporting, and had the following stack trace:

<details>
<summary>Stack Trace</summary>

```
panic serving 10.31.2.14:39948: runtime error: invalid memory address or nil pointer dereference
goroutine 99 [running]:
net/http.(*conn).serve.func1()
	/usr/local/go/src/net/http/server.go:1850 +0xbf
panic({0x12c20c0, 0x2177a60})
	/usr/local/go/src/runtime/panic.go:890 +0x262
github.com/oasisprotocol/oasis-indexer/api.ErrStorageError.Error({{0x0?, 0x0?}})
	/code/go/api/errors.go:30 +0x1e
github.com/oasisprotocol/oasis-indexer/api.HumanReadableJsonErrorHandler({0x18b5180, 0xc00041e620}, 0x18b5180?, {0x18ac120, 0xc000328c60})
	/code/go/api/errors.go:69 +0x1cb
github.com/oasisprotocol/oasis-indexer/api/v1/types.(*strictHandler).GetRuntimeEvmTokens(0xc0001bee80, {0x18b5180, 0xc00041e620}, 0xc0002c7b00, {0xc0001b9088, 0x8}, {0x0?, 0x0?})
	/code/go/api/v1/types/server.gen.go:4262 +0x1fe
github.com/oasisprotocol/oasis-indexer/api/v1/types.(*ServerInterfaceWrapper).GetRuntimeEvmTokens.func1({0x18b5180?, 0xc00041e620?}, 0x189d301?)
	/code/go/api/v1/types/server.gen.go:1489 +0x56
net/http.HandlerFunc.ServeHTTP(0x18b6458?, {0x18b5180?, 0xc00041e620?}, 0x189d340?)
	/usr/local/go/src/net/http/server.go:2109 +0x2f
[... cropped ...]
```

</details>

In other words, stringifying the `ErrStorageError` struct sometimes produced a nil dereference. This PR 1) fixes that by checking for nil, and 2) I manually checked all 70 places where `ErrStorageError` is constructed, and found two where it's unintentionally initialized with a nil and fixed them.


**Testing:** Deployed in testnet indexer (`mitjat-dev` tag), confirmed that the crash at https://testnet-index.oasislabs.com/v1/sapphire/evm_tokens goes away.