### PR TITLE
api: /{runtime}/accounts/{addr}: Show contract runtime bytecode, show eth address of originating tx

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2076,12 +2076,14 @@ components:
             and the constructor parameters. When run, this code generates the runtime bytecode.
             Can be omitted for contracts that were created by another contract, as opposed 
             to a direct `Create` call.
-        # runtime_bytecode:
-        #   type: string
-        #   format: byte
-        #   description: |
-        #     The runtime bytecode of the smart contract. This is the code stored on-chain that
-        #     descibes a smart contract.
+        runtime_bytecode:
+          type: string
+          format: byte
+          description: |
+            The runtime bytecode of the smart contract. This is the code stored on-chain that
+            descibes a smart contract. Every contract has this info, but the indexer fetches
+            it separately, so the field may be missing for very fresh contracts (or if the fetching
+            process is stalled).
         verification:
           $ref: '#/components/schemas/RuntimeEvmContractVerification'
           description: |

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2066,8 +2066,14 @@ components:
           type: string
           description: | 
             The Oasis cryptographic hash of the transaction that created the smart contract.
-             Can be omitted for contracts that were created by another contract, as opposed 
-             to a direct `Create` call.
+            Can be omitted for contracts that were created by another contract, as opposed 
+            to a direct `Create` call.
+        eth_creation_tx:
+          type: string
+          description: |
+            The Ethereum transaction hash of the transaction in `creation_tx`.
+            Encoded as a lowercase hex string.
+          example: 'dc19a122e268128b5ee20366299fc7b5b199c8e3'
         creation_bytecode:
           type: string
           format: byte

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1384,6 +1384,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	).Scan(
 		&evmContract.CreationTx,
 		&evmContract.CreationBytecode,
+		&evmContract.RuntimeBytecode,
 	)
 	switch err {
 	case nil:

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1383,6 +1383,7 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 		address.String(),
 	).Scan(
 		&evmContract.CreationTx,
+		&evmContract.EthCreationTx,
 		&evmContract.CreationBytecode,
 		&evmContract.RuntimeBytecode,
 	)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -403,7 +403,7 @@ const (
 			OFFSET $9::bigint`
 
 	RuntimeEvmContract = `
-		SELECT creation_tx, creation_bytecode
+		SELECT creation_tx, creation_bytecode, runtime_bytecode
 			FROM chain.evm_contracts
 			WHERE (runtime = $1) AND
 					(contract_address = $2::text)`

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -403,10 +403,18 @@ const (
 			OFFSET $9::bigint`
 
 	RuntimeEvmContract = `
-		SELECT creation_tx, creation_bytecode, runtime_bytecode
-			FROM chain.evm_contracts
-			WHERE (runtime = $1) AND
-					(contract_address = $2::text)`
+		SELECT
+			creation_tx,
+			(
+				SELECT tx_eth_hash FROM chain.runtime_transactions rtt
+				WHERE (rtt.runtime = $1) AND (rtt.tx_hash = creation_tx)
+				ORDER BY timestamp DESC LIMIT 1  -- Technically more than one tx might share the same hash, but it's so vanishingly rare that this hack is fine.
+			) AS eth_creation_tx,
+			creation_bytecode,
+			runtime_bytecode
+		FROM chain.evm_contracts
+		
+		WHERE (runtime = $1) AND (contract_address = $2::text)`
 
 	AddressPreimage = `
 		SELECT context_identifier, context_version, address_data


### PR DESCRIPTION
This PR exposes two new fields in the contracts API:
- the newly-added runtime_bytecode field (see #448)
- exadds the eth variant of the originating tx's hash

Testing: Manually ran the new analyzer, then visited a contract address and a non-contract address and verified that the new field is as expected.

