### PR TITLE
analyzer: genesis: parse compute nodes for each runtime

### DIFF
--- a/analyzer/consensus/genesis.go
+++ b/analyzer/consensus/genesis.go
@@ -76,9 +76,12 @@ ON CONFLICT (id) DO UPDATE SET address = EXCLUDED.address;`
 
 	// Populate nodes.
 	queries = append(queries, `TRUNCATE chain.nodes CASCADE;`)
+	queries = append(queries, `TRUNCATE chain.runtime_nodes CASCADE;`)
 	query = `INSERT INTO chain.nodes (id, entity_id, expiration, tls_pubkey, tls_next_pubkey, p2p_pubkey, consensus_pubkey, roles)
 VALUES
 `
+	queryRt := "" // Query for populating the chain.runtime_nodes table.
+
 	for i, signedNode := range document.Registry.Nodes {
 		var node node.Node
 		if err := signedNode.Open(registry.RegisterNodeSignatureContext, &node); err != nil {
@@ -99,9 +102,29 @@ VALUES
 		if i != len(document.Registry.Nodes)-1 {
 			query += ",\n"
 		}
+
+		for _, runtime := range node.Runtimes {
+			if queryRt != "" {
+				// There's already a values tuple in the query.
+				queryRt += ",\n"
+			}
+			queryRt += fmt.Sprintf(
+				"\t('%s', '%s')",
+				runtime.ID.String(),
+				node.ID.String(),
+			)
+		}
 	}
 	query += ";"
 	queries = append(queries, query)
+
+	// There might be no runtime_nodes to insert; create a query only if there are.
+	if queryRt != "" {
+		queryRt = `INSERT INTO chain.runtime_nodes(runtime_id, node_id) 
+VALUES
+` + queryRt + ";"
+		queries = append(queries, queryRt)
+	}
 
 	// Populate runtimes.
 	if len(document.Registry.Runtimes) > 0 {


### PR DESCRIPTION
This PR slightly expands genesis processing: We now also populate the `chain.runtime_nodes` table from the genesis.

While working on https://github.com/oasisprotocol/oasis-indexer/pull/457, this was the only piece of data that could/should be extracted from genesis (because it's available in the genesis, and interesting in that we track it during block processing), but is not.

This table is also the basis for the "active nodes" query which is used by the Explorer to show the number of nodes supporting each runtime: https://github.com/oasisprotocol/oasis-indexer/blob/4a5120057ec008e8b40ce18f4b8068716eb47318/storage/client/queries/queries.go#L500-L504

Once this PR and https://github.com/oasisprotocol/oasis-indexer/pull/456 (which will introduce the use of `GenesisAtHeight()`) are both merged, we can start the consensus indexer at a recent height, ignore non-recent blocks, and expose up-to-date node registry info to the Explorer. (NB, other stuff like list of txs, events etc will be missing for non-recent blocks; but short-term the Explorer does not care about those.)
Related: https://app.clickup.com/t/866agmn0m