### PR TITLE
Pontusx native symbol rename

### DIFF
--- a/.changelog/1177.feature.md
+++ b/.changelog/1177.feature.md
@@ -1,0 +1,1 @@
+Pontus-X native symbol rename

--- a/go.mod
+++ b/go.mod
@@ -183,7 +183,7 @@ require (
 	github.com/oasisprotocol/curve25519-voi v0.0.0-20230904125328-1f23a7beb09a
 	github.com/oasisprotocol/metadata-registry-tools v0.0.0-20240304080528-3218befba9ca
 	github.com/oasisprotocol/oasis-core/go v0.2504.0
-	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.0
+	github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.1-0.20251014092014-fb69325c5e3c
 	github.com/rs/cors v1.11.1
 	go.dedis.ch/kyber/v3 v3.1.0
 	golang.org/x/crypto v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -640,6 +640,8 @@ github.com/oasisprotocol/oasis-core/go v0.2504.0 h1:efo1IfMDZMlvby3s+g3iNFUfzC5V
 github.com/oasisprotocol/oasis-core/go v0.2504.0/go.mod h1:mj2X/x97RT0FTex2gDygZPHxCROtfcG+orP/gyQKk4U=
 github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.0 h1:RR18vzfrczejDUsD5nXln6weBNqUZoslh0rEpXcieDk=
 github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.0/go.mod h1:cLtdOgAtSsVGQAZ1KWCXCgnj9CzNeOOEWUMZB0PIBeA=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.1-0.20251014092014-fb69325c5e3c h1:Nzn4cOkzj6pEOJy8sC7N/sRESXznyfTrwOPwhlsvZ+w=
+github.com/oasisprotocol/oasis-sdk/client-sdk/go v0.16.1-0.20251014092014-fb69325c5e3c/go.mod h1:cLtdOgAtSsVGQAZ1KWCXCgnj9CzNeOOEWUMZB0PIBeA=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/storage/migrations/50_pontusx_fee_rename.up.sql
+++ b/storage/migrations/50_pontusx_fee_rename.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+UPDATE chain.runtime_transactions
+	SET fee_symbol = 'EURAU'
+	WHERE runtime IN ('pontusx_dev', 'pontusx_test') AND fee_symbol = 'EUROe';
+
+UPDATE chain.runtime_transactions
+	SET amount_symbol = 'EURAU'
+	WHERE runtime IN ('pontusx_dev', 'pontusx_test') AND amount_symbol = 'EUROe';
+
+UPDATE chain.runtime_transfers
+	SET symbol = 'EURAU'
+	WHERE runtime IN ('pontusx_dev', 'pontusx_test') AND symbol = 'EUROe';
+
+UPDATE chain.runtime_sdk_balances
+	SET symbol = 'EURAU'
+	WHERE runtime IN ('pontusx_dev', 'pontusx_test') AND symbol = 'EUROe';
+
+COMMIT;


### PR DESCRIPTION
Rename fee_symbol from `EUROe` to  `EURAU` for runtime transactions.