### PR TITLE
db: Move analysis tables to their own schema

### DIFF
--- a/analyzer/block/block.go
+++ b/analyzer/block/block.go
@@ -39,7 +39,7 @@ type BlockProcessor interface {
 	// from source storage and committing an atomically-executed batch of queries
 	// to target storage.
 	//
-	// The implementation must commit processed blocks (update the chain.processed_blocks record with processed_time timestamp).
+	// The implementation must commit processed blocks (update the analysis.processed_blocks record with processed_time timestamp).
 	ProcessBlock(ctx context.Context, height uint64) error
 }
 

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -13,7 +13,7 @@ func TotalCountQuery(inner string) string {
 const (
 	Status = `
 		SELECT height, processed_time
-			FROM chain.processed_blocks
+			FROM analysis.processed_blocks
 			WHERE analyzer=$1 AND processed_time IS NOT NULL
 		ORDER BY processed_time DESC
 		LIMIT 1`

--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -285,7 +285,7 @@ CREATE TABLE chain.accounts_related_transactions
 CREATE INDEX ix_accounts_related_transactions_address_block_index ON chain.accounts_related_transactions (account_address);
 
 -- Indexing Progress Management
-CREATE TABLE chain.processed_blocks
+CREATE TABLE chain.processed_blocks  -- Moved to analysis.processed_blocks in 06_analysis_schema.up.sql
 (
   height         UINT63 NOT NULL,
   analyzer       TEXT NOT NULL,

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -186,7 +186,7 @@ CREATE TABLE chain.evm_tokens
   total_supply uint_numeric
 );
 
-CREATE TABLE chain.evm_token_analysis
+CREATE TABLE chain.evm_token_analysis  -- Moved to analysis.evm_tokens in 06_analysis_schema.up.sql
 (
   runtime runtime NOT NULL,
   token_address oasis_addr NOT NULL,
@@ -199,7 +199,7 @@ CREATE TABLE chain.evm_token_analysis
 );
 CREATE INDEX ix_evm_token_analysis_stale ON chain.evm_token_analysis (runtime, token_address) WHERE last_download_round IS NULL OR last_mutate_round > last_download_round;
 
-CREATE TABLE chain.evm_token_balance_analysis
+CREATE TABLE chain.evm_token_balance_analysis  -- Moved to analysis.evm_token_balances in 06_analysis_schema.up.sql
 (
   runtime runtime NOT NULL,
   -- This table is used to track balance querying primarily for EVM tokens (ERC-20, ERC-271, etc), but also for

--- a/storage/migrations/05_evm_runtime_bytecode.up.sql
+++ b/storage/migrations/05_evm_runtime_bytecode.up.sql
@@ -1,7 +1,6 @@
 BEGIN;
 
 -- A schema for keeping track of analyzers' internal state/progess.
--- TODO: Move chain.processed_blocks and chain.*_analysis tables here.
 CREATE SCHEMA IF NOT EXISTS analysis;
 GRANT USAGE ON SCHEMA analysis TO PUBLIC;
 

--- a/storage/migrations/06_analysis_schema.up.sql
+++ b/storage/migrations/06_analysis_schema.up.sql
@@ -1,0 +1,9 @@
+-- Moves analysis tables (= those that keep track of analyzers' internal state/progess) to the new `analysis` schema.
+
+ALTER TABLE chain.processed_blocks SET SCHEMA analysis;
+
+ALTER TABLE chain.evm_token_analysis SET SCHEMA analysis;
+ALTER TABLE analysis.evm_token_analysis RENAME TO evm_tokens;
+
+ALTER TABLE chain.evm_token_balance_analysis SET SCHEMA analysis;
+ALTER TABLE analysis.evm_token_balance_analysis RENAME TO evm_token_balances;

--- a/tests/statecheck/util.go
+++ b/tests/statecheck/util.go
@@ -53,7 +53,7 @@ func snapshotBackends(target *postgres.Client, analyzer string, tables []string)
 	}
 	batch.Queue(`
 		INSERT INTO snapshot.snapshotted_heights (analyzer, height)
-			SELECT analyzer, height FROM chain.processed_blocks WHERE analyzer=$1 ORDER BY height DESC, processed_time DESC LIMIT 1
+			SELECT analyzer, height FROM analysis.processed_blocks WHERE analyzer=$1 ORDER BY height DESC, processed_time DESC LIMIT 1
 			ON CONFLICT DO NOTHING;
 	`, analyzer)
 


### PR DESCRIPTION
Internal refactor. This PR moves analysis DB tables (= those with analyzer-internal info) into their own `analysis` schema, introduced in #448.

Testing: Ran for 2000 blocks with all analyzers; no errors were produced.