### PR TITLE
api/{rofl_apps,evm_tokens}: Filter by multiple name fragments

### DIFF
--- a/.changelog/1026.feature.1.md
+++ b/.changelog/1026.feature.1.md
@@ -1,0 +1,1 @@
+api/rofl_apps: Support filtering by multiple name fragments

--- a/.changelog/1026.feature.2.md
+++ b/.changelog/1026.feature.2.md
@@ -1,0 +1,1 @@
+api/evm_tokens: Support filtering by multiple name fragments

--- a/api/spec/v1.yaml
+++ b/api/spec/v1.yaml
@@ -1075,9 +1075,14 @@ paths:
         - *runtime
         - in: query
           name: name
+          style: form
+          explode: false
           schema:
-            type: string
-          description: A filter on the name, the name or symbol must contain this value as a substring.
+            type: array
+            items:
+              type: string
+            maxItems: 6
+          description: A filter on the name, the name or symbol must contain this value as a substring. If multiple names are provided, the token must match all of them.
         - in: query
           name: sort_by
           schema:
@@ -1266,9 +1271,14 @@ paths:
         - *runtime
         - in: query
           name: name
+          style: form
+          explode: false
           schema:
-            type: string
-          description: A filter on the name of the ROFL app.
+            type: array
+            items:
+              type: string
+            maxItems: 6
+          description: A filter on the name of the ROFL app. If multiple names are provided, the ROFL App must match all of them.
       responses:
         '200':
           description: A JSON object containing a list of ROFL apps.

--- a/tests/e2e_regression/eden/expected/emerald_token_by_multiple_names.body
+++ b/tests/e2e_regression/eden/expected/emerald_token_by_multiple_names.body
@@ -1,0 +1,32 @@
+{
+  "evm_tokens": [
+    {
+      "contract_addr": "oasis1qzpxtzc3xphccjq94wxffchfc5sua5t24vc6gvt6",
+      "decimals": 18,
+      "eth_contract_addr": "0x5C78A65AD6D0eC6618788b6E8e211F31729111Ca",
+      "is_verified": true,
+      "name": "Wrapped ROSE",
+      "num_holders": 1,
+      "num_transfers": 1,
+      "symbol": "WROSE",
+      "total_supply": "370854109276538025377920",
+      "type": "ERC20",
+      "verification_level": "partial"
+    },
+    {
+      "contract_addr": "oasis1qpgcp5jzlgk4hcenaj2x82rqk8rrve2keyuc8aaf",
+      "decimals": 18,
+      "eth_contract_addr": "0x21C718C22D52d0F3a789b752D4c2fD5908a8A733",
+      "is_verified": true,
+      "name": "Wrapped ROSE",
+      "num_holders": 14,
+      "num_transfers": 48,
+      "symbol": "wROSE",
+      "total_supply": "11110528749907675559457292",
+      "type": "ERC20",
+      "verification_level": "partial"
+    }
+  ],
+  "is_total_count_clipped": false,
+  "total_count": 2
+}

--- a/tests/e2e_regression/eden/expected/emerald_token_by_multiple_names.headers
+++ b/tests/e2e_regression/eden/expected/emerald_token_by_multiple_names.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden/expected/emerald_token_by_name.body
+++ b/tests/e2e_regression/eden/expected/emerald_token_by_name.body
@@ -1,0 +1,56 @@
+{
+  "evm_tokens": [
+    {
+      "contract_addr": "oasis1qzel2watfs6g3cm765dwlukymjs5k3rnhvua4z78",
+      "decimals": 18,
+      "eth_contract_addr": "0x3223f17957Ba502cbe71401D55A0DB26E5F7c68F",
+      "is_verified": false,
+      "name": "Wrapped Ether",
+      "num_holders": 2,
+      "num_transfers": 2,
+      "symbol": "WETH",
+      "total_supply": "153212215450000000000",
+      "type": "ERC20"
+    },
+    {
+      "contract_addr": "oasis1qzpxtzc3xphccjq94wxffchfc5sua5t24vc6gvt6",
+      "decimals": 18,
+      "eth_contract_addr": "0x5C78A65AD6D0eC6618788b6E8e211F31729111Ca",
+      "is_verified": true,
+      "name": "Wrapped ROSE",
+      "num_holders": 1,
+      "num_transfers": 1,
+      "symbol": "WROSE",
+      "total_supply": "370854109276538025377920",
+      "type": "ERC20",
+      "verification_level": "partial"
+    },
+    {
+      "contract_addr": "oasis1qpgcp5jzlgk4hcenaj2x82rqk8rrve2keyuc8aaf",
+      "decimals": 18,
+      "eth_contract_addr": "0x21C718C22D52d0F3a789b752D4c2fD5908a8A733",
+      "is_verified": true,
+      "name": "Wrapped ROSE",
+      "num_holders": 14,
+      "num_transfers": 48,
+      "symbol": "wROSE",
+      "total_supply": "11110528749907675559457292",
+      "type": "ERC20",
+      "verification_level": "partial"
+    },
+    {
+      "contract_addr": "oasis1qrsl7tgujttvscfe2k268s7q2s7kdu9tyv9qv2tx",
+      "decimals": 8,
+      "eth_contract_addr": "0x5D9ab5522c64E1F6ef5e3627ECCc093f56167818",
+      "is_verified": false,
+      "name": "Wrapped BTC",
+      "num_holders": 1,
+      "num_transfers": 2,
+      "symbol": "WBTC",
+      "total_supply": "175579512",
+      "type": "ERC20"
+    }
+  ],
+  "is_total_count_clipped": false,
+  "total_count": 4
+}

