### PR TITLE
Add /evm_tokens/{address}/holders endpoint

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2450,15 +2450,15 @@ components:
 
     EvmToken:
       type: object
-      required: [contract_addr, evm_contract_addr, num_holders, type]
+      required: [contract_addr, num_holders, type]
       properties:
         contract_addr:
           type: string
           description: The Oasis address of this token's contract.
           example: 'oasis1qp2hssandc7dekjdr6ygmtzt783k3gn38uupdeys'
-        evm_contract_addr:
+        eth_contract_addr:
           type: string
-          description: The EVM address of this token's contract.
+          description: The Ethereum address of this token's contract.
           example: *eth_address_1
         name:
           type: string

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -996,7 +996,7 @@ paths:
           required: true
           schema:
             <<: *StakingAddressType
-          description: The staking address of the account to return.
+          description: The staking address of the token contract.
       responses:
         '200':
           description: The requested token.
@@ -1004,6 +1004,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/EvmToken'
+        <<: *common_error_responses
+
+  /{runtime}/evm_tokens/{address}/holders:
+    get:
+      summary: |
+        Returns the list of holders of an EVM (ERC-20, ...) token. 
+        This endpoint does not verify that `address` is actually an EVM token; if it is not, it will simply return an empty list.
+      parameters:
+        - *limit
+        - *offset
+        - *runtime
+        - in: path
+          name: address
+          required: true
+          schema:
+            <<: *StakingAddressType
+          description: The staking address of the token contract for which to return the holders.
+      responses:
+        '200':
+          description: The requested holders.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenHolderList'
         <<: *common_error_responses
 
   /{runtime}/accounts/{address}:
@@ -1732,6 +1756,38 @@ components:
           type: integer
           description: The number of decimals of precision for this token.
           example: 18
+
+    TokenHolderList:
+      allOf:
+        - $ref: '#/components/schemas/List'
+        - type: object
+          required: [holders]
+          properties:
+            holders:
+              type: array
+              items:
+                $ref: '#/components/schemas/BareTokenHolder'
+          description: |
+            A list of token holders for a specific (implied) runtime and token.
+
+    BareTokenHolder:
+      description: |
+        Balance of an account for a specific (implied) runtime and token.
+      type: object
+      required: [holder_address, balance]
+      properties:
+        holder_address:
+          type: string
+          description: The oasis address of the account holder.
+          example: *staking_address_1
+        eth_holder_address:
+          type: string
+          description: The Ethereum address of the same account holder, if meaningfully defined.
+          example: *eth_address_1
+        balance:
+          <<: *BigIntType
+          description: Number of tokens held, in base units.
+
 
     Account:
       type: object

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -2458,8 +2458,8 @@ components:
           example: 'oasis1qp2hssandc7dekjdr6ygmtzt783k3gn38uupdeys'
         evm_contract_addr:
           type: string
-          description: The EVM address of this token's contract. Encoded as a lowercase hex string.
-          example: 'dc19a122e268128b5ee20366299fc7b5b199c8e3'
+          description: The EVM address of this token's contract.
+          example: *eth_address_1
         name:
           type: string
           description: Name of the token, as provided by token contract's `name()` method.

--- a/api/v1/strict_server.go
+++ b/api/v1/strict_server.go
@@ -279,6 +279,14 @@ func (srv *StrictServerImpl) GetRuntimeEvmTokensAddress(ctx context.Context, req
 	return apiTypes.GetRuntimeEvmTokensAddress200JSONResponse(tokens.EvmTokens[0]), nil
 }
 
