### PR TITLE
api: Add /{runtime}/evm_tokens/{address} endpoint

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -986,6 +986,26 @@ paths:
                 $ref: '#/components/schemas/EvmTokenList'
         <<: *common_error_responses
 
+  /{runtime}/evm_tokens/{address}:
+    get:
+      summary: Returns info on an EVM (ERC-20, ...) token on the runtime.
+      parameters:
+        - *runtime
+        - in: path
+          name: address
+          required: true
+          schema:
+            <<: *StakingAddressType
+          description: The staking address of the account to return.
+      responses:
+        '200':
+          description: The requested token.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvmToken'
+        <<: *common_error_responses
+
   /{runtime}/accounts/{address}:
     get:
       summary: Returns a runtime account.

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -972,7 +972,7 @@ paths:
 
   /{runtime}/evm_tokens:
     get:
-      summary: Returns a list of EVM (ERC-20, ...) tokens on Emerald.
+      summary: Returns a list of EVM (ERC-20, ...) tokens on the runtime.
       parameters:
         - *limit
         - *offset
@@ -2403,8 +2403,7 @@ components:
           type: integer
           format: int64
           description: |
-            The number of addresses that have a nonzero balance of this token,
-            as calculated from Transfer events.
+            The number of addresses that have a nonzero balance of this token.
           example: 123
 
     AccountStats:

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	apiTypes "github.com/oasisprotocol/oasis-indexer/api/v1/types"
+	"github.com/oasisprotocol/oasis-indexer/common"
 	"github.com/oasisprotocol/oasis-indexer/log"
 	"github.com/oasisprotocol/oasis-indexer/storage/client"
 )
@@ -260,11 +261,22 @@ func (srv *StrictServerImpl) GetRuntimeBlocks(ctx context.Context, request apiTy
 }
 
 func (srv *StrictServerImpl) GetRuntimeEvmTokens(ctx context.Context, request apiTypes.GetRuntimeEvmTokensRequestObject) (apiTypes.GetRuntimeEvmTokensResponseObject, error) {
-	tokens, err := srv.dbClient.RuntimeTokens(ctx, request.Params)
+	tokens, err := srv.dbClient.RuntimeTokens(ctx, request.Params, nil)
 	if err != nil {
 		return nil, err
 	}
 	return apiTypes.GetRuntimeEvmTokens200JSONResponse(*tokens), nil
+}
+
+func (srv *StrictServerImpl) GetRuntimeEvmTokensAddress(ctx context.Context, request apiTypes.GetRuntimeEvmTokensAddressRequestObject) (apiTypes.GetRuntimeEvmTokensAddressResponseObject, error) {
+	tokens, err := srv.dbClient.RuntimeTokens(ctx, apiTypes.GetRuntimeEvmTokensParams{Limit: common.Ptr(uint64(1))}, &request.Address)
+	if err != nil {
+		return nil, err
+	}
+	if len(tokens.EvmTokens) != 1 {
+		return apiTypes.GetRuntimeEvmTokensAddress404JSONResponse{}, nil
+	}
+	return apiTypes.GetRuntimeEvmTokensAddress200JSONResponse(tokens.EvmTokens[0]), nil
 }
 
 func (srv *StrictServerImpl) GetRuntimeTransactions(ctx context.Context, request apiTypes.GetRuntimeTransactionsRequestObject) (apiTypes.GetRuntimeTransactionsResponseObject, error) {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1423,11 +1423,14 @@ func (c *StorageClient) RuntimeAccount(ctx context.Context, address staking.Addr
 	return &a, nil
 }
 
-func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntimeEvmTokensParams) (*EvmTokenList, error) {
+// If `address` is non-nil, it is used to filter the results to at most 1 token: the one
+// with the correcponding contract address.
+func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntimeEvmTokensParams, address *staking.Address) (*EvmTokenList, error) {
 	res, err := c.withTotalCount(
 		ctx,
 		queries.EvmTokens,
 		runtimeFromCtx(ctx),
+		address,
 		p.Limit,
 		p.Offset,
 	)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -458,10 +458,11 @@ const (
 		JOIN holders USING (token_address)
 		WHERE
 			(tokens.runtime = $1) AND
+			($2::oasis_addr IS NULL OR tokens.token_address = $2::oasis_addr) AND
 			tokens.token_type != 0 -- exclude unknown-type tokens; they're often just contracts that emitted Transfer events but don't expose the token ticker, name, balance etc.
 		ORDER BY num_holders DESC
-		LIMIT $2::bigint
-		OFFSET $3::bigint`
+		LIMIT $3::bigint
+		OFFSET $4::bigint`
 
 	AccountRuntimeSdkBalances = `
 		SELECT


### PR DESCRIPTION
This PR adds a new endpoint for retrieving token-specific details about a single token contract.

I was initially planning to put this info under a field in the `/{runtime}/accounts/{address}` endpoint, but then decided to put it here as that endpoint's response is pretty heavy already.

There's not a task/issue for this PR, but I expect it to be needed in the near future as the explorer will show info about individual token-like contracts. cc @csillag

Testing: Manually visited an url of a token contract, verified the info was there. Visited a non-token contract, verified I got HTTP 404.