### PR TITLE
bugfix: db: Make custom types public

### DIFF
--- a/storage/migrations/01_consensus.up.sql
+++ b/storage/migrations/01_consensus.up.sql
@@ -8,13 +8,13 @@ CREATE SCHEMA IF NOT EXISTS chain;
 GRANT USAGE ON SCHEMA chain TO PUBLIC;
 
 -- Custom types
-CREATE DOMAIN uint_numeric NUMERIC(1000,0) CHECK(VALUE >= 0);
-CREATE DOMAIN uint63 BIGINT CHECK(VALUE >= 0);
-CREATE DOMAIN uint31 INTEGER CHECK(VALUE >= 0);
-CREATE DOMAIN hex64 TEXT CHECK(VALUE ~ '^[0-9a-f]{64}$');
+CREATE DOMAIN public.uint_numeric NUMERIC(1000,0) CHECK(VALUE >= 0);
+CREATE DOMAIN public.uint63 BIGINT CHECK(VALUE >= 0);
+CREATE DOMAIN public.uint31 INTEGER CHECK(VALUE >= 0);
+CREATE DOMAIN public.hex64 TEXT CHECK(VALUE ~ '^[0-9a-f]{64}$');
 -- base64(ed25519 public key); from https://github.com/oasisprotocol/oasis-core/blob/f95186e3f15ec64bdd36493cde90be359bd17da8/go/common/crypto/signature/signature.go#L90-L90
-CREATE DOMAIN base64_ed25519_pubkey TEXT CHECK(VALUE ~ '^[A-Za-z0-9+/]{43}=$');
-CREATE DOMAIN oasis_addr TEXT CHECK(length(VALUE) = 46 AND VALUE ~ '^oasis1');
+CREATE DOMAIN public.base64_ed25519_pubkey TEXT CHECK(VALUE ~ '^[A-Za-z0-9+/]{43}=$');
+CREATE DOMAIN public.oasis_addr TEXT CHECK(length(VALUE) = 46 AND VALUE ~ '^oasis1');
 
 -- Block Data
 CREATE TABLE chain.blocks

--- a/storage/migrations/02_runtimes.up.sql
+++ b/storage/migrations/02_runtimes.up.sql
@@ -2,8 +2,8 @@
 
 BEGIN;
 
-CREATE TYPE runtime AS ENUM ('emerald', 'sapphire', 'cipher');
-CREATE TYPE call_format AS ENUM ('encrypted/x25519-deoxysii');
+CREATE TYPE public.runtime AS ENUM ('emerald', 'sapphire', 'cipher');
+CREATE TYPE public.call_format AS ENUM ('encrypted/x25519-deoxysii');
 
 CREATE TABLE chain.runtime_blocks
 (

--- a/storage/migrations/05_evm_runtime_bytecode.up.sql
+++ b/storage/migrations/05_evm_runtime_bytecode.up.sql
@@ -4,7 +4,7 @@ BEGIN;
 CREATE SCHEMA IF NOT EXISTS analysis;
 GRANT USAGE ON SCHEMA analysis TO PUBLIC;
 
-CREATE DOMAIN eth_addr BYTEA CHECK(length(VALUE) = 20);
+CREATE DOMAIN public.eth_addr BYTEA CHECK(length(VALUE) = 20);
 
 -- Used to keep track of potential contract addresses, and our progress in
 -- downloading their runtime bytecode. ("Runtime" in the sense of ETH terminology


### PR DESCRIPTION
All custom DB types defined by the `indexer` DB user were by default created in the `indexer` DB schema. The `api` (readonly) DB user was unable to see and use them. A recent change introduced a query with `$1::oasis_addr` on the API side, and that failed with `storage error: storage error: ERROR: type \"oasis_addr\" does not exist`. It's surprising to me that this happened only now.

This PR changes the definitions of custom types so that they live in the `public` schema. This makes them publicly viewable. The more principled solution would be to put them into the `chain` schema, but then we'd need things like `$1::chain.oasis_addr` everywhere (or we'd need to include `chain` in the `search_path`, which I'm not a fan of because it makes behavior more hidden).

I verified that the DB wiping code will remove these types despite them living in a different schema now. And I verified in prod that API now works as expected.

I have already applied this as a migration to {staging,prod}x{mainnet,testnet}:
```sql
alter domain uint_numeric set schema public;
alter domain uint63 set schema public;
alter domain uint31 set schema public;
alter domain hex64 set schema public;
alter domain base64_ed25519_pubkey set schema public;
alter domain oasis_addr set schema public;
alter domain eth_addr set schema public;
alter type runtime set schema public;
alter type call_format set schema public;
```