+func (srv *StrictServerImpl) GetRuntimeEvmTokensAddressHolders(ctx context.Context, request apiTypes.GetRuntimeEvmTokensAddressHoldersRequestObject) (apiTypes.GetRuntimeEvmTokensAddressHoldersResponseObject, error) {
+	holders, err := srv.dbClient.RuntimeTokenHolders(ctx, request.Params, request.Address)
+	if err != nil {
+		return nil, err
+	}
+	return apiTypes.GetRuntimeEvmTokensAddressHolders200JSONResponse(*holders), nil
+}
+
 func (srv *StrictServerImpl) GetRuntimeTransactions(ctx context.Context, request apiTypes.GetRuntimeTransactionsRequestObject) (apiTypes.GetRuntimeTransactionsResponseObject, error) {
 	transactions, err := srv.dbClient.RuntimeTransactions(ctx, request.Params, nil)
 	if err != nil {

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1477,7 +1477,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 			return nil, wrapError(err2)
 		}
 
-		t.EvmContractAddr = ethCommon.BytesToAddress(addrPreimage).String()
+		t.EthContractAddr = common.Ptr(ethCommon.BytesToAddress(addrPreimage).String())
 		ts.EvmTokens = append(ts.EvmTokens, t)
 	}
 

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -1463,9 +1463,10 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 	}
 	for res.rows.Next() {
 		var t EvmToken
+		var addrPreimage []byte
 		if err2 := res.rows.Scan(
 			&t.ContractAddr,
-			&t.EvmContractAddr,
+			&addrPreimage,
 			&t.Name,
 			&t.Symbol,
 			&t.Decimals,
@@ -1476,6 +1477,7 @@ func (c *StorageClient) RuntimeTokens(ctx context.Context, p apiTypes.GetRuntime
 			return nil, wrapError(err2)
 		}
 
+		t.EvmContractAddr = ethCommon.BytesToAddress(addrPreimage).String()
 		ts.EvmTokens = append(ts.EvmTokens, t)
 	}
 
@@ -1503,14 +1505,15 @@ func (c *StorageClient) RuntimeTokenHolders(ctx context.Context, p apiTypes.GetR
 	}
 	for res.rows.Next() {
 		var h BareTokenHolder
+		var addrPreimage []byte
 		if err2 := res.rows.Scan(
 			&h.HolderAddress,
-			&h.EthHolderAddress,
+			&addrPreimage,
 			&h.Balance,
 		); err2 != nil {
 			return nil, wrapError(err2)
 		}
-
+		h.EthHolderAddress = common.Ptr(ethCommon.BytesToAddress(addrPreimage).String())
 		hs.Holders = append(hs.Holders, h)
 	}
 

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -450,7 +450,7 @@ const (
 		)
 		SELECT
 			tokens.token_address AS contract_addr,
-			encode(preimages.address_data, 'hex') as eth_contract_addr,
+			preimages.address_data as eth_contract_addr,
 			tokens.token_name AS name,
 			tokens.symbol,
 			tokens.decimals,
@@ -475,7 +475,7 @@ const (
 	EvmTokenHolders = `
 		SELECT
 			balances.account_address AS holder_addr,
-			encode(preimages.address_data, 'hex') as eth_holder_addr,
+			preimages.address_data as eth_holder_addr,
 			balances.balance AS balance
 		FROM chain.evm_token_balances AS balances
 		JOIN chain.address_preimages AS preimages ON (balances.account_address = preimages.address AND preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND preimages.context_version = 0)

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -471,6 +471,21 @@ const (
 		LIMIT $3::bigint
 		OFFSET $4::bigint`
 
+	//nolint:gosec // Linter suspects a hardcoded credentials token.
+	EvmTokenHolders = `
+		SELECT
+			balances.account_address AS holder_addr,
+			encode(preimages.address_data, 'hex') as eth_holder_addr,
+			balances.balance AS balance
+		FROM chain.evm_token_balances AS balances
+		JOIN chain.address_preimages AS preimages ON (balances.account_address = preimages.address AND preimages.context_identifier = 'oasis-runtime-sdk/address: secp256k1eth' AND preimages.context_version = 0)
+		WHERE
+			(balances.runtime = $1::runtime) AND
+			(balances.token_address = $2::oasis_addr)
+		ORDER BY balance DESC
+		LIMIT $3::bigint
+		OFFSET $4::bigint`
+
 	AccountRuntimeSdkBalances = `
 		SELECT
 			balance AS balance,

--- a/storage/client/types.go
+++ b/storage/client/types.go
@@ -131,6 +131,10 @@ type EvmTokenList = api.EvmTokenList
 
 type EvmToken = api.EvmToken
 
+type BareTokenHolder = api.BareTokenHolder
+
+type TokenHolderList = api.TokenHolderList
+
 // TxVolumeList is the storage response for GetVolumes.
 type TxVolumeList = api.TxVolumeList
 


### PR DESCRIPTION
This PR adds a new endpoint that lets clients retrieve the list of token holders for non-native tokens.

It is implemented as a separate endpoint because the most popular token in mainnet emerald has ~23k holders, so we need pagination.

Minor: The PR also updates the recently added `evm_contract_addr` field in the endpoint that lists EVM tokens: It renames it to `eth_*` (the preferred prefix, I believe) and applies checksum capitalization.

Testing (in local DB):
```
-- Get top-held tokens
indexer=# SELECT token_address, COUNT(*) AS cnt FROM chain.evm_token_balances where runtime='emerald' group by 1 order by 2 desc;
                 token_address                  | cnt 
------------------------------------------------+-----
 oasis1qzw6wua8kc6jmjef6trm8mndqnuuyg7cpcjxt0e2 | 429
 oasis1qznnt6tr5vmecg78eff0h9mcu5xtcq5jlqjagqe2 | 171
 oasis1qr0gufmmwzmfgymsp626n2zyt4yx4a4l7q6e7hx2 |  42
 oasis1qqjpg0kr8tmmmxhydfwf9gnlkl60p8pp6qrzv99s |  36

-- Get holders for top token
indexer=# select account_address, balance from chain.evm_token_balances where token_address = 'oasis1qzw6wua8kc6jmjef6trm8mndqnuuyg7cpcjxt0e2' order by balance desc limit 5;
                account_address                 |         balance         
------------------------------------------------+-------------------------
 oasis1qpc49j9styptjg6hhs3y9kaa6n95r4y9zc4nlg6l | 50000000000000000000000
 oasis1qzjzeck3zphvwz3td7qhjduv6y0l7qpxtyayy3uf | 42000000000000000000000
 oasis1qpxzwlxferjfey5g3haldqfy5htzd8ny95286qkd | 30002626437022043145826
 oasis1qrxghxqk0hx88jl75cxcxaeftzv9dqcesg3dc9yg | 28311550722808922850536
 oasis1qqledgspkpmq8gfudag0hzafczdulu5edu3fn4fa | 20801773731006379406345
 
# Test the API
curl 'localhost:8008/v1/emerald/accounts/oasis1qzw6wua8kc6jmjef6trm8mndqnuuyg7cpcjxt0e2/holders?limit=5'
{
  "holders":[
    {"balance":"50000000000000000000000","eth_holder_address":"0x061d3e46407520553753249277D21fdCA325Bbb1","holder_address":"oasis1qpc49j9styptjg6hhs3y9kaa6n95r4y9zc4nlg6l"},
    {"balance":"42000000000000000000000","eth_holder_address":"0xE1D6a3f9851C770E5aD2590E8901f018f06283b1","holder_address":"oasis1qzjzeck3zphvwz3td7qhjduv6y0l7qpxtyayy3uf"},
    {"balance":"30002626437022043145826","eth_holder_address":"0x4C09b14bE5e02C9a22dEc2A9D4230ECA5e8656e6","holder_address":"oasis1qpxzwlxferjfey5g3haldqfy5htzd8ny95286qkd"},
    {"balance":"28311550722808922850536","eth_holder_address":"0xb412B96Dbe138DA98be8e475f632E1A8F0037748","holder_address":"oasis1qrxghxqk0hx88jl75cxcxaeftzv9dqcesg3dc9yg"},
    {"balance":"20801773731006379406345","eth_holder_address":"0x0a3EdE29c4c7E892ac3e0a024C718E725A37DC39","holder_address":"oasis1qqledgspkpmq8gfudag0hzafczdulu5edu3fn4fa"}
  ],
  "is_total_count_clipped":false,"total_count":429
}
```

Resolves https://app.clickup.com/t/866agdwgv