### PR TITLE
api/rofl_apps: No active instances for removed apps

### DIFF
--- a/.changelog/1076.bugfix.md
+++ b/.changelog/1076.bugfix.md
@@ -1,0 +1,1 @@
+api/rofl_apps: No active instances for removed apps

--- a/storage/client/queries/queries.go
+++ b/storage/client/queries/queries.go
@@ -1351,6 +1351,8 @@ func RuntimeRoflApps(rawNames *[]string, args *[]interface{}) string {
 					) AS instance_json
 				FROM chain.rofl_instances ri
 				JOIN max_epoch ON true
+				-- Only include apps that are not removed.
+				JOIN chain.rofl_apps ra ON ra.id = ri.app_id AND ra.removed = false
 				WHERE ri.expiration_epoch > max_epoch.id
 				GROUP BY ri.app_id
 			)


### PR DESCRIPTION
"Active instances" are computed by just looking at the expiration epoch. However removed apps don't have any active instances (even if the expiration has not yet expired). So just don't compute active instances for that case. That will also fix the sorting, since currently it can happen that a removed app will show up before non-removed one, due to the misleading "active instances".