--- a/tests/e2e_regression/eden/expected/emerald_token_by_name.headers
+++ b/tests/e2e_regression/eden/expected/emerald_token_by_name.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden/test_cases.sh
+++ b/tests/e2e_regression/eden/test_cases.sh
@@ -32,6 +32,8 @@ testCases=(
   'emerald_token_nfts                         /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts'
   'emerald_token_nfts_eth                     /v1/emerald/evm_tokens/0x1108A83b867c8b720fEa7261AE7A64DAB17B4159/nfts'
   'emerald_token_nft                          /v1/emerald/evm_tokens/oasis1qz29t7nxkwfqgfk36uqqs9pzuzdt8zmrjud5mehx/nfts/2'
+  'emerald_token_by_name                      /v1/emerald/evm_tokens?name=Wrapped'
+  'emerald_token_by_multiple_names            /v1/emerald/evm_tokens?name=WROSE,Wrapped'
   'emerald_account_with_rose                  /v1/emerald/accounts/oasis1qrt0sv2s2x2lkt9e7kmr2mzxgme8m0pzauwztprl'
   'emerald_account_with_evm_token             /v1/emerald/accounts/oasis1qpl38f2a8m55ylha8ysdn03ya0mgrftkasmy8wyv'
   'emerald_account_with_evm_token_eth         /v1/emerald/accounts/0x8d82559A91929DD72682f5C6E2EEA3905B6c2A18'

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_by_multiple_names.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_by_multiple_names.body
@@ -1,0 +1,25 @@
+{
+  "evm_tokens": [
+    {
+      "contract_addr": "oasis1qr43dvghx4a75vndjcsg2r9ct2xqftwrgcnt5tge",
+      "decimals": 18,
+      "eth_contract_addr": "0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520",
+      "is_verified": true,
+      "name": "Ocean Token",
+      "num_holders": 52,
+      "num_transfers": 5948,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "OCEAN",
+      "total_supply": "1418576715298904178394593",
+      "type": "ERC20",
+      "verification_level": "full"
+    }
+  ],
+  "is_total_count_clipped": false,
+  "total_count": 1
+}

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_by_multiple_names.headers
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_by_multiple_names.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.body
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.body
@@ -1,0 +1,43 @@
+{
+  "evm_tokens": [
+    {
+      "contract_addr": "oasis1qq309j5u6ut8da3fh9ra5k8ky77sqhhr8cmdqzpw",
+      "decimals": 18,
+      "eth_contract_addr": "0xA14167756d9F86Aed12b472C29B257BBdD9974C2",
+      "is_verified": true,
+      "name": "BitUSDs",
+      "num_holders": 0,
+      "num_transfers": 0,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "BitUSDs",
+      "total_supply": "1653477128185483411842062",
+      "type": "ERC20",
+      "verification_level": "full"
+    },
+    {
+      "contract_addr": "oasis1qq7vtcrmsyzfyf0rtkf99g9psh6ps29gx57nasxp",
+      "decimals": 18,
+      "eth_contract_addr": "0xe66421fD29fC2D27D0724F161F01b8cbDCd69690",
+      "is_verified": false,
+      "name": "BTC/USDT",
+      "num_holders": 0,
+      "num_transfers": 3,
+      "ref_token": {
+        "decimals": 18,
+        "name": "Wrapped ROSE",
+        "symbol": "wROSE",
+        "type": "ERC20"
+      },
+      "symbol": "BTC/USDT",
+      "total_supply": "0",
+      "type": "ERC20"
+    }
+  ],
+  "is_total_count_clipped": false,
+  "total_count": 2
+}

--- a/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.headers
+++ b/tests/e2e_regression/eden_2025/expected/sapphire_token_by_name.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden_2025/test_cases.sh
+++ b/tests/e2e_regression/eden_2025/test_cases.sh
@@ -30,6 +30,8 @@ testCases=(
   'sapphire_transfer_events_of_token           /v1/sapphire/events?evm_log_signature=ddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef&contract_address=0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520'
   'sapphire_token                              /v1/sapphire/evm_tokens/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520'
   'sapphire_token_holders                      /v1/sapphire/evm_tokens/0x39d22B78A7651A76Ffbde2aaAB5FD92666Aca520/holders'
+  'sapphire_token_by_name                      /v1/sapphire/evm_tokens?name=USD'
+  'sapphire_token_by_multiple_names            /v1/sapphire/evm_tokens?name=Token,Ocean'
   'sapphire_account_with_rose                  /v1/sapphire/accounts/0xCCD706B1c30d1c6F46F74885C3B13e3Ea28ce8AF'
   'sapphire_account_with_evm_token             /v1/sapphire/accounts/0x6Cc4Fe9Ba145AbBc43227b3D4860FA31AFD225CB'
   'sapphire_token_configured_addresses         /v1/sapphire/evm_tokens/0xA14167756d9F86Aed12b472C29B257BBdD9974C2'

--- a/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_by_multiple_names.body
+++ b/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_by_multiple_names.body
@@ -1,0 +1,56 @@
+{
+  "is_total_count_clipped": false,
+  "rofl_apps": [
+    {
+      "active_instances": [
+        {
+          "endorsing_entity_id": "hp8sjG2cJPncrEYWZKqisUNiMYzUC/QomhrJwoLQVjc=",
+          "endorsing_node_id": "5MsgQwijUlpH9+0Hbyors5jwmx7tTmKMA4c9leV3prI=",
+          "expiration_epoch": 44111,
+          "extra_keys": [
+            "{\"secp256k1\":\"Ax7ww8ukRTiqn8X2gSQTwcDM9oW2kWF3RByqfdpiT7gf\"}"
+          ],
+          "rak": "tnvWUYb/SGtHSlDxoGENW0BzSD8t+VEJU4umH9RzVFw=",
+          "rek": "cpw+0KhZudVM9YtdgPeOUTyI/pyp564hDzWsnqiZd0c="
+        }
+      ],
+      "admin": "oasis1qpupfu7e2n6pkezeaw0yhj8mcem8anj64ytrayne",
+      "date_created": "2025-05-06T15:54:15Z",
+      "id": "rofl1qrtetspnld9efpeasxmryl6nw9mgllr0euls3dwn",
+      "last_activity": "2025-05-06T15:54:15Z",
+      "metadata": {
+        "net.oasis.rofl.author": "Matevž Jekovec <matevz@oasisprotocol.org>",
+        "net.oasis.rofl.license": "Apache-2.0",
+        "net.oasis.rofl.name": "demo-rofl-chatbot",
+        "net.oasis.rofl.repository": "https://github.com/oasisprotocol/demo-rofl-chatbot",
+        "net.oasis.rofl.version": "0.1.0"
+      },
+      "num_active_instances": 1,
+      "policy": {
+        "enclaves": [
+          "YjeeznQx9i/UQKVoPcOVT3P5oxOHGJ6r1VwMBetuSREAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+          "IyVddKd5AtSGmo7FHnZrj0vIzfIOp3DMBFHwUbb0qVQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+        ],
+        "endorsements": [
+          {
+            "any": {}
+          }
+        ],
+        "fees": 2,
+        "max_expiration": 3,
+        "quotes": {
+          "pcs": {
+            "min_tcb_evaluation_data_number": 17,
+            "tcb_validity_period": 30,
+            "tdx": {}
+          }
+        }
+      },
+      "removed": false,
+      "secrets": null,
+      "sek": "2L9Jcwa+cfGbhfv24x3TWEn6UekjfKlvEL6qY3PLnwo=",
+      "stake": "10000000000000000000000"
+    }
+  ],
+  "total_count": 1
+}

--- a/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_by_multiple_names.headers
+++ b/tests/e2e_regression/eden_testnet_2025/expected/sapphire_rofl_app_by_multiple_names.headers
@@ -1,0 +1,6 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Vary: Origin
+Date: UNINTERESTING
+Content-Length: UNINTERESTING
+

--- a/tests/e2e_regression/eden_testnet_2025/test_cases.sh
+++ b/tests/e2e_regression/eden_testnet_2025/test_cases.sh
@@ -34,6 +34,7 @@ testCases=(
   'sapphire_account_with_evm_token                     /v1/sapphire/accounts/0xeDA395666E56dd9E2Ef3Bdc76eee373b738640DD'
   'sapphire_rofl_app                                   /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw'
   'sapphire_rofl_app_by_name                           /v1/sapphire/rofl_apps?name=demo-rofl'
+  'sapphire_rofl_app_by_multiple_names                 /v1/sapphire/rofl_apps?name=chatbot,demo'
   'sapphire_rofl_app_instances                         /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instances'
   'sapphire_rofl_app_instance                          /v1/sapphire/rofl_apps/rofl1qp55evqls4qg6cjw5fnlv4al9ptc0fsakvxvd9uw/instances/8EUGnz+hAqblEMWh+ZHKyZU7CSItm1wrJqK15dAjlfI='
   'sapphire_rofl_app_transactions                      /v1/sapphire/rofl_apps/rofl1qr5s5r9pkdkhmj7l5z4nuncjkc05p62m9uqa2svc/transactions'


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/1015

Change is backrwads compatible, providing a single name term works as before.

TODO:
- [x] also do for evm tokens