### PR TITLE
feature: setup ghcr.io/oasisprotocol/nexus docker repository

### DIFF
--- a/.changelog/827.feature.md
+++ b/.changelog/827.feature.md
@@ -1,0 +1,1 @@
+feature: push images to ghcr.io/oasisprotocol/nexus docker repository

--- a/.github/workflows/docker-nexus.yaml
+++ b/.github/workflows/docker-nexus.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           # We need history to determine oasis-indexer version from git tag.
           fetch-depth: '0'
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -37,7 +38,8 @@ jobs:
         # Version oasis-indexer image by date and git revision.
         run: |
           echo "VERSION=$(date +%Y-%m-%d-git$(git rev-parse --short HEAD))" >> $GITHUB_ENV
-      - name: Build and push Docker
+
+      - name: Build and push Docker to DockerHub
         uses: docker/build-push-action@v3
         with:
           build-args: |
@@ -51,3 +53,39 @@ jobs:
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      # Also push the image to ghcr.io/oasisprotocol/nexus.
+      # XXX: In future, we will remove the Dockerhub repository and only push to ghcr.io.
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker to ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            VERSION=${{ env.VERSION }}
+          context: .
+          file: docker/nexus/Dockerfile
+          tags: |
+            ghcr.io/oasisprotocol/nexus:latest
+            ghcr.io/oasisprotocol/nexus:latest-${{ env.VERSION }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Prune old ghcr.io/oasisprotocol/nexus images
+        if: ${{ github.event_name == 'push' }}
+        uses: vlaurin/action-ghcr-prune@v0.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          organization: oasisprotocol
+          container: nexus
+          keep-younger-than: 14 # days
+          keep-last: 4
+          prune-untagged: true
+          prune-tags-regexes: ^latest-

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           # For more info, see:
           # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
       # Prepare the tagged Docker image.
       - name: Set release tag
         run: |
@@ -61,6 +61,29 @@ jobs:
           file: docker/nexus/Dockerfile
           tags: |
             oasislabs/oasis-indexer:${{ env.TAG }}
+          push: true
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.html_url }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      # Also push the image to ghcr.io/oasisprotocol/nexus.
+      # XXX: In future, we will remove the Dockerhub repository and only push to ghcr.io.
+      - name: Login to ghcr.io
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker to ghcr.io
+        uses: docker/build-push-action@v3
+        with:
+          build-args: |
+            TAG=${{ env.TAG }}
+          context: .
+          file: docker/nexus/Dockerfile
+          tags: |
+            ghcr.io/oasisprotocol/nexus:${{ env.TAG }}
           push: true
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/814

For now we push images to both Dockerhub and ghcr.io/oasisprotocol/nexus. After some transition period, we will remove the dockerhub repository.