### PR TITLE
status: Expose datetime of most recent block

### DIFF
--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1124,13 +1124,18 @@ components:
 
     Status:
       type: object
-      required: [latest_block, latest_update]
+      required: [latest_block, latest_block_time, latest_update]
       properties:
         latest_block:
           type: integer
           format: int64
           description: The height of the most recent indexed block. Query a synced Oasis node for the latest block produced.
           example: *block_height_1
+        latest_block_time:
+          type: string
+          format: date-time
+          description: The RFC 3339 formatted consensus time of when the most recent block was produced.
+          example: *iso_timestamp_2
         latest_update:
           type: string
           format: date-time
@@ -2342,7 +2347,7 @@ components:
 
     RuntimeStatus:
       type: object
-      required: [active_nodes, latest_block, latest_update]
+      required: [active_nodes, latest_block, latest_block_time, latest_update]
       properties:
         active_nodes:
           type: integer
@@ -2353,6 +2358,11 @@ components:
           format: int64
           description: The height of the most recent indexed block (also sometimes referred to as "round") for this runtime. Query a synced Oasis node for the latest block produced.
           example: *block_height_1
+        latest_block_time:
+          type: string
+          format: date-time
+          description: The RFC 3339 formatted consensus time of when the latest indexed block for this runtime was produced.
+          example: *iso_timestamp_2
         latest_update:
           type: string
           format: date-time

--- a/storage/client/client.go
+++ b/storage/client/client.go
@@ -187,6 +187,15 @@ func (c *StorageClient) Status(ctx context.Context) (*Status, error) {
 	// https://github.com/oasisprotocol/oasis-core/blob/5985dc5c2844de28241b7b16b19d91a86e5cbeda/docs/oasis-node/cli.md?plain=1#L41
 	s.LatestUpdate = s.LatestUpdate.Truncate(time.Second)
 
+	// Query latest block for info.
+	if err := c.db.QueryRow(
+		ctx,
+		queries.Block,
+		s.LatestBlock,
+	).Scan(nil, nil, &s.LatestBlockTime, nil); err != nil {
+		return nil, wrapError(err)
+	}
+
 	return &s, nil
 }
 
@@ -1501,6 +1510,16 @@ func (c *StorageClient) RuntimeStatus(ctx context.Context) (*RuntimeStatus, erro
 	// oasis-node control status returns time truncated to the second
 	// https://github.com/oasisprotocol/oasis-core/blob/5985dc5c2844de28241b7b16b19d91a86e5cbeda/docs/oasis-node/cli.md?plain=1#L41
 	s.LatestUpdate = s.LatestUpdate.Truncate(time.Second)
+
+	// Query latest block for info.
+	if err := c.db.QueryRow(
+		ctx,
+		queries.RuntimeBlock,
+		runtimeName,
+		s.LatestBlock,
+	).Scan(nil, nil, &s.LatestBlockTime, nil, nil, nil); err != nil {
+		return nil, wrapError(err)
+	}
 
 	// Query active nodes.
 	if err := c.db.QueryRow(

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -317,6 +317,11 @@ const (
 		LIMIT $6::bigint
 		OFFSET $7::bigint`
 
+	RuntimeBlock = `
+		SELECT round, block_hash, timestamp, num_transactions, size, gas_used
+			FROM chain.runtime_blocks
+			WHERE (runtime = $1) AND (round = $2::bigint)`
+
 	RuntimeTransactions = `
 		SELECT
 			txs.round,

--- a/tests/e2e_regression/expected/emerald_status.body
+++ b/tests/e2e_regression/expected/emerald_status.body
@@ -1,5 +1,6 @@
 {
   "active_nodes": 28,
   "latest_block": 1003598,
+  "latest_block_time": "2022-04-11T13:38:14Z",
   "latest_update": "UNINTERESTING"
 }

--- a/tests/e2e_regression/expected/status.body
+++ b/tests/e2e_regression/expected/status.body
@@ -1,4 +1,5 @@
 {
   "latest_block": 8049056,
+  "latest_block_time": "2022-04-11T11:12:48Z",
   "latest_update": "UNINTERESTING"
 }


### PR DESCRIPTION
Resloves https://app.clickup.com/t/866af85d2

Testing (locally):
```
curl "localhost:8008/v1/"
{"latest_block":8049056,"latest_block_time":"2022-04-11T13:12:48+02:00","latest_update":"2023-06-25T09:20:13+02:00"}


curl "localhost:8008/v1/emerald/status"
{"active_nodes":0,"latest_block":1004425,"latest_block_time":"2022-04-11T17:04:34+02:00","latest_update":"2023-06-25T09:18:49+02:00"}
```