### PR TITLE
api: log binned request latencies

### DIFF
--- a/.changelog/676.internal.md
+++ b/.changelog/676.internal.md
@@ -1,0 +1,4 @@
+Improve api request logging
+
+- log binned request latencies
+- log request query params


### PR DESCRIPTION
## Task

The API layer logs requests but does not log query params: [https://github.com/oasisprotocol/nexus/blob/908a841427c146cd81fdfac00bfebf771f885d1a/api/middleware.go#L85-L85](https://github.com/oasisprotocol/nexus/blob/908a841427c146cd81fdfac00bfebf771f885d1a/api/middleware.go#L85-L85)
  
Add those, and add the duration of query, and add a field that categorizes the duration (e.g. <100ms, 100-300ms, 300-1000ms, >1000ms) so we can find expensive queries easily from the logs.

## This PR
Adds query params and binned request latency to api logging. Also renames the existing `time` field to `latency`.
