### PR TITLE
analyzer/queries: avoid uint_numeric check failure on negative shares during upsert

### DIFF
--- a/.changelog/1189.bugfix.md
+++ b/.changelog/1189.bugfix.md
@@ -1,0 +1,1 @@
+analyzer/queries: avoid uint_numeric check failure on negative shares


### PR DESCRIPTION
Fixes 
```
{"args":["sapphire","oasis1qpn09fsupnx720uv6zav8vzgkcl3mgfkas7wpth2","oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3","-13398826426497"],"caller":"client.go:155","db":"nexusmainnet","err":"ERROR: value for domain uint_numeric violates check constraint \"uint_numeric_check\" (SQLSTATE 23514)","level":"error","module":"postgres","msg":"Query","pid":730080,"sql":"\n    INSERT INTO chain.runtime_accounts_delegations AS old (runtime, delegator, delegatee, shares)\n      VALUES ($1, $2, $3, $4)\n    ON CONFLICT (runtime, delegator, delegatee) DO UPDATE\n      SET shares = old.shares + $4","time":"3.914196ms","ts":"2025-11-04T10:56:31.366742875Z"}
{"analyzer":"sapphire","caller":"block.go:493","err":"query 520 &{\n    INSERT INTO chain.runtime_accounts_delegations AS old (runtime, delegator, delegatee, shares)\n      VALUES ($1, $2, $3, $4)\n    ON CONFLICT (runtime, delegator, delegatee) DO UPDATE\n      SET shares = old.shares + $4 [sapphire oasis1qpn09fsupnx720uv6zav8vzgkcl3mgfkas7wpth2 oasis1qpn83e8hm3gdhvpfv66xj3qsetkj3ulmkugmmxn3 -13398826426497]}: ERROR: value for domain uint_numeric violates check constraint \"uint_numeric_check\" (SQLSTATE 23514)","height":11322402,"level":"error","mode":"slow-sync","module":"analysis_service","msg":"failed to process block","ts":"2025-11-04T10:56:31.367852125Z"}
```

tested the fix with the exact same query that fails on mainnet db (with rollback of-course)


Future TODO:
- update E2E regression test block ranges so that it covers at least one runtime undelegation