### PR TITLE
Fix stale accounts for multiple lists for same chain

### DIFF
--- a/.changelog/1164.bugfix.md
+++ b/.changelog/1164.bugfix.md
@@ -1,0 +1,1 @@
+Fix stale accounts handling with multiple lists per chain

--- a/config/config.go
+++ b/config/config.go
@@ -368,6 +368,11 @@ type RuntimeAnalyzerConfig struct {
 	// part of the spec (decimals, symbol, etc.) but do not emit ERC20 events - therefore are not
 	// ever picked up by the analyzer.
 	AdditionalEVMTokenAddresses []string `koanf:"additional_evm_token_addresses"`
+
+	// ForceMarkStaleAccounts forces marking of known stale accounts in the DB even when
+	// the analyzer has already passed the height at which they would normally be processed.
+	// This allows avoiding a reindex.
+	ForceMarkStaleAccounts bool `koanf:"force_mark_stale_accounts"`
 }
 
 type BlockBasedAnalyzerConfig struct {

--- a/tests/e2e_regression/eden_2025/e2e_config_1.yml
+++ b/tests/e2e_regression/eden_2025/e2e_config_1.yml
@@ -28,6 +28,7 @@ analysis:
       to: 8_514_134    # ~2000 blocks; compromise between fast and comprehensive
       additional_evm_token_addresses:
         - "0xA14167756d9F86Aed12b472C29B257BBdD9974C2" # BitUSD
+      # force_mark_stale_accounts: true # TODO: Uncomment once the eden archive node is fixed: https://github.com/oasisprotocol/nexus/pull/1017
   storage:
     backend: postgres
     endpoint: postgresql://rwuser:password@localhost:5432/indexer?sslmode=disable&pool_max_conns=10


### PR DESCRIPTION
Also moves `NEXUS_FORCE_MARK_STALE_ACCOUNTS` from env variable to a config parameter.