### PR TITLE
analyzer/runtime: Parse precompile results

### DIFF
--- a/.changelog/1093.feature.md
+++ b/.changelog/1093.feature.md
@@ -1,0 +1,1 @@
+analyzer/runtime: Parse precompile results

--- a/analyzer/runtime/evm/precompile.go
+++ b/analyzer/runtime/evm/precompile.go
@@ -1,0 +1,54 @@
+package evm
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+
+	"github.com/oasisprotocol/nexus/analyzer/util/addresses"
+	"github.com/oasisprotocol/nexus/api/v1/types"
+)
+
+var (
+	// 0x0100000000000000000000000000000000000103
+	subcallPrecompile = addresses.FromBech32("oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn")
+
+	typeUint256, _ = abi.NewType("uint256", "", nil)
+	typeBytes, _   = abi.NewType("bytes", "", nil)
+)
+
+// IsSubcallPrecompile checks if the address is the subcall precompile address.
+func IsSubcallPrecompile(address types.Address) bool {
+	return address == subcallPrecompile
+}
+
+// EVMMaybeUnmarshalPrecompileResult tries to unmarshal a precompile result.
+func EVMMaybeUnmarshalPrecompileResult(result []byte) (uint32, string, error) {
+	// Try parsing the output:
+	// https://github.com/oasisprotocol/oasis-sdk/blob/deca9369166757b3075dc4414d7450340fdaa779/runtime-sdk/modules/evm/src/precompile/subcall.rs#L97-L106
+	var output []byte
+	if err := cbor.Unmarshal(result, &output); err != nil {
+		return 0, "", fmt.Errorf("unmarshal precompile result: %w", err)
+	}
+
+	args := abi.Arguments{
+		{Type: typeUint256, Name: "status_code"},
+		{Type: typeBytes, Name: "module"},
+	}
+	out, err := args.Unpack(output)
+	if err != nil {
+		return 0, "", fmt.Errorf("unpack precompile result: %w", err)
+	}
+	if len(out) != 2 {
+		return 0, "", fmt.Errorf("expected 2 arguments, got %d", len(out))
+	}
+
+	statusCode := out[0].(*big.Int).Uint64()
+	if statusCode == 0 {
+		return 0, "", nil
+	}
+
+	return uint32(statusCode), string(out[1].([]byte)), nil
+}

--- a/analyzer/runtime/evm/precompile_test.go
+++ b/analyzer/runtime/evm/precompile_test.go
@@ -1,0 +1,47 @@
+package evm
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/oasisprotocol/oasis-core/go/common/cbor"
+)
+
+func TestPrecompileResult(t *testing.T) {
+	testCases := []struct {
+		name       string
+		result     string
+		statusCode uint32
+		module     string
+	}{
+		// https://github.com/oasisprotocol/nexus/issues/1093
+		{
+			name:       "failed precompile",
+			result:     "000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000004636f726500000000000000000000000000000000000000000000000000000000",
+			statusCode: 10,
+			module:     "core",
+		},
+		{
+			name:       "success precompile",
+			result:     "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000001f600000000000000000000000000000000000000000000000000000000000000",
+			statusCode: 0,
+			module:     "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prepare the precompile result.
+			result, err := hex.DecodeString(tc.result)
+			require.NoError(t, err)
+
+			// Test unmarshalling.
+			statusCode, module, err := EVMMaybeUnmarshalPrecompileResult(cbor.Marshal(result))
+			require.NoError(t, err)
+			require.Equal(t, tc.statusCode, statusCode)
+			require.Equal(t, tc.module, module)
+		})
+	}
+}

--- a/analyzer/util/addresses/addresses.go
+++ b/analyzer/util/addresses/addresses.go
@@ -70,3 +70,10 @@ func SliceFromSet(accounts map[apiTypes.Address]struct{}) []apiTypes.Address {
 	}
 	return addrs
 }
+
+func FromBech32(bech32 string) apiTypes.Address {
+	address := sdkTypes.NewAddressFromBech32(bech32)
+	// Address is valid, otherwise the above call panics.
+	addr, _ := FromSdkAddress(&address)
+	return addr
+}


### PR DESCRIPTION
Fixes: https://github.com/oasisprotocol/nexus/issues/1093

Note that this will only effect future transaction and not past, already indexed ones.


See the `error ` field for the example mentioned in #1093:
```
		{
			"amount": "0",
			"body": {
				"address": "AQAAAAAAAAAAAAAAAAAAAAAAAQM=",
				"data": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAALcm9mbC5VcGRhdGUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAC1adiaWRVAKEei2XqpUgkDJPJu8QQu2ZS+YdZY3Nla1gghq8D4IWg3i4hynE6Q2NVYMkv/aNPefRVFgKSbcmWgk1lYWRtaW5VABUafBL3j0oDGd4HRygbj5UK92DGZXN0YWtlgkkFa8deLWMQAABAZnBvbGljeaVkZmVlcwJmcXVvdGVzomNpYXP2Y3Bjc6NjdGR4oXNhbGxvd2VkX3RkeF9tb2R1bGVzgHN0Y2JfdmFsaWRpdHlfcGVyaW9kGB54Hm1pbl90Y2JfZXZhbHVhdGlvbl9kYXRhX251bWJlchJoZW5jbGF2ZXOAbGVuZG9yc2VtZW50c4GhY2FueaBubWF4X2V4cGlyYXRpb24DZ3NlY3JldHOiYWNYcKRicGtYILqTuMcoz+9h5PyVzuKiAAm9oi8GZjw40I9uhZOkpNU8ZG5hbWVRO0tcG5Q7/xZKKYbeFYQcSrVlbm9uY2VPZhpXLjpOrJFAeMSCkY1JZXZhbHVlVoxtsD+88Mw3pZIpsDuDjm3J84paLhlhZFhwpGJwa1ggQzsGYw7IHcYP3bmyoPRXiRzRC5f2JTNp91Jk0Ld2YlpkbmFtZVETy/Sb70HqOhDon1NySNh2tmVub25jZU9VVY56uK4S8NtrHEOa6BRldmFsdWVW/NZxCqH47OaBCDL2dxVmv/s4z0yJ1WhtZXRhZGF0YaRzbmV0Lm9hc2lzLnJvZmwubmFtZXZjcmVhdGUgdGhyb3VnaCBzdWJjYWxsdm5ldC5vYXNpcy5yb2ZsLmxpY2Vuc2VqQXBhY2hlLTIuMHZuZXQub2FzaXMucm9mbC52ZXJzaW9uZTAuMS4weBluZXQub2FzaXMucm9mbC5yZXBvc2l0b3J5eEZodHRwczovL2dpdGh1Yi5jb20vb2FzaXNwcm90b2NvbC9vYXNpcy1zZGsvdHJlZS9tYWluL2NsaWVudC1zZGsvdHMtd2ViAAAAAAAAAAAAAAA=",
				"value": ""
			},
			"charged_fee": "3548600000000000",
			"error": {
				"code": 10,
				"module": "core"
			},
			"eth_hash": "26911fd1bab06a9a8ccc30f5e57ca703cd838c31c71ea1c3677f8c21142f6c15",
			"fee": "3565900000000000",
			"fee_symbol": "TEST",
			"gas_limit": 35659,
			"gas_used": 35486,
			"hash": "acdf0913db2bd45e2e20cc1ca815681b979b378efe4a467f52601b6f5c42db8e",
			"index": 2,
			"is_likely_native_token_transfer": false,
			"method": "evm.Call",
			"nonce_0": 100,
			"round": 12228806,
			"sender_0": "oasis1qq235lqj77855qcemcr5w2qm372s4amqcc4v3ztc",
			"sender_0_eth": "0xC3ecf872F643C6238Aa20673798eed6F7dA199e9",
			"signers": [
				{
					"address": "oasis1qq235lqj77855qcemcr5w2qm372s4amqcc4v3ztc",
					"address_eth": "0xC3ecf872F643C6238Aa20673798eed6F7dA199e9",
					"nonce": 100
				}
			],
			"size": 1032,
			"success": false,
			"timestamp": "2025-06-21T09:05:05+02:00",
			"to": "oasis1qzr543mmela3xwflqtz3e0l8jzp8tupf3v59r6qn",
			"to_eth": "0x0100000000000000000000000000000000000103"
		}
